### PR TITLE
fix: custom fields pass to the deployment tool

### DIFF
--- a/config/predefined/tool/dial_rag.json
+++ b/config/predefined/tool/dial_rag.json
@@ -8,7 +8,6 @@
   "deployment": {
     "name": "dial-rag",
     "parameters": {
-      "seed": 820288,
       "custom_fields": {
         "configuration": {}
       }

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -2,7 +2,7 @@ import logging
 import mimetypes
 import re
 from datetime import datetime
-from typing import Optional, Any
+from typing import Any, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -149,8 +149,8 @@ def to_plain_dict(obj: Any, _seen: set[int] | None = None) -> Any:
     # As a last resort, return the object if JSON-serializable, else empty dict
     try:
         import json
+
         json.dumps(obj)
         return obj
     except Exception:
         return {}
-

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -2,7 +2,7 @@ import logging
 import mimetypes
 import re
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Any
 
 logger = logging.getLogger(__name__)
 
@@ -59,6 +59,56 @@ def generate_attachment_filename(mime_type: Optional[str], base_filename: str = 
     timestamp = datetime.now().isoformat(timespec='microseconds')
     filename = f"{base_filename}-{timestamp}{extension if extension is not None else ''}"
     return sanitize_filename(filename)
+
+def to_plain_dict(obj: Any) -> dict:
+    """
+    Convert an object into a plain dict.
+
+    Behavior:
+    - Returns an empty dict for None.
+    - If the object exposes a `.dict()` method (e.g. pydantic models), returns
+      obj.dict(exclude_none=True) to avoid including None values; falls back to
+      obj.dict() if exclude_none is not supported.
+    - If the object is already a dict, returns a copy with None-valued entries
+      removed.
+    - Otherwise, attempts to coerce the object to a dict via dict(obj).
+    - On any error, returns an empty dict.
+
+    This helper was moved into quickapp.common.utils to provide a shared,
+    defensive conversion used across the codebase (pydantic models, mapping-like
+    objects, and iterable-of-pairs).
+
+    Args:
+        obj: Any serializable/mapping-like object to convert.
+
+    Returns:
+        A plain dict representation (never None).
+
+    Example:
+        >>> to_plain_dict(None)
+        {}
+        >>> to_plain_dict({"a": 1, "b": None})
+        {"a": 1}
+    """
+
+    if obj is None:
+        return {}
+    if hasattr(obj, "dict") and callable(getattr(obj, "dict")):
+        try:
+            return obj.dict(exclude_none=True)
+        except Exception:
+            try:
+                return obj.dict()
+            except Exception:
+                return {}
+    if isinstance(obj, dict):
+        # drop None values for cleanliness
+        return {k: v for k, v in obj.items() if v is not None}
+    try:
+        return dict(obj)
+    except Exception:
+        return {}
+
 
 
 if __name__ == '__main__':

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -60,58 +60,97 @@ def generate_attachment_filename(mime_type: Optional[str], base_filename: str = 
     filename = f"{base_filename}-{timestamp}{extension if extension is not None else ''}"
     return sanitize_filename(filename)
 
-def to_plain_dict(obj: Any) -> dict:
+
+def to_plain_dict(obj: Any, _seen: set[int] | None = None) -> Any:
     """
-    Convert an object into a plain dict.
+    Recursively convert an object into plain JSON-serializable structures.
 
     Behavior:
-    - Returns an empty dict for None.
-    - If the object exposes a `.dict()` method (e.g. pydantic models), returns
-      obj.dict(exclude_none=True) to avoid including None values; falls back to
-      obj.dict() if exclude_none is not supported.
-    - If the object is already a dict, returns a copy with None-valued entries
-      removed.
-    - Otherwise, attempts to coerce the object to a dict via dict(obj).
-    - On any error, returns an empty dict.
-
-    This helper was moved into quickapp.common.utils to provide a shared,
-    defensive conversion used across the codebase (pydantic models, mapping-like
-    objects, and iterable-of-pairs).
-
-    Args:
-        obj: Any serializable/mapping-like object to convert.
-
-    Returns:
-        A plain dict representation (never None).
-
-    Example:
-        >>> to_plain_dict(None)
-        {}
-        >>> to_plain_dict({"a": 1, "b": None})
-        {"a": 1}
+    - Preserves JSON primitives (str, int, float, bool) as-is.
+    - Returns an empty dict for top-level None (backwards-compatible).
+    - Converts Pydantic v2 (`model_dump`) or v1 (`dict`) using `exclude_none=True`
+      when available, then recurses.
+    - Recursively converts dicts, lists, tuples, sets and mapping-like objects,
+      dropping entries with None or empty dict values.
+    - Attempts `dict(obj)` for iterable-of-pairs fallback.
+    - Avoids infinite recursion using `_seen`.
+    - On failure returns an empty dict.
     """
+    if _seen is None:
+        _seen = set()
 
+    try:
+        obj_id = id(obj)
+    except Exception:
+        obj_id = None
+
+    if obj_id is not None:
+        if obj_id in _seen:
+            return {}
+        _seen.add(obj_id)
+
+    # None -> empty dict (preserve previous top-level behavior)
     if obj is None:
         return {}
-    if hasattr(obj, "dict") and callable(getattr(obj, "dict")):
+
+    # Primitive JSON types are returned unchanged
+    if isinstance(obj, (str, int, float, bool)):
+        return obj
+
+    # Pydantic v2
+    if hasattr(obj, "model_dump") and callable(getattr(obj, "model_dump")):
         try:
-            return obj.dict(exclude_none=True)
+            dumped = obj.model_dump(exclude_none=True)
         except Exception:
             try:
-                return obj.dict()
+                dumped = obj.model_dump()
             except Exception:
                 return {}
+        return to_plain_dict(dumped, _seen)
+
+    # Pydantic v1 or similar .dict() API
+    if hasattr(obj, "dict") and callable(getattr(obj, "dict")):
+        try:
+            dumped = obj.dict(exclude_none=True)
+        except Exception:
+            try:
+                dumped = obj.dict()
+            except Exception:
+                return {}
+        return to_plain_dict(dumped, _seen)
+
+    # Mapping / dict -> recurse and drop None/empty values
     if isinstance(obj, dict):
-        # drop None values for cleanliness
-        return {k: v for k, v in obj.items() if v is not None}
+        result: dict = {}
+        for k, v in obj.items():
+            normalized = to_plain_dict(v, _seen)
+            if normalized is None or normalized == {}:
+                continue
+            result[k] = normalized
+        return result
+
+    # Iterable containers -> normalize elements and return list (drop empty/None)
+    if isinstance(obj, (list, tuple, set)):
+        normalized_list = []
+        for item in obj:
+            n = to_plain_dict(item, _seen)
+            if n is None or n == {}:
+                continue
+            normalized_list.append(n)
+        return normalized_list
+
+    # Try to coerce mapping-like via dict() and recurse
     try:
-        return dict(obj)
+        coerced = dict(obj)
+        return to_plain_dict(coerced, _seen)
+    except Exception:
+        pass
+
+    # As a last resort, return the object if JSON-serializable, else empty dict
+    try:
+        import json
+        json.dumps(obj)
+        return obj
     except Exception:
         return {}
 
-
-
-if __name__ == '__main__':
-    mime_type = "vnd.psn.employees/json"
-    allowed_mime_types = ["image/png", "image/jpeg", "vnd.psn.employees/json"]
-    print(matches_type(mime_type, allowed_mime_types))

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -1,4 +1,4 @@
-from typing import Any, Optional
+from typing import Any, Optional, cast
 
 from injector import AssistedBuilder
 
@@ -9,6 +9,7 @@ from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentT
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
 
 from .deployment_stage_wrapper import DeploymentStageWrapper
+from ..common.utils import to_plain_dict
 
 
 class BaseDeploymentTool(StagedBaseTool):
@@ -49,3 +50,25 @@ class BaseDeploymentTool(StagedBaseTool):
             stage_wrapper,
             attachment_urls,
         )
+
+    def _pre_process_params(self, **kwargs: Any) -> Any:
+
+        if isinstance(self.tool_config, DialDeploymentTool):
+            tool_config = cast(DialDeploymentTool, self.tool_config)
+            # deployment and parameters are expected to be present on DialDeploymentTool
+            deployment = tool_config.deployment
+            params = deployment.parameters
+            params_dict = to_plain_dict(params)
+
+            for key, value in params_dict.items():
+                if key == "custom_fields":
+                    cf = to_plain_dict(value)
+                    if cf:
+                        kwargs["custom_fields"] = cf
+                    else:
+                        # if custom_fields exists but is empty, set as empty dict to be explicit
+                        kwargs["custom_fields"] = {}
+                else:
+                    kwargs[key] = value
+
+        return kwargs

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -5,11 +5,11 @@ from injector import AssistedBuilder
 from quickapp.common import CompletionResult, StagedBaseTool
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
+from quickapp.common.utils import to_plain_dict
 from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
 
 from .deployment_stage_wrapper import DeploymentStageWrapper
-from ..common.utils import to_plain_dict
 
 
 class BaseDeploymentTool(StagedBaseTool):

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -56,10 +56,9 @@ class BaseDeploymentTool(StagedBaseTool):
         if isinstance(self.tool_config, DialDeploymentTool):
             tool_config = cast(DialDeploymentTool, self.tool_config)
             # deployment and parameters are expected to be present on DialDeploymentTool
-            deployment = tool_config.deployment
-            params = deployment.parameters
-            params_dict = to_plain_dict(params)
 
+            params = tool_config.deployment.parameters
+            params_dict = to_plain_dict(params)
             for key, value in params_dict.items():
                 if key == "custom_fields":
                     cf = to_plain_dict(value)

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Iterable, Tuple
 
 from aidial_client import AsyncDial
 from aidial_client.resources import AsyncMetadata
@@ -17,6 +17,7 @@ from quickapp.common import CompletionResult
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.deployment_usage import DeploymentUsage
 from quickapp.config.tools.deployment import ContentPropagation
+from quickapp.common.utils import to_plain_dict
 
 _CONTENT_PARAM: str = "query"
 _ATTACHMENT_PARAM: str = "attachment_urls"
@@ -33,9 +34,23 @@ class DialCompletionService:
         self.__dial_client: AsyncDial = dial_client
         self.__history: list[Message] = messages[:-1] if messages and len(messages) > 0 else []
 
+    @staticmethod
+    def _prepare_custom_fields(items: Iterable[Tuple[str, Any]]) -> Optional[Dict[str, Any]]:
+        normalized: dict[str, Any] = {}
+        for k, v in items:
+            if k == _CONTENT_PARAM or k == _ATTACHMENT_PARAM:
+                continue
+            n = to_plain_dict(v)
+            if n == {}:
+                continue
+            normalized[k] = n
+        if normalized:
+            return {"configuration": normalized}
+        return None
+
     async def complete_request_async(
         self,
-        params: Dict[str, str],
+        params: Dict[str, Any],
         deployment_id: str,
         deployment_name: str,
         content_propagation: Optional[ContentPropagation],
@@ -47,26 +62,23 @@ class DialCompletionService:
             logger.warning(
                 "Tool call content is empty. Check the tool configuration, it should use `query` parameter"
             )
-        custom_args = {
-            "configuration": {
-                k: v for k, v in params.items() if k != _CONTENT_PARAM and k != _ATTACHMENT_PARAM
-            }
-        }
-
         messages = await self.__build_request_messages(
             content, content_propagation, relative_attachment_urls
         )
-        chat_completion_params = {
+        chat_completion_params: dict[str, Any] = {
             "deployment_name": deployment_id,
             "stream": True,
             "messages": messages,
         }
-        if custom_args:
-            chat_completion_params[_EXTRA_BODY] = {_CUSTOM_FIELDS: custom_args}
+
+        custom_fields = self._prepare_custom_fields(params.items())
+        if custom_fields:
+            chat_completion_params[_EXTRA_BODY] = {_CUSTOM_FIELDS: custom_fields}
+
 
         chunks = await self.__dial_client.chat.completions.create(**chat_completion_params)
 
-        content = ''
+        content_parts = []
         custom_content: CustomContent = CustomContent(attachments=[])
         usage: Optional[CompletionUsage] = None
         statistics: dict[str, Any] = {}
@@ -80,7 +92,7 @@ class DialCompletionService:
                     if delta.content:
                         if stage_wrapper:
                             stage_wrapper.append_stage_content(delta.content)
-                        content += delta.content
+                        content_parts.append(delta.content)
                     if delta.custom_content and delta.custom_content.attachments:
                         attachments = delta.custom_content.attachments
                         custom_content.attachments.extend(attachments)
@@ -107,7 +119,7 @@ class DialCompletionService:
                 statistics = chunk.model_extra.get("statistics", {}).get("usage_per_model", {})
 
         return CompletionResult(
-            content=content,
+            content="".join(content_parts),
             content_type="text/markdown",
             attachments=custom_content.attachments,
             usage=self.__get_deployment_usage(usage, statistics, deployment_id, deployment_name),
@@ -206,7 +218,6 @@ class DialCompletionService:
         )
 
     def _build_result_message(self, content, attachments, deployment_usage):
-
         m = Message(
             role=Role.TOOL,
             content=content,

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict, List, Optional, Iterable, Tuple
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from aidial_client import AsyncDial
 from aidial_client.resources import AsyncMetadata
@@ -16,8 +16,8 @@ from injector import inject
 from quickapp.common import CompletionResult
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.deployment_usage import DeploymentUsage
-from quickapp.config.tools.deployment import ContentPropagation
 from quickapp.common.utils import to_plain_dict
+from quickapp.config.tools.deployment import ContentPropagation
 
 _CONTENT_PARAM: str = "query"
 _ATTACHMENT_PARAM: str = "attachment_urls"
@@ -74,7 +74,6 @@ class DialCompletionService:
         custom_fields = self._prepare_custom_fields(params.items())
         if custom_fields:
             chat_completion_params[_EXTRA_BODY] = {_CUSTOM_FIELDS: custom_fields}
-
 
         chunks = await self.__dial_client.chat.completions.create(**chat_completion_params)
 

--- a/src/tests/integration_tests/test_runner/config.py
+++ b/src/tests/integration_tests/test_runner/config.py
@@ -47,7 +47,7 @@ class TestConfig:
     DEFAULT_MODEL = os.getenv("MODEL", "gpt4_1")  # "gpt4o", "claude35", "claude37"
     REMOTE_DIAL_API_KEY = SecretStr(os.getenv("REMOTE_DIAL_API_KEY", "dial_api_key"))
 
-    PY_INTERPRETER_URL = "https://dev-dial-core.staging.deltixhub.io"
+    PY_INTERPRETER_URL = os.getenv("PY_INTERPRETER_URL")
     PY_INTERPRETER_API_KEY = SecretStr(os.getenv("PY_INTERPRETER_API_KEY", REMOTE_DIAL_API_KEY))
 
     WARNING_MESSAGE = "No cached value found, this means that something was changed in the logic"


### PR DESCRIPTION
### Applicable issues

- fixes #53

### Description of changes

Add possibility to pass custom fields to any deployment or any other type of tool. 
The tool should have the possiblity to consume these paramters, otherwise you would see "extra_params" issue like this:

> Extra inputs are not permitted [type=extra_forbidden, input_value='some value', input_type=str]

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
