### PR TITLE
feat: Ability to disable content downloader tool

### DIFF
--- a/src/quickapp/config/config_template_resolver.py
+++ b/src/quickapp/config/config_template_resolver.py
@@ -141,17 +141,21 @@ class TemplateType(str, Enum):
 
 
 def add_default_content_downloader(raw_config: ApplicationConfig):
+    # Check if any existing tool set already has the `content_downloader` predefined tool
     for tool_set in raw_config.tool_sets:
-        for tool in tool_set.tools:
+        if not hasattr(tool_set, "tools"):
+            # Some tool set variants do not define `tools`
+            continue
+        for tool in tool_set.tools:  # type: ignore[union-attr]
             if isinstance(tool, PredefinedTool) and tool.template_name == "content_downloader":
                 return
-    raw_config.tool_sets.extend(
-        [
-            InternalToolSet(
-                name="Default tools",
-                tools=[PredefinedTool(template_name="content_downloader", enabled=True)],
-            )
-        ]
+
+    # If not found, append a default internal tool set with the content_downloader tool
+    raw_config.tool_sets.append(
+        InternalToolSet(
+            name="Default tools",
+            tools=[PredefinedTool(template_name="content_downloader", enabled=True)],
+        )
     )
 
 

--- a/src/quickapp/config/config_template_resolver.py
+++ b/src/quickapp/config/config_template_resolver.py
@@ -10,6 +10,7 @@ from quickapp.config.application import ApplicationConfig
 from quickapp.config.prompt import PredefinedSystemPromptConfig
 from quickapp.config.tools.predefined import PredefinedTool
 from quickapp.config.tools.tool import AnyTool
+from quickapp.config.toolsets.internal import InternalToolSet
 from quickapp.config.toolsets.predefined import PredefinedToolSet
 from quickapp.config.toolsets.toolset import ToolSet
 
@@ -139,6 +140,21 @@ class TemplateType(str, Enum):
     tool = 'tool'
 
 
+def add_default_content_downloader(raw_config: ApplicationConfig):
+    for tool_set in raw_config.tool_sets:
+        for tool in tool_set.tools:
+            if isinstance(tool, PredefinedTool) and tool.template_name == "content_downloader":
+                return
+    raw_config.tool_sets.extend(
+        [
+            InternalToolSet(
+                name="Default tools",
+                tools=[PredefinedTool(template_name="content_downloader", enabled=True)],
+            )
+        ]
+    )
+
+
 class ConfigResolver:
     def __init__(self):
         self.predefined_settings = PredefinedSettings()
@@ -215,6 +231,7 @@ class ConfigResolver:
             spc.content = self.read_template_content(TemplateType.system_prompt, spc.template)
 
         # tool-sets
+        add_default_content_downloader(raw_config)
         resolved_tool_set_list = []
         for tool_set in raw_config.tool_sets:
             if isinstance(tool_set, PredefinedToolSet):
@@ -236,7 +253,7 @@ class ConfigResolver:
             return tool_set
         resolved_tools: List[AnyTool] = []
         for tool in tool_set.tools:
-            if isinstance(tool, PredefinedTool):
+            if isinstance(tool, PredefinedTool) and tool.enabled:
                 resolved_tools.append(self.resolve_tool(tool))
             else:
                 # It's not a template, just append it

--- a/src/quickapp/internal_tooling/internal_tooling_module.py
+++ b/src/quickapp/internal_tooling/internal_tooling_module.py
@@ -7,7 +7,6 @@ from injector import AssistedBuilder, Binder, Module, multiprovider, provider, s
 from quickapp.common import DIAL_API_KEY, StagedBaseTool
 from quickapp.common.dial_settings import DialSettings
 from quickapp.config.application import ApplicationConfig
-from quickapp.config.config_template_resolver import ConfigResolver
 from quickapp.config.tools.predefined import PredefinedTool
 from quickapp.config.toolsets.internal import InternalToolSet
 from quickapp.internal_tooling.content_download_tooling._content_download_tool import (
@@ -44,6 +43,7 @@ class InternalToolModule(Module):
         self,
         app_config: ApplicationConfig,
         py_builder: AssistedBuilder[_PyInterpreterTool],
+        cd_builder: AssistedBuilder[_ContentDownloadTool],
     ) -> list[StagedBaseTool]:
         tools: list[StagedBaseTool] = []
         for tool_set in app_config.tool_sets:
@@ -65,16 +65,20 @@ class InternalToolModule(Module):
                                     description=tool_config.open_ai_tool.function.description,
                                 )
                             )
+                        elif tool_config.open_ai_tool.function.name.startswith(
+                            'content_downloader'
+                        ):
+                            tools.append(
+                                cd_builder.build(
+                                    tool_config=tool_config,
+                                    name=tool_config.open_ai_tool.function.name,
+                                    description=tool_config.open_ai_tool.function.description,
+                                    content_size_limit=int(
+                                        os.getenv("CONTENT_DOWNLOADER_FILE_SIZE_LIMIT", "20971520")
+                                    ),  # 20Mb
+                                )
+                            )
         return tools
-
-    @multiprovider
-    def _provide_content_downloader(
-        self, cd_builder: AssistedBuilder[_ContentDownloadTool], config_resolver: ConfigResolver
-    ) -> list[StagedBaseTool]:
-        tool_config = config_resolver.resolve_tool(
-            PredefinedTool(template_name="content_downloader")
-        )
-        return [self._build_cd_tool(tool_config, cd_builder)]
 
     @singleton
     @provider
@@ -110,15 +114,4 @@ class InternalToolModule(Module):
             base_url=py_interpreter_settings.url,
             timeout=py_interpreter_settings.client_timeout,
             max_retries=py_interpreter_settings.client_max_retries,
-        )
-
-    @staticmethod
-    def _build_cd_tool(tool_config, cd_builder: AssistedBuilder[_ContentDownloadTool]):
-        return cd_builder.build(
-            tool_config=tool_config,
-            name=tool_config.open_ai_tool.function.name,
-            description=tool_config.open_ai_tool.function.description,
-            content_size_limit=int(
-                os.getenv("CONTENT_DOWNLOADER_FILE_SIZE_LIMIT", "20971520")
-            ),  # 20Mb
         )


### PR DESCRIPTION
### Applicable issues

There is no ability to disable the content downloader tool in the quick app

### Description of changes

It has become possible to disable the tool by:

```json
"tool_sets": [
          {
            "name": "Some toolset",
            "description": "",
            "type": "internal",
            "tools": [
              {
                "type": "predefined-tool",
                "template_name": "content_downloader",
                "enabled": false
              }
            ]
          }
        ]
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
