### PR TITLE
chore: completely switched to pydantic v2 #60

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,5 @@
+# AI DIAL SDK: pydantic v2 mode
+PYDANTIC_V2=True
 # Python 3.13 + poetry 2.1.1 environment
 PYTHON=python3
 POETRY=poetry

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PREDEFINED_BASE_PATH="/app/predefined" \
     CHROME_BIN=/home/appuser/.cache/kaleido/chrome
+ENV PYDANTIC_V2=True
 
 # Copy the sources and virtual env. No poetry.
 RUN adduser -u 1001 --disabled-password --gecos "" appuser

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,9 @@ PYTHON ?= python3
 -include .env
 export
 
+# AI DIAL SDK: pydantic v2 mode
+export PYDANTIC_V2=True
+
 init_venv:
 	$(POETRY) env use $(PYTHON)
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -20,14 +20,14 @@ pydantic = ">=1.10,<3"
 
 [[package]]
 name = "aidial-sdk"
-version = "0.31.0"
+version = "0.32.0"
 description = "Framework to create applications and model adapters for AI DIAL"
 optional = false
-python-versions = "<4.0,>=3.9"
+python-versions = "<4.0,>=3.10"
 groups = ["main"]
 files = [
-    {file = "aidial_sdk-0.31.0-py3-none-any.whl", hash = "sha256:40b743f774fe26a1ecbc675a3503bf40ca8dc478e78cd8e90781b2d2962017cf"},
-    {file = "aidial_sdk-0.31.0.tar.gz", hash = "sha256:dc714bc366952057a157db6dde9fe2724390617ba3958772450680919b30b970"},
+    {file = "aidial_sdk-0.32.0-py3-none-any.whl", hash = "sha256:6d6cee07ea4a932a27e0f0fdf69cef5ecd34569fb492c18392c6277c75d7a548"},
+    {file = "aidial_sdk-0.32.0.tar.gz", hash = "sha256:ea952aab6722d4524783d10e5d7379833f8b1f1f2f6c28bfd53375fa746b5764"},
 ]
 
 [package.dependencies]
@@ -5855,4 +5855,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "dc4e15f6fc7b671532efab506bde263f058270621b1fdf7cc26327dbdc6ae0d0"
+content-hash = "321eb4c16febc615532106a929d882c10f88d03ef3b3a25e8dd82f048084b84c"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,35 @@ license = "Apache-2.0"
 authors = [
     {name = "EPAM Systems"}
 ]
+dependencies = [
+    # Core framework & DI
+    "aidial-client>=0.4.0,<0.5.0",                # DIAL API client
+    "aidial-sdk[telemetry]>=0.32.0,<0.33.0",      # DIAL integration SDK
+    "pydantic>=2.12.4,<3.0.0",                    # Data validation
+    "pydantic-settings>=2.12.0,<3.0.0",           # Settings management
+    "injector>=0.23.0,<0.24.0",                   # Dependency injection
+    "fastapi-injector>=0.9.0,<0.10.0",            # FastAPI + injector integration
+
+    # Data processing & visualization
+    "pandas>=2.3.3,<3.0.0",                       # Data manipulation
+    "tabulate>=0.9.0,<0.10.0",                    # Table formatting
+    "plotly[kaleido]>=6.5.2,<7.0.0",              # Data visualization with image export
+
+    # MCP (Model Context Protocol)
+    "mcp>=1.23.2,<2.0.0",                         # MCP protocol support
+    "fastmcp>=2.14.3,<3.0.0",                     # High-level MCP server framework
+
+    # HTML & web content
+    "beautifulsoup4>=4.14.2,<5.0.0",              # HTML parsing
+    "bs4>=0.0.2,<0.0.3",                          # BeautifulSoup4 meta-package
+
+    # Authentication & networking
+    "authlib>=1.6.5,<2.0.0",                      # OAuth / JWT authentication
+    "urllib3>=2.6.3,<3.0.0",                      # HTTP client library
+
+    # Utilities
+    "common>=0.1.2,<0.2.0",                       # Shared utilities
+]
 homepage = "https://dialx.ai"
 repository = "https://github.com/epam/ai-dial-quickapps-backend"
 keywords = ["ai"]
@@ -15,24 +44,6 @@ keywords = ["ai"]
 [tool.poetry]
 package-mode = false
 requires-poetry = '>=2.0.0,<3.0.0'
-
-[tool.poetry.dependencies]
-aidial-client = "^0.4.0"
-aidial-sdk = {version="^0.31.0", extras = ["telemetry"]}
-pydantic = { version = "^2.12.4" }
-pydantic-settings = { version = "^2.12.0" }
-injector = "^0.23.0"
-fastapi-injector = "^0.9.0"
-pandas = "^2.3.3"
-tabulate = "^0.9.0"
-common = "^0.1.2"
-beautifulsoup4 = "^4.14.2"
-bs4 = "^0.0.2"
-authlib = "^1.6.5"
-plotly = {version = "^6.5.2", extras = ["kaleido"]}
-mcp = "^1.23.2"
-fastmcp = "^2.14.3"
-urllib3 = "^2.6.3"
 
 [tool.poetry.group.dev.dependencies]
 black = { version = "^24.4.0", extras = ["jupyter"] }

--- a/src/quickapp/agent/_attachment_filter.py
+++ b/src/quickapp/agent/_attachment_filter.py
@@ -2,7 +2,6 @@ import copy
 import logging
 
 from aidial_sdk.chat_completion import Message, Role
-from pydantic import StrictStr
 
 from quickapp.common.utils import matches_type
 
@@ -28,7 +27,7 @@ class _AttachmentFilter:
     def _filter(self, message: Message):
         updated_attachments = []
         if message.content is None:
-            message.content = StrictStr("")
+            message.content = ""
         if self._has_attachments(message):
             for attachment in message.custom_content.attachments:
                 if message.role == Role.USER and matches_type(

--- a/src/quickapp/agent/_messages_transformers.py
+++ b/src/quickapp/agent/_messages_transformers.py
@@ -2,7 +2,6 @@ import logging
 
 from aidial_sdk.chat_completion import Message, Role
 from injector import ProviderOf, inject
-from pydantic import StrictStr
 
 from quickapp.agent.agent_instructions_provider import AgentInstructionsProvider
 from quickapp.common.abstract.base_transformer import MessagesTransformer
@@ -31,6 +30,6 @@ class _AddSystemPromptTransformer(MessagesTransformer):
         if not combined_system_prompt:
             return messages
         if len(messages) > 0 and messages[0].role != Role.SYSTEM:
-            return [Message(role=Role.SYSTEM, content=StrictStr(combined_system_prompt))] + messages
+            return [Message(role=Role.SYSTEM, content=combined_system_prompt)] + messages
 
         return messages

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -1,14 +1,13 @@
 import logging
 from typing import Any, Dict, Optional
 
+from aidial_client.types.chat.response import Attachment
 from aidial_sdk.chat_completion import Choice, Stage
 from aidial_sdk.chat_completion.request import ToolCall
 from injector import inject
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
-
-from quickapp.common.dial_core_client import Attachment
 
 
 class Usage:
@@ -45,7 +44,7 @@ class AssistantCallResult:
 
     def append_tool_call_delta(self, tool_call_delta: ChoiceDeltaToolCall) -> None:
         if tool_call_delta.id:
-            tool_call = ToolCall(**tool_call_delta.dict())
+            tool_call = ToolCall(**tool_call_delta.model_dump())
             self.__tool_calls[tool_call_delta.index] = tool_call
         else:
             tool_call = self.__tool_calls[tool_call_delta.index]

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -3,7 +3,6 @@ import logging
 from aidial_sdk.chat_completion import Choice
 from aidial_sdk.chat_completion.request import CustomContent, Message, Role
 from injector import ProviderOf, inject
-from pydantic.v1 import StrictStr
 
 from quickapp.agent.assistant_invoker import AssistantInvoker
 from quickapp.agent.chunk_processor import ChunkProcessor
@@ -71,7 +70,7 @@ class Orchestrator:
             self.__messages_context.append_message(
                 Message(
                     role=Role.ASSISTANT,
-                    content=assistant_call_result.content or StrictStr(" "),
+                    content=assistant_call_result.content or " ",
                     custom_content=CustomContent(attachments=assistant_call_result.attachments),
                     tool_calls=assistant_call_result.tool_calls,
                 )

--- a/src/quickapp/application/_messages_setup.py
+++ b/src/quickapp/application/_messages_setup.py
@@ -5,7 +5,6 @@ import warnings
 from aidial_sdk.chat_completion import Message, Role, ToolCall
 from aidial_sdk.utils.pydantic import ExtraAllowModel
 from injector import inject
-from pydantic import StrictStr
 
 from quickapp.agent.models import TOOL_EXECUTION_HISTORY
 from quickapp.common.abstract.base_transformer import MessagesTransformer
@@ -61,9 +60,9 @@ class _MessagesSetup:
 
         extracted_messages: list[Message] = []
         for history_part in tool_history:
-            executed_tool_call = ExecutedToolCallDTO.validate(history_part)
+            executed_tool_call = ExecutedToolCallDTO.model_validate(history_part)
             assistant_tool_call = copy.deepcopy(assistant_message)
-            assistant_tool_call.content = StrictStr("")
+            assistant_tool_call.content = ""
 
             if assistant_tool_call.tool_calls is None:
                 assistant_tool_call.tool_calls = []

--- a/src/quickapp/common/dial_core_client.py
+++ b/src/quickapp/common/dial_core_client.py
@@ -4,19 +4,7 @@ from typing import Any, Dict, Optional
 
 import httpx
 from aidial_client.types.deployment import Features
-from aidial_sdk.pydantic_v1 import SecretStr as SecretStrV1
-from pydantic import BaseModel, ConfigDict, Field
-from pydantic import SecretStr as SecretStrV2
-from pydantic import StrictStr, alias_generators
-
-
-class Attachment(BaseModel):
-    type: Optional[StrictStr] = "text/markdown"
-    title: Optional[StrictStr] = None
-    data: Optional[StrictStr] = None
-    url: Optional[StrictStr] = None
-    reference_type: Optional[StrictStr] = None
-    reference_url: Optional[StrictStr] = None
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, alias_generators
 
 
 class AttachmentResponse(BaseModel):
@@ -53,7 +41,7 @@ class ToolsetInfo(BaseModel, extra='allow'):
 
 
 class DialCoreClient:
-    def __init__(self, api_key: str | SecretStrV1 | SecretStrV2, base_url: str):
+    def __init__(self, api_key: str | SecretStr, base_url: str):
         self.api_key = self._get_api_key(api_key)
         self.base_url = base_url
         self._bucket_id: str | None = None
@@ -66,10 +54,8 @@ class DialCoreClient:
         )
         return self
 
-    def _get_api_key(self, api_key: str | SecretStrV1 | SecretStrV2) -> str:
-        if isinstance(api_key, SecretStrV1):
-            return api_key.get_secret_value()
-        if isinstance(api_key, SecretStrV2):
+    def _get_api_key(self, api_key: str | SecretStr) -> str:
+        if isinstance(api_key, SecretStr):
             return api_key.get_secret_value()
         return api_key
 

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -72,8 +72,8 @@ def to_plain_dict(obj: Any, _seen: set[int] | None = None) -> Any:
     Behavior:
     - Preserves JSON primitives (str, int, float, bool) as-is.
     - Returns an empty dict for top-level None (backwards-compatible).
-    - Converts Pydantic v2 (`model_dump`) or v1 (`dict`) using `exclude_none=True`
-      when available, then recurses.
+    - Converts Pydantic v2 models using `model_dump(exclude_none=True)`,
+      then recurses.
     - Recursively converts dicts, lists, tuples, sets and mapping-like objects,
       dropping entries with None or empty dict values.
     - Attempts `dict(obj)` for iterable-of-pairs fallback.
@@ -108,17 +108,6 @@ def to_plain_dict(obj: Any, _seen: set[int] | None = None) -> Any:
         except Exception:
             try:
                 dumped = obj.model_dump()
-            except Exception:
-                return {}
-        return to_plain_dict(dumped, _seen)
-
-    # Pydantic v1 or similar .dict() API
-    if hasattr(obj, "dict") and callable(getattr(obj, "dict")):
-        try:
-            dumped = obj.dict(exclude_none=True)
-        except Exception:
-            try:
-                dumped = obj.dict()
             except Exception:
                 return {}
         return to_plain_dict(dumped, _seen)

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -1,7 +1,6 @@
-from aidial_sdk.pydantic_v1 import SecretStr
 from fastapi import FastAPI, HTTPException, Request, status
 from injector import inject
-from pydantic import TypeAdapter
+from pydantic import SecretStr, TypeAdapter
 
 from quickapp.config.config_template_resolver import ConfigResolver, TemplateType
 from quickapp.config.tools.deployment import DialDeploymentTool

--- a/src/quickapp/dial_core_services/attachment_service.py
+++ b/src/quickapp/dial_core_services/attachment_service.py
@@ -2,10 +2,11 @@ import base64
 import logging
 from io import BytesIO
 
+from aidial_client.types.chat.response import Attachment
 from injector import inject
 
 from quickapp.common import DIAL_API_KEY
-from quickapp.common.dial_core_client import Attachment, DialCoreClient
+from quickapp.common.dial_core_client import DialCoreClient
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.utils import generate_attachment_filename
 

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/display_content_processor.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/display_content_processor.py
@@ -15,7 +15,6 @@ from aidial_client.types.chat.request_param import (
     UserMessageParam,
 )
 from aidial_client.types.chat.response import Attachment, ChatCompletionResponse
-from aidial_sdk.pydantic_v1 import StrictStr
 from injector import inject
 
 from quickapp.common import DIAL_API_KEY
@@ -125,7 +124,7 @@ class DisplayContentProcessor:
         user_message = await self._generate_attachment_message(attachment)
         if user_message:
             messages = [
-                SystemMessageParam(role='system', content=StrictStr(_NAMING_SYS_PROMPT)),
+                SystemMessageParam(role='system', content=_NAMING_SYS_PROMPT),
                 user_message,
             ]
             try:

--- a/src/quickapp/mcp_tooling/_mcp_stage_wrapper.py
+++ b/src/quickapp/mcp_tooling/_mcp_stage_wrapper.py
@@ -41,7 +41,7 @@ class _MCPStageWrapper(TimedStageWrapper):
     @staticmethod
     def __serialize(obj):
         if isinstance(obj, BaseModel):
-            return obj.dict()
+            return obj.model_dump()
         if hasattr(obj, "__dict__"):
             return obj.__dict__
         raise TypeError(f"Object of type {type(obj).__name__} isn't JSON serializable")

--- a/src/quickapp/rest_api_tooling/_rest_api_stage_wrapper.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_stage_wrapper.py
@@ -50,7 +50,7 @@ class _RestApiStageWrapper(TimedStageWrapper):
         from pydantic import BaseModel
 
         if isinstance(obj, BaseModel):
-            return obj.dict()
+            return obj.model_dump()
         if hasattr(obj, '__dict__'):
             return obj.__dict__
         raise TypeError(f"Object of type {obj.__class__.__name__} isn't JSON serializable")

--- a/src/tests/unit_tests/agent_tests/test_attachment_filter.py
+++ b/src/tests/unit_tests/agent_tests/test_attachment_filter.py
@@ -1,11 +1,10 @@
 from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
-from pydantic.v1 import StrictStr
 
 from quickapp.agent._attachment_filter import _AttachmentFilter
 
 
 def _user_msg(content: str = "", attachments: list[Attachment] | None = None) -> Message:
-    msg = Message(role=Role.USER, content=StrictStr(content))
+    msg = Message(role=Role.USER, content=content)
     if attachments:
         msg.custom_content = CustomContent(attachments=attachments)
     return msg
@@ -13,10 +12,11 @@ def _user_msg(content: str = "", attachments: list[Attachment] | None = None) ->
 
 def _attachment(title: str, url: str, mime_type: str) -> Attachment:
     return Attachment(
-        title=StrictStr(title),
-        url=StrictStr(url),
-        type=StrictStr(mime_type),
+        title=title,
+        url=url,
+        type=mime_type,
     )
+
 
 class Test_AttachmentFilter:
     def test_image_attachments_kept_inline(self):

--- a/src/tests/unit_tests/application_tests/test_completion.py
+++ b/src/tests/unit_tests/application_tests/test_completion.py
@@ -6,8 +6,6 @@ import fastapi
 import pytest
 from aidial_sdk.chat_completion import Request, Message, Role
 from httpx import HTTPError
-from pydantic import StrictStr
-
 import quickapp.application._quick_app_completion as quick_app_completion
 from quickapp.application._messages_setup import _MessagesSetup
 from quickapp.application._request_context import _RequestContext
@@ -100,7 +98,7 @@ async def valid_app_props(*args, **kwargs):
 @pytest.fixture
 def make_request_completion():
     def _make(orchestrator=None, api_key="k", has_binding=True, extra_mapping=None):
-        request = Request(api_key_secret=StrictStr(api_key), messages=[Message(content="123", role=Role.USER), Message(content="456", role=Role.USER)], deployment_id=StrictStr("default-deployment"),
+        request = Request(api_key_secret=api_key, messages=[Message(content="123", role=Role.USER), Message(content="456", role=Role.USER)], deployment_id="default-deployment",
                           headers={"1":"2"}, original_request=fastapi.Request(scope={"type": "http"}))
         request.request_dial_application_properties = valid_app_props
 

--- a/src/tests/unit_tests/application_tests/test_extract_tool_calls_processor.py
+++ b/src/tests/unit_tests/application_tests/test_extract_tool_calls_processor.py
@@ -179,10 +179,15 @@ class TestExtractToolCallsFromStateProcessor:
             warnings.simplefilter("always")
             result = msgs_setup.setup(messages)
 
-            # Should emit deprecation warning
-            assert len(w) == 1
-            assert issubclass(w[0].category, DeprecationWarning)
-            assert "deprecated" in str(w[0].message).lower()
+            # Should emit deprecation warning about legacy tool_execution_history format
+            deprecation_warnings = [
+                x
+                for x in w
+                if issubclass(x.category, DeprecationWarning)
+                and "tool_execution_history" in str(x.message).lower()
+            ]
+            assert len(deprecation_warnings) == 1
+            assert "deprecated" in str(deprecation_warnings[0].message).lower()
 
         # Should still produce correct output
         assert len(result) == 3

--- a/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
+++ b/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
@@ -15,7 +15,6 @@ import unittest
 from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
 from fastapi_injector import Injected
 from injector import Binder
-from pydantic.v1 import StrictStr
 from starlette.testclient import TestClient
 
 from quickapp.application._messages_setup import _MessagesSetup
@@ -27,7 +26,7 @@ from tests.unit_tests.common.common import create_app_configuration, create_test
 
 
 def _user_msg(content: str = "", attachments: list[Attachment] | None = None) -> Message:
-    msg = Message(role=Role.USER, content=StrictStr(content))
+    msg = Message(role=Role.USER, content=content)
     if attachments:
         msg.custom_content = CustomContent(attachments=attachments)
     return msg
@@ -35,10 +34,11 @@ def _user_msg(content: str = "", attachments: list[Attachment] | None = None) ->
 
 def _attachment(title: str, url: str, mime_type: str) -> Attachment:
     return Attachment(
-        title=StrictStr(title),
-        url=StrictStr(url),
-        type=StrictStr(mime_type),
+        title=title,
+        url=url,
+        type=mime_type,
     )
+
 
 class TestContextPipelineDI(unittest.TestCase):
     def setUp(self):
@@ -47,10 +47,7 @@ class TestContextPipelineDI(unittest.TestCase):
         def configure(binder: Binder):
             app_config = create_app_configuration([])
             app_config.contexts = [ctx]
-            binder.bind(
-                ApplicationConfig,
-                to=app_config
-            )
+            binder.bind(ApplicationConfig, to=app_config)
 
         self.app = create_test_app([AttachmentProcessingModule, configure])
         self.client = TestClient(self.app)
@@ -88,10 +85,7 @@ class TestCombinedPipelineDI(unittest.TestCase):
         def configure(binder: Binder):
             app_config = create_app_configuration([])
             app_config.contexts = [ctx]
-            binder.bind(
-                ApplicationConfig,
-                to=app_config
-            )
+            binder.bind(ApplicationConfig, to=app_config)
 
         self.app = create_test_app([AttachmentProcessingModule, configure])
         self.client = TestClient(self.app)

--- a/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
+++ b/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
@@ -2,8 +2,6 @@ import json
 from types import SimpleNamespace
 
 from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
-from pydantic import StrictStr
-
 from quickapp.attachment_processing._attachment_notification_injector import (
     _AttachmentNotificationInjector,
 )
@@ -15,7 +13,7 @@ from quickapp.config.prompt import CustomSystemPromptConfig
 
 
 def _user_msg(content: str = "", attachments: list[Attachment] | None = None) -> Message:
-    msg = Message(role=Role.USER, content=StrictStr(content))
+    msg = Message(role=Role.USER, content=content)
     if attachments:
         msg.custom_content = CustomContent(attachments=attachments)
     return msg

--- a/src/tests/unit_tests/dial_core_services_tests/test_attachment_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_attachment_service.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import SecretStr
 
 from quickapp.common.dial_settings import DialSettings
-from quickapp.common.dial_core_client import Attachment
+from aidial_client.types.chat.response import Attachment
 from quickapp.dial_core_services.attachment_service import AttachmentService
 
 

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
@@ -1,8 +1,6 @@
 import pytest
 from unittest.mock import AsyncMock, MagicMock, call
 from aidial_sdk.chat_completion import Message, Role
-from pydantic import StrictStr
-
 from quickapp.config.tools.deployment import ContentPropagation
 from quickapp.dial_deployment_tooling.constants import EXTRA_BODY
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
@@ -29,9 +27,9 @@ def dial_client():
 @pytest.fixture
 def history_messages():
     return [
-        Message(role=Role.USER, content=StrictStr("First message")),
-        Message(role=Role.ASSISTANT, content=StrictStr("First response")),
-        Message(role=Role.USER, content=StrictStr("Current message"))
+        Message(role=Role.USER, content="First message"),
+        Message(role=Role.ASSISTANT, content="First response"),
+        Message(role=Role.USER, content="Current message")
     ]
 
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #60 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

- completely switched to pydantic v2 using aidial-sdk `PYDANTIC_V2` env variable
- reorganized poetry dependencies for poetry 2 compliance and clarity
- removed all occurrences of code that was constructing `StrictStr(...)`. `StrictStr` must be used for type annotations only
- removed duplicated `Attachment` model

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
