### PR TITLE
chore: fix extra fields for attachments

### DIFF
--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -109,7 +109,9 @@ class Orchestrator:
                     )
                     for attachment in tool_call_results[i].propagate_to_choice:
                         # Need to repack, cause Message contains same attachment but from other package: aidial_client.types.chat.response.Attachment
-                        self.__choice.add_attachment(**attachment.model_dump())
+                        self.__choice.add_attachment(
+                            **attachment.model_dump(exclude={"index"})
+                        )  # attachment can't be created with any extra parameters
                     if tool_call_results[i].usage and self.__SHOW_USAGE_STATISTICS:
                         self.__usage_statistics_list.extend(tool_call_results[i].usage)
                 logger.debug(f"State:{tool_execution_history}")


### PR DESCRIPTION
### Applicable issues

### Description of changes

Some models doesn't allow extra fields for attachment object. This fix removes extra field

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
