### PR TITLE
feat: rest api attachments

### DIFF
--- a/src/quickapp/config/toolsets/authorization.py
+++ b/src/quickapp/config/toolsets/authorization.py
@@ -8,6 +8,7 @@ class AuthorizationType(str, Enum):
     bearer = 'bearer'
     client_id_secret = 'client_id_secret'
     api_key = 'api_key'
+    forward_auth_token = 'forward_auth_token'
 
 
 class AuthorizationLocation(str, Enum):
@@ -34,6 +35,10 @@ class BasicAuthorization(BaseAuthorization):
 class BearerAuthorization(BaseAuthorization):
     type: Literal[AuthorizationType.bearer] = Field(default=AuthorizationType.bearer)
     token: str
+
+
+class ForwardAuthTokenAuthorization(BaseAuthorization):
+    type: Literal[AuthorizationType.forward_auth_token] = Field(default=AuthorizationType.forward_auth_token)
 
 
 class ClientIdSecretAuthorization(BaseAuthorization):

--- a/src/quickapp/config/toolsets/authorization.py
+++ b/src/quickapp/config/toolsets/authorization.py
@@ -38,7 +38,9 @@ class BearerAuthorization(BaseAuthorization):
 
 
 class ForwardAuthTokenAuthorization(BaseAuthorization):
-    type: Literal[AuthorizationType.forward_auth_token] = Field(default=AuthorizationType.forward_auth_token)
+    type: Literal[AuthorizationType.forward_auth_token] = Field(
+        default=AuthorizationType.forward_auth_token
+    )
 
 
 class ClientIdSecretAuthorization(BaseAuthorization):

--- a/src/quickapp/config/toolsets/rest_api.py
+++ b/src/quickapp/config/toolsets/rest_api.py
@@ -15,7 +15,11 @@ from quickapp.config.toolsets.base import BaseToolSet
 
 Authorization = Annotated[
     Union[
-        BasicAuthorization, BearerAuthorization, ClientIdSecretAuthorization, ApiKeyAuthorization, ForwardAuthTokenAuthorization
+        BasicAuthorization,
+        BearerAuthorization,
+        ClientIdSecretAuthorization,
+        ApiKeyAuthorization,
+        ForwardAuthTokenAuthorization,
     ],
     Field(discriminator="type"),
 ]

--- a/src/quickapp/config/toolsets/rest_api.py
+++ b/src/quickapp/config/toolsets/rest_api.py
@@ -9,12 +9,13 @@ from quickapp.config.toolsets.authorization import (
     BasicAuthorization,
     BearerAuthorization,
     ClientIdSecretAuthorization,
+    ForwardAuthTokenAuthorization,
 )
 from quickapp.config.toolsets.base import BaseToolSet
 
 Authorization = Annotated[
     Union[
-        BasicAuthorization, BearerAuthorization, ClientIdSecretAuthorization, ApiKeyAuthorization
+        BasicAuthorization, BearerAuthorization, ClientIdSecretAuthorization, ApiKeyAuthorization, ForwardAuthTokenAuthorization
     ],
     Field(discriminator="type"),
 ]

--- a/src/quickapp/rest_api_tooling/_request_detail_builder.py
+++ b/src/quickapp/rest_api_tooling/_request_detail_builder.py
@@ -5,18 +5,15 @@ from httpx import URL, Headers, QueryParams
 from injector import inject
 from pydantic import BaseModel
 
+from quickapp.common import DIAL_BEARER
 from quickapp.common.media_types import MediaTypes
 from quickapp.common.oauth_token_fetcher import OAuthTokenFetcher
 from quickapp.config.tools.base import ConfigurableSchemaConst
 from quickapp.config.tools.rest_api import ToolEndpointInfoMethodType, ToolEndpointParamType
 from quickapp.config.toolsets.authorization import AuthorizationLocation, AuthorizationType
-from quickapp.config.toolsets.rest_api import (
-    ApiKeyAuthorization,
-    Authorization
-)
+from quickapp.config.toolsets.rest_api import ApiKeyAuthorization, Authorization
 
 from ._request_details import _RequestDetails
-from quickapp.common import DIAL_BEARER
 
 
 @inject
@@ -139,6 +136,10 @@ class _RequestDetailsBuilder:
                 case AuthorizationType.api_key:  # type: ignore[union-attr]
                     self.__handle_api_key_auth(auth_info)
                 case AuthorizationType.forward_auth_token:
+                    if self.__bearer is None:
+                        raise ValueError(
+                            "Missing forwarded bearer token for AuthorizationType.forward_auth_token"
+                        )
                     self.__headers['Authorization'] = f"Bearer {self.__bearer.get_secret_value()}"
         return self
 

--- a/src/quickapp/rest_api_tooling/_request_detail_builder.py
+++ b/src/quickapp/rest_api_tooling/_request_detail_builder.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 from httpx import URL, Headers, QueryParams
 from injector import inject
@@ -12,11 +12,11 @@ from quickapp.config.tools.rest_api import ToolEndpointInfoMethodType, ToolEndpo
 from quickapp.config.toolsets.authorization import AuthorizationLocation, AuthorizationType
 from quickapp.config.toolsets.rest_api import (
     ApiKeyAuthorization,
-    Authorization,
-    ClientIdSecretAuthorization,
+    Authorization
 )
 
 from ._request_details import _RequestDetails
+from quickapp.common import DIAL_BEARER
 
 
 @inject
@@ -39,11 +39,12 @@ class _RequestDetailsBuilder:
         + '; charset=utf-8'
     }
 
-    def __init__(self, oauth_token_fetcher: OAuthTokenFetcher):
+    def __init__(self, oauth_token_fetcher: OAuthTokenFetcher, bearer: DIAL_BEARER = None):
         self.__oauth_token_fetcher: OAuthTokenFetcher = oauth_token_fetcher
+        self.__bearer: DIAL_BEARER = bearer
         self.__headers: Headers = Headers(self.DEFAULT_HEADERS)
         self.__params: QueryParams = QueryParams()
-        self.__data: dict[str, Any] = dict()
+        self.__data: dict[str, Any] = {}
         self.__url: Optional[URL] = None
         self.__method: Optional[str] = None
 
@@ -133,11 +134,12 @@ class _RequestDetailsBuilder:
                 case AuthorizationType.bearer:
                     self.__headers['Authorization'] = f"Bearer {auth_info.token}"  # type: ignore[union-attr]
                 case AuthorizationType.client_id_secret:
-                    client_secret_auth = cast(ClientIdSecretAuthorization, auth_info)
-                    token = await self.__oauth_token_fetcher.fetch_oauth_token(client_secret_auth)
+                    token = await self.__oauth_token_fetcher.fetch_oauth_token(auth_info)
                     self.__headers['Authorization'] = f"Bearer {token}"
                 case AuthorizationType.api_key:  # type: ignore[union-attr]
                     self.__handle_api_key_auth(auth_info)
+                case AuthorizationType.forward_auth_token:
+                    self.__headers['Authorization'] = f"Bearer {self.__bearer.get_secret_value()}"
         return self
 
     def with_parameters(self, parameters: dict[str, Any], **kwargs: Any):

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -71,7 +71,7 @@ class _RestApiTool(StagedBaseTool):
             )
             response.raise_for_status()
 
-            raw_mime: Optional[str] = response.headers.get('Content-Type', None)
+            raw_mime = response.headers.get('Content-Type', None)
 
             mime_type = raw_mime.split(';', 1)[0].strip() if raw_mime else None
 
@@ -81,7 +81,6 @@ class _RestApiTool(StagedBaseTool):
                 self._tool_config
                 and mime_type
                 and matches_type(mime_type, self._tool_config.attachment.supported_types)
-                # type: ignore[arg-type]
             ):
                 title = generate_attachment_filename(
                     mime_type, base_filename=self._tool_config.open_ai_tool.function.name

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -12,6 +12,7 @@ from quickapp.common.utils import generate_attachment_filename, matches_type
 from quickapp.config.tools.rest_api import RestApiTool
 from quickapp.config.toolsets.rest_api import Authorization
 from quickapp.dial_core_services.attachment_service import AttachmentService
+
 from ._request_detail_builder import _RequestDetailsBuilder
 from ._rest_api_stage_wrapper import _RestApiStageWrapper
 
@@ -22,13 +23,13 @@ logger = logging.getLogger(__name__)
 class _RestApiTool(StagedBaseTool):
 
     def __init__(
-            self,
-            auth_info: Authorization,
-            request_details_builder: _RequestDetailsBuilder,
-            tool_config: RestApiTool,
-            stage_wrapper_builder: AssistedBuilder[_RestApiStageWrapper],
-            dial_attachment_service: AttachmentService,
-            perf_timer: PerformanceTimer,
+        self,
+        auth_info: Authorization,
+        request_details_builder: _RequestDetailsBuilder,
+        tool_config: RestApiTool,
+        stage_wrapper_builder: AssistedBuilder[_RestApiStageWrapper],
+        dial_attachment_service: AttachmentService,
+        perf_timer: PerformanceTimer,
     ):
         super().__init__(
             stage_wrapper_builder=stage_wrapper_builder,  # type: ignore[arg-type]
@@ -44,7 +45,7 @@ class _RestApiTool(StagedBaseTool):
         self.__dial_attachment_service = dial_attachment_service
 
     async def _run_in_stage_async(
-            self, stage_wrapper: Optional[BaseStageWrapper], *args: Any, **kwargs: Any
+        self, stage_wrapper: Optional[BaseStageWrapper], *args: Any, **kwargs: Any
     ) -> CompletionResult:
         request_details = (
             self.__request_details_builder.with_url(
@@ -81,21 +82,22 @@ class _RestApiTool(StagedBaseTool):
             attachment = Attachment(title=title, type=mime_type, data=response.text)
             attachments = []
             if (
-                    attachment
-                    and self._tool_config
-                    and matches_type(attachment.type, self._tool_config.attachment.supported_types)
-                    # type: ignore[arg-type]
+                attachment
+                and self._tool_config
+                and matches_type(attachment.type, self._tool_config.attachment.supported_types)
+                # type: ignore[arg-type]
             ):
                 logger.debug(f"Attachment: {attachment.title}, Tool Config: {self._tool_config}")
                 attachment = await self.__dial_attachment_service.upload_attachment_to_core(
                     attachment
-
                 )
 
                 attachments.append(attachment)
 
             result = CompletionResult(
-                content=response.text, content_type=response.headers.get('Content-Type', ""), attachments=attachments
+                content=response.text,
+                content_type=response.headers.get('Content-Type', ""),
+                attachments=attachments,
             )
 
             if stage_wrapper:

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -75,17 +75,17 @@ class _RestApiTool(StagedBaseTool):
 
             mime_type = raw_mime.split(';', 1)[0].strip() if raw_mime else None
 
-            title = generate_attachment_filename(
-                mime_type, base_filename=self._tool_config.open_ai_tool.function.name
-            )
-
             attachments = []
+
             if (
                 self._tool_config
                 and mime_type
                 and matches_type(mime_type, self._tool_config.attachment.supported_types)
                 # type: ignore[arg-type]
             ):
+                title = generate_attachment_filename(
+                    mime_type, base_filename=self._tool_config.open_ai_tool.function.name
+                )
                 logger.debug(f"Attachment: {title}, Tool Config: {self._tool_config}")
                 attachment = Attachment(title=title, type=mime_type, data=response.text)
                 attachment = await self.__dial_attachment_service.upload_attachment_to_core(

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -1,28 +1,34 @@
-from typing import Any, Optional
+import logging
+from typing import Any, Optional, cast
 
 import httpx
+from aidial_client.types.chat.response import Attachment
 from injector import AssistedBuilder, inject
 
 from quickapp.common import CompletionResult, StagedBaseTool
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
+from quickapp.common.utils import generate_attachment_filename, matches_type
 from quickapp.config.tools.rest_api import RestApiTool
 from quickapp.config.toolsets.rest_api import Authorization
-
+from quickapp.dial_core_services.attachment_service import AttachmentService
 from ._request_detail_builder import _RequestDetailsBuilder
 from ._rest_api_stage_wrapper import _RestApiStageWrapper
+
+logger = logging.getLogger(__name__)
 
 
 @inject
 class _RestApiTool(StagedBaseTool):
 
     def __init__(
-        self,
-        auth_info: Authorization,
-        request_details_builder: _RequestDetailsBuilder,
-        tool_config: RestApiTool,
-        stage_wrapper_builder: AssistedBuilder[_RestApiStageWrapper],
-        perf_timer: PerformanceTimer,
+            self,
+            auth_info: Authorization,
+            request_details_builder: _RequestDetailsBuilder,
+            tool_config: RestApiTool,
+            stage_wrapper_builder: AssistedBuilder[_RestApiStageWrapper],
+            dial_attachment_service: AttachmentService,
+            perf_timer: PerformanceTimer,
     ):
         super().__init__(
             stage_wrapper_builder=stage_wrapper_builder,  # type: ignore[arg-type]
@@ -35,9 +41,10 @@ class _RestApiTool(StagedBaseTool):
         self.stage_name_component = f"Calling {tool_config.rest_api_method_info.method_url}"
         self.__auth_info: Authorization = auth_info
         self._tool_config: RestApiTool = tool_config
+        self.__dial_attachment_service = dial_attachment_service
 
     async def _run_in_stage_async(
-        self, stage_wrapper: Optional[BaseStageWrapper], *args: Any, **kwargs: Any
+            self, stage_wrapper: Optional[BaseStageWrapper], *args: Any, **kwargs: Any
     ) -> CompletionResult:
         request_details = (
             self.__request_details_builder.with_url(
@@ -63,8 +70,32 @@ class _RestApiTool(StagedBaseTool):
             )
             response.raise_for_status()
 
+            raw_mime = cast(Optional[str], response.headers.get('Content-Type', None))
+
+            mime_type = raw_mime.split(';', 1)[0].strip() if raw_mime else None
+
+            title = generate_attachment_filename(
+                mime_type, base_filename=self._tool_config.open_ai_tool.function.name
+            )
+
+            attachment = Attachment(title=title, type=mime_type, data=response.text)
+            attachments = []
+            if (
+                    attachment
+                    and self._tool_config
+                    and matches_type(attachment.type, self._tool_config.attachment.supported_types)
+                    # type: ignore[arg-type]
+            ):
+                logger.debug(f"Attachment: {attachment.title}, Tool Config: {self._tool_config}")
+                attachment = await self.__dial_attachment_service.upload_attachment_to_core(
+                    attachment
+
+                )
+
+                attachments.append(attachment)
+
             result = CompletionResult(
-                content=response.text, content_type=response.headers.get('Content-Type', "")
+                content=response.text, content_type=response.headers.get('Content-Type', ""), attachments=attachments
             )
 
             if stage_wrapper:

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional, cast
+from typing import Any, Optional
 
 import httpx
 from aidial_client.types.chat.response import Attachment
@@ -71,7 +71,7 @@ class _RestApiTool(StagedBaseTool):
             )
             response.raise_for_status()
 
-            raw_mime = cast(Optional[str], response.headers.get('Content-Type', None))
+            raw_mime: Optional[str] = response.headers.get('Content-Type', None)
 
             mime_type = raw_mime.split(';', 1)[0].strip() if raw_mime else None
 
@@ -79,15 +79,15 @@ class _RestApiTool(StagedBaseTool):
                 mime_type, base_filename=self._tool_config.open_ai_tool.function.name
             )
 
-            attachment = Attachment(title=title, type=mime_type, data=response.text)
             attachments = []
             if (
-                attachment
-                and self._tool_config
-                and matches_type(attachment.type, self._tool_config.attachment.supported_types)
+                self._tool_config
+                and mime_type
+                and matches_type(mime_type, self._tool_config.attachment.supported_types)
                 # type: ignore[arg-type]
             ):
-                logger.debug(f"Attachment: {attachment.title}, Tool Config: {self._tool_config}")
+                logger.debug(f"Attachment: {title}, Tool Config: {self._tool_config}")
+                attachment = Attachment(title=title, type=mime_type, data=response.text)
                 attachment = await self.__dial_attachment_service.upload_attachment_to_core(
                     attachment
                 )

--- a/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
+++ b/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
@@ -1,14 +1,17 @@
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
 
+from aidial_client.types.chat.response import Attachment
 from aidial_sdk.chat_completion import Stage
 from fastapi_injector import Injected
 from httpx import QueryParams
-from injector import Binder
+from injector import Binder, InstanceProvider
 from parameterized import parameterized
+from pydantic import SecretStr
 from starlette.testclient import TestClient
 
-from quickapp.common import CompletionResult, StagedBaseTool
+from quickapp.common import  StagedBaseTool, DIAL_BEARER, DIAL_API_KEY
+from quickapp.common.dial_settings import DialSettings
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.tools.base import OpenAiToolConfig, OpenAiToolFunction, OpenAiToolFunctionParameters
 from quickapp.config.tools.rest_api import RestApiTool, RestApiEndpointMethodInfo, RestApiEndpointSimpleTypeParam, \
@@ -73,6 +76,10 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
 
 
         def configure(binder: Binder):
+            binder.bind(DialSettings, DialSettings(url="https://core"))
+            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+            # binder.bind(AttachmentService, mock_dial_attachment_service)
             binder.bind(Stage, to=mock_stage)
             binder.bind(
                 ApplicationConfig,
@@ -87,7 +94,17 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
             tool = tools[0]
 
             result = await tool.arun("call-1", None, **{"query_key": "query_value"})
-            self.assertEqual(result, CompletionResult(tool_call_id="call-1", content='{"some_key":"some value"}', content_type="application/json", attachments=None))
+
+            # Validate core completion result properties without asserting on auto-generated attachment filenames
+            self.assertEqual(result.tool_call_id, "call-1")
+            self.assertEqual(result.content, '{"some_key":"some value"}')
+            self.assertEqual(result.content_type, "application/json")
+            self.assertIsNotNone(result.attachments)
+            self.assertEqual(len(result.attachments), 1)
+            self.assertIsInstance(result.attachments[0], Attachment)
+            self.assertEqual(result.attachments[0].type, "application/json")
+            self.assertEqual(result.attachments[0].data, '{"some_key":"some value"}')
+
             return {"message": "success"}
 
         client = TestClient(app)


### PR DESCRIPTION
### Applicable issues

Currently, the quick app definition has no reaction in the attachment section of the tool configuration for the REST API tool.
No way to use the forward-auth token with the REST API tool.

### Description of changes

Added support for 
```json 
"attachment": {
        "supported_types": [
          "application/json"
        ],
        "propagate_types_to_choice": [
          "application/json"
        ]
      }
```
section for REST API tools. Responses of supported_types uploaded to dial core and treated as attachments, as well as text-based results of a tool. So now it is possible to return and visualize the REST API response.
A new authorization option has been added to the REST API tool to support access token forwarding.


### Checklist

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
