### PR TITLE
feat: refactor propagate_history logic for deployment tools #85

### DIFF
--- a/docker_compose_files/core/configuration/applications.json
+++ b/docker_compose_files/core/configuration/applications.json
@@ -86,6 +86,144 @@
       "features": {
         "assistant_attachments_in_request_supported": true
       }
+    },
+    "nested_quick_app": {
+      "displayName": "NestedQuickApp",
+      "description": "QuickApp that has access to web search and image generation tools and can be used as a tool in other QuickApp",
+      "applicationTypeSchemaId": "https://mydial.epam.com/custom_application_schemas/quickapps2",
+      "inputAttachmentTypes": [
+        "*/*"
+      ],
+      "features": {
+        "assistant_attachments_in_request_supported": true
+      },
+      "applicationProperties": {
+        "orchestrator": {
+          "deployment": {
+            "name": "gpt-4.1-2025-04-14"
+          },
+          "system_prompt": {
+            "type": "custom",
+            "variables": {},
+            "content": "You are an AI assistant that helps people find information using web search and generate images using image generation tool. Always format your responses in markdown."
+          }
+        },
+        "contexts": [],
+        "tool_sets": [
+          {
+            "name": "sample",
+            "description": "sample toolset",
+            "type": "dial-deployment",
+            "tools": [
+              {
+                "type": "predefined-tool",
+                "template_name": "web_search"
+              },
+              {
+                "type": "predefined-tool",
+                "template_name": "image_generation"
+              }
+            ]
+          }
+        ]
+      }
+    },
+    "root_quick_app": {
+      "displayName": "RootQuickApp",
+      "description": "Sample quick app that demonstrates nesting of quick apps. Has access to NestedQuickApp which in turn has access to web search and image generation tools",
+      "applicationTypeSchemaId": "https://mydial.epam.com/custom_application_schemas/quickapps2",
+      "inputAttachmentTypes": [
+        "*/*"
+      ],
+      "features": {
+        "assistant_attachments_in_request_supported": true
+      },
+      "applicationProperties": {
+        "orchestrator": {
+          "deployment": {
+            "name": "gpt-4.1-2025-04-14"
+          },
+          "system_prompt": {
+            "type": "custom",
+            "variables": {},
+            "content": "You are smart AI assistant with access to tools. Always format your responses in markdown."
+          }
+        },
+        "contexts": [],
+        "tool_sets": [
+          {
+            "name": "nested-quick-app-toolset",
+            "description": "Set with NestedQuickApp quick app as a tool",
+            "type": "dial-deployment",
+            "tools": [
+              {
+                "type": "deployment-tool",
+                "display": {
+                  "stage": {
+                    "name": "Nested QuickApp: "
+                  }
+                },
+                "deployment": {
+                  "name": "nested_quick_app"
+                },
+                "content_propagation": {
+                  "propagate_history": true,
+                  "propagate_headers": []
+                },
+                "open_ai_tool": {
+                  "type": "function",
+                  "function": {
+                    "name": "nested_quick_app_tool",
+                    "description": "Tool that has access to NestedQuickApp subagent, which in turn has access to web search and image generation tools. Use when web search or image generation is needed and you want to use NestedQuickApp toolset capabilities to process the request. Always provide clear and concise input to get the best results.",
+                    "parameters": {
+                      "type": "object",
+                      "properties": {
+                        "query": {
+                          "type": "string",
+                          "description": "Agent prompt",
+                          "display": {
+                            "stage": {
+                              "show_value_in_stage_title": true,
+                              "name": "**Prompt:** "
+                            }
+                          }
+                        },
+                        "attachment_urls": {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          },
+                          "description": "A list of full URLs for each attachment related to the tool call. Each item must be a full URL string. *Always provide a list*, even if there is only one attachment. Do not provide a single string; use a list with one element instead. If there are no attachments, provide an empty list.",
+                          "display": {
+                            "stage": {
+                              "name": "**Files:** "
+                            }
+                          }
+                        }
+                      },
+                      "required": [
+                        "query"
+                      ]
+                    }
+                  }
+                },
+                "attachment": {
+                  "supported_types": [
+                    "*/*"
+                  ]
+                },
+                "fallback_configuration": {
+                  "strategies": [
+                    {
+                      "type": "continue"
+                    }
+                  ]
+                }
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 }

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -1,4 +1,6 @@
 import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
 
 from aidial_sdk.chat_completion import Choice
 from aidial_sdk.chat_completion.request import CustomContent, Message, Role
@@ -52,75 +54,89 @@ class Orchestrator:
         self.__perf_timer: PerformanceTimer = perf_timer
         self.__period_name = "orchestrator_invocation"
 
+    @asynccontextmanager
+    async def _persisting_state(self) -> AsyncIterator[None]:
+        exc_to_reraise: BaseException | None = None
+        try:
+            yield
+        except BaseException as exc:
+            exc_to_reraise = exc
+            logger.warning("Orchestrator interrupted by %s, saving state before re-raising", exc)
+        finally:
+            tool_execution_history = self._build_tool_execution_history()
+            if tool_execution_history:
+                self.__state_holder.add_state(TOOL_EXECUTION_HISTORY, tool_execution_history)
+
+            self.__choice.set_state(self.__state_holder.get_state())
+            if self.__usage_statistics_list and self.__SHOW_USAGE_STATISTICS:
+                await self.__usage_statistics_service.process_usage_statistics(
+                    self.__usage_statistics_list
+                )
+            logger.debug(f"State holder: {self.__state_holder.get_state()}")
+
+        if exc_to_reraise is not None:
+            raise exc_to_reraise
+
     async def invoke(self):
-        while True:
-            self.__iterations_counter += 1
-            if self.__iterations_counter > self.__MAX_ITERATIONS_COUNT:
-                raise OrchestratorExceedMaxIterationsException()
+        async with self._persisting_state():
+            while await self._run_iteration():
+                pass
 
-            self.__perf_timer.start_period(
-                f"{self.__period_name}_{self.__iterations_counter}", level=2
+    async def _run_iteration(self) -> bool:
+        """Run a single orchestrator iteration. Returns True if the loop should continue."""
+        self.__iterations_counter += 1
+        if self.__iterations_counter > self.__MAX_ITERATIONS_COUNT:
+            raise OrchestratorExceedMaxIterationsException()
+
+        period = f"{self.__period_name}_{self.__iterations_counter}"
+        self.__perf_timer.start_period(period, level=2)
+
+        assistant_invoker = self.__assistant_invoker_provider.get()
+        chat_completion_stream = await assistant_invoker.invoke()
+        assistant_call_result = await self.__chunk_processor_provider.get().process_chunks(
+            chat_completion=chat_completion_stream, destination=self.__choice
+        )
+
+        self.__messages_context.append_message(
+            Message(
+                role=Role.ASSISTANT,
+                content=assistant_call_result.content or StrictStr(" "),
+                custom_content=CustomContent(attachments=assistant_call_result.attachments),
+                tool_calls=assistant_call_result.tool_calls,
             )
-
-            assistant_invoker = self.__assistant_invoker_provider.get()
-            chat_completion_stream = await assistant_invoker.invoke()
-            assistant_call_result = await self.__chunk_processor_provider.get().process_chunks(
-                chat_completion=chat_completion_stream, destination=self.__choice
-            )
-
-            self.__messages_context.append_message(
-                Message(
-                    role=Role.ASSISTANT,
-                    content=assistant_call_result.content or StrictStr(" "),
-                    custom_content=CustomContent(attachments=assistant_call_result.attachments),
-                    tool_calls=assistant_call_result.tool_calls,
+        )
+        if assistant_call_result.usage and self.__SHOW_USAGE_STATISTICS:
+            self.__usage_statistics_list.append(
+                DeploymentUsage(
+                    model_name=self.__orchestrator_deployment_name,
+                    prompt_tokens=assistant_call_result.usage.prompt_tokens,
+                    completion_tokens=assistant_call_result.usage.completion_tokens,
                 )
             )
-            if assistant_call_result.usage and self.__SHOW_USAGE_STATISTICS:
-                self.__usage_statistics_list.append(
-                    DeploymentUsage(
-                        model_name=self.__orchestrator_deployment_name,
-                        prompt_tokens=assistant_call_result.usage.prompt_tokens,
-                        completion_tokens=assistant_call_result.usage.completion_tokens,
-                    )
-                )
-            self.__perf_timer.add_milestone(
-                f"{self.__period_name}_{self.__iterations_counter}", "assistant_response_received"
-            )
-            logger.debug(f"Message from agent: {self.__messages_context.messages}")
+        self.__perf_timer.add_milestone(period, "assistant_response_received")
+        logger.debug(f"Message from agent: {self.__messages_context.messages}")
 
-            tool_calls = assistant_call_result.tool_calls
-            if not tool_calls:
-                break
+        tool_calls = assistant_call_result.tool_calls
+        if not tool_calls:
+            return False
 
-            logger.debug(f"Agent requests tool calls: {tool_calls}")
-            tool_call_results = await self.__tool_executor.execute(tool_calls)
-            if not tool_call_results:
-                raise RuntimeError(f"Tool call(s) {tool_calls} doesn't return any result.")
+        logger.debug(f"Agent requests tool calls: {tool_calls}")
+        tool_call_results = await self.__tool_executor.execute(tool_calls)
+        if not tool_call_results:
+            raise RuntimeError(f"Tool call(s) {tool_calls} doesn't return any result.")
 
-            logger.debug(f"Tool call results: {tool_call_results}")
-            for tool_call_result in tool_call_results:
-                tool_call_result_message = tool_call_result.to_tool_message()
-                self.__messages_context.append_message(tool_call_result_message)
-                for attachment in tool_call_result.propagate_to_choice:
-                    self.__choice.add_attachment(**attachment.model_dump(exclude={"index"}))
-                if tool_call_result.usage and self.__SHOW_USAGE_STATISTICS:
-                    self.__usage_statistics_list.extend(tool_call_result.usage)
+        logger.debug(f"Tool call results: {tool_call_results}")
+        for tool_call_result in tool_call_results:
+            tool_call_result_message = tool_call_result.to_tool_message()
+            self.__messages_context.append_message(tool_call_result_message)
+            for attachment in tool_call_result.propagate_to_choice:
+                self.__choice.add_attachment(**attachment.model_dump(exclude={"index"}))
+            if tool_call_result.usage and self.__SHOW_USAGE_STATISTICS:
+                self.__usage_statistics_list.extend(tool_call_result.usage)
 
-            self.__perf_timer.stop_period(f"{self.__period_name}_{self.__iterations_counter}")
-            logger.debug(f"Message from context: {self.__messages_context.messages}")
-
-        # Derive tool execution history from messages and write state once
-        tool_execution_history = self._build_tool_execution_history()
-        if tool_execution_history:
-            self.__state_holder.add_state(TOOL_EXECUTION_HISTORY, tool_execution_history)
-
-        self.__choice.set_state(self.__state_holder.get_state())
-        if self.__usage_statistics_list and self.__SHOW_USAGE_STATISTICS:
-            await self.__usage_statistics_service.process_usage_statistics(
-                self.__usage_statistics_list
-            )
-        logger.debug(f"State holder: {self.__state_holder.get_state()}")
+        self.__perf_timer.stop_period(period)
+        logger.debug(f"Message from context: {self.__messages_context.messages}")
+        return True
 
     def _build_tool_execution_history(self) -> list[dict[str, object]]:
         """Build tool execution history by extracting ASSISTANT and TOOL messages.

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -96,6 +96,8 @@ class Orchestrator:
         assistant_call_result = await self.__chunk_processor_provider.get().process_chunks(
             chat_completion=chat_completion_stream, destination=self.__choice
         )
+        if assistant_call_result is None:
+            raise RuntimeError("Assistant invocation returned no result.")
 
         self.__messages_context.append_message(
             Message(

--- a/src/quickapp/common/completion_result.py
+++ b/src/quickapp/common/completion_result.py
@@ -12,6 +12,7 @@ class CompletionResult(BaseModel):
     content: Any
     content_type: str
     attachments: Optional[list[Attachment]] = None
+    state: Any | None = None
     usage: Optional[list[DeploymentUsage]] = None
 
     propagate_to_choice: list[Attachment] = Field(default_factory=list)
@@ -25,7 +26,7 @@ class CompletionResult(BaseModel):
             content=self.content,
             custom_content=CustomContent(
                 attachments=self.attachments,
-                # state={"usage": self.deployment_usage}
+                state=self.state,
             ),
             tool_call_id=self.tool_call_id,
         )

--- a/src/quickapp/common/completion_result.py
+++ b/src/quickapp/common/completion_result.py
@@ -12,7 +12,7 @@ class CompletionResult(BaseModel):
     content: Any
     content_type: str
     attachments: Optional[list[Attachment]] = None
-    state: Any | None = None
+    state: dict[str, Any] | None = None
     usage: Optional[list[DeploymentUsage]] = None
 
     propagate_to_choice: list[Attachment] = Field(default_factory=list)

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -165,7 +165,7 @@ class BaseDeploymentTool(StagedBaseTool):
         if isinstance(self.tool_config, DialDeploymentTool):
             tool_config = cast(DialDeploymentTool, self.tool_config)
             params = tool_config.deployment.parameters
-            self.merge_to_prepared_params(params, prepared)
+            self._merge_to_prepared_params(params, prepared)
 
         # Now process runtime kwargs - these should override defaults
         prepared.update(kwargs)
@@ -174,7 +174,8 @@ class BaseDeploymentTool(StagedBaseTool):
 
         return prepared
 
-    def merge_to_prepared_params(self, params: Any, prepared: dict[str, Any]):
+    @staticmethod
+    def _merge_to_prepared_params(params: Any, prepared: dict[str, Any]):
         """Merge deployment parameters into a plain dict. Grouping into extra_body is done in DialCompletionService."""
         params_dict = to_plain_dict(params)
         if isinstance(params_dict, dict):

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -2,8 +2,14 @@ import json
 import logging
 from typing import Any, Optional, cast
 
-from aidial_client.types.chat.request_param import AssistantMessageParam, UserMessageParam
+from aidial_client.types.chat.request_param import (
+    AssistantMessageParam,
+    AttachmentParam,
+    CustomContentParam,
+    UserMessageParam,
+)
 from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.chat_completion.request import Attachment as SdkAttachment
 from injector import AssistedBuilder
 
 from quickapp.common import CompletionResult, StagedBaseTool
@@ -11,7 +17,7 @@ from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import to_plain_dict
 from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
-from quickapp.dial_deployment_tooling.constants import CONTENT_PARAM
+from quickapp.dial_deployment_tooling.constants import ATTACHMENT_PARAM, CONTENT_PARAM
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
 
 from .deployment_stage_wrapper import DeploymentStageWrapper
@@ -54,9 +60,7 @@ class BaseDeploymentTool(StagedBaseTool):
         tool_config = cast(DialDeploymentTool, self.tool_config)
         history = None
         if self.__content_propagation and self.__content_propagation.propagate_history:
-            history = self._extract_tool_history(
-                self.__messages, tool_config.open_ai_tool.function.name
-            )
+            history = await self._extract_tool_history(tool_config.open_ai_tool.function.name)
         return await self.__dial_completion_service.complete_request_async(
             kwargs,
             self.__application_id,
@@ -67,20 +71,37 @@ class BaseDeploymentTool(StagedBaseTool):
         )
 
     @staticmethod
-    def _extract_tool_history(
-        messages: list[Message],
+    def _sdk_attachment_to_param(attachment: SdkAttachment) -> AttachmentParam:
+        param = AttachmentParam()
+        if attachment.type is not None:
+            param["type"] = attachment.type
+        if attachment.title is not None:
+            param["title"] = attachment.title
+        if attachment.data is not None:
+            param["data"] = attachment.data
+        if attachment.url is not None:
+            param["url"] = attachment.url
+        if attachment.reference_url is not None:
+            param["reference_url"] = attachment.reference_url
+        if attachment.reference_type is not None:
+            param["reference_type"] = attachment.reference_type
+        return param
+
+    async def _extract_tool_history(
+        self,
         tool_name: str,
     ) -> list[UserMessageParam | AssistantMessageParam]:
         if not tool_name:
             return []
 
-        # Build map: tool_call_id -> TOOL message content
-        tool_result_by_id: dict[str, str] = {}
+        messages = self.__messages
+
+        # Build map: tool_call_id -> (content, custom_content)
+        tool_result_by_id: dict[str, tuple[str, Any]] = {}
         for msg in messages:
             if msg.role == Role.TOOL and msg.tool_call_id and msg.content:
-                tool_result_by_id[msg.tool_call_id] = (
-                    msg.content if isinstance(msg.content, str) else str(msg.content)
-                )
+                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                tool_result_by_id[msg.tool_call_id] = (content, msg.custom_content)
 
         # Walk ASSISTANT messages, find tool_calls matching tool_name
         history: list[UserMessageParam | AssistantMessageParam] = []
@@ -90,19 +111,49 @@ class BaseDeploymentTool(StagedBaseTool):
             for tc in msg.tool_calls:
                 if tc.function.name != tool_name:
                     continue
-                tool_result = tool_result_by_id.get(tc.id)
-                if tool_result is None:
+                result_entry = tool_result_by_id.get(tc.id)
+                if result_entry is None:
                     # Current call — its TOOL result hasn't been appended yet
                     continue
+
+                tool_content, tool_custom_content = result_entry
+
+                # --- Request side: build UserMessageParam ---
                 try:
                     args = json.loads(tc.function.arguments)
                     query = args.get(CONTENT_PARAM, "")
+                    attachment_urls: list[str] | None = args.get(ATTACHMENT_PARAM)
                 except (json.JSONDecodeError, AttributeError):
                     query = ""
-                if query:
-                    history.append(UserMessageParam(role="user", content=query))
-                if tool_result:
-                    history.append(AssistantMessageParam(role="assistant", content=tool_result))
+                    attachment_urls = None
+
+                if query or attachment_urls:
+                    user_msg = UserMessageParam(role="user", content=query or "")
+                    if attachment_urls:
+                        resolved = await self.__dial_completion_service.resolve_attachment_urls(
+                            attachment_urls
+                        )
+                        if resolved:
+                            user_msg["custom_content"] = CustomContentParam(attachments=resolved)
+                    history.append(user_msg)
+
+                # --- Response side: build AssistantMessageParam ---
+                if tool_content:
+                    assistant_msg = AssistantMessageParam(role="assistant", content=tool_content)
+
+                    if tool_custom_content:
+                        cc_param = CustomContentParam()
+                        if tool_custom_content.attachments:
+                            cc_param["attachments"] = [
+                                self._sdk_attachment_to_param(a)
+                                for a in tool_custom_content.attachments
+                            ]
+                        if tool_custom_content.state is not None:
+                            cc_param["state"] = tool_custom_content.state
+                        if cc_param:
+                            assistant_msg["custom_content"] = cc_param
+
+                    history.append(assistant_msg)
 
         return history
 

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -1,6 +1,9 @@
+import json
 import logging
 from typing import Any, Optional, cast
 
+from aidial_client.types.chat.request_param import AssistantMessageParam, UserMessageParam
+from aidial_sdk.chat_completion import Message, Role
 from injector import AssistedBuilder
 
 from quickapp.common import CompletionResult, StagedBaseTool
@@ -8,6 +11,7 @@ from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import to_plain_dict
 from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
+from quickapp.dial_deployment_tooling.constants import CONTENT_PARAM
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
 
 from .deployment_stage_wrapper import DeploymentStageWrapper
@@ -24,6 +28,7 @@ class BaseDeploymentTool(StagedBaseTool):
         tool_config: DialDeploymentTool,
         content_propagation: Optional[ContentPropagation],
         dial_completion_service: DialCompletionService,
+        messages: list[Message],
         perf_timer: PerformanceTimer,
         stage_wrapper_builder: AssistedBuilder[DeploymentStageWrapper],
         **kwargs: Any,
@@ -38,6 +43,7 @@ class BaseDeploymentTool(StagedBaseTool):
         self.__application_name: str = application_name
         self.__dial_completion_service: DialCompletionService = dial_completion_service
         self.__content_propagation: Optional[ContentPropagation] = content_propagation
+        self.__messages: list[Message] = messages
 
     async def _run_in_stage_async(
         self,
@@ -45,14 +51,60 @@ class BaseDeploymentTool(StagedBaseTool):
         attachment_urls: Optional[list[str]] = None,
         **kwargs,
     ) -> CompletionResult:
+        tool_config = cast(DialDeploymentTool, self.tool_config)
+        history = None
+        if self.__content_propagation and self.__content_propagation.propagate_history:
+            history = self._extract_tool_history(
+                self.__messages, tool_config.open_ai_tool.function.name
+            )
         return await self.__dial_completion_service.complete_request_async(
             kwargs,
             self.__application_id,
             self.__application_name,
-            self.__content_propagation,
             stage_wrapper,
             attachment_urls,
+            history=history,
         )
+
+    @staticmethod
+    def _extract_tool_history(
+        messages: list[Message],
+        tool_name: str,
+    ) -> list[UserMessageParam | AssistantMessageParam]:
+        if not tool_name:
+            return []
+
+        # Build map: tool_call_id -> TOOL message content
+        tool_result_by_id: dict[str, str] = {}
+        for msg in messages:
+            if msg.role == Role.TOOL and msg.tool_call_id and msg.content:
+                tool_result_by_id[msg.tool_call_id] = (
+                    msg.content if isinstance(msg.content, str) else str(msg.content)
+                )
+
+        # Walk ASSISTANT messages, find tool_calls matching tool_name
+        history: list[UserMessageParam | AssistantMessageParam] = []
+        for msg in messages:
+            if msg.role != Role.ASSISTANT or not msg.tool_calls:
+                continue
+            for tc in msg.tool_calls:
+                if tc.function.name != tool_name:
+                    continue
+                tool_result = tool_result_by_id.get(tc.id)
+                if tool_result is None:
+                    # Current call — its TOOL result hasn't been appended yet
+                    continue
+                try:
+                    args = json.loads(tc.function.arguments)
+                    query = args.get(CONTENT_PARAM, "")
+                except (json.JSONDecodeError, AttributeError):
+                    query = ""
+                if query:
+                    history.append(UserMessageParam(role="user", content=query))
+                if tool_result:
+                    history.append(AssistantMessageParam(role="assistant", content=tool_result))
+
+        return history
 
     def _pre_process_params(self, **kwargs: Any) -> Any:
 

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -72,20 +72,12 @@ class BaseDeploymentTool(StagedBaseTool):
 
     @staticmethod
     def _sdk_attachment_to_param(attachment: SdkAttachment) -> AttachmentParam:
-        param = AttachmentParam()
-        if attachment.type is not None:
-            param["type"] = attachment.type
-        if attachment.title is not None:
-            param["title"] = attachment.title
-        if attachment.data is not None:
-            param["data"] = attachment.data
-        if attachment.url is not None:
-            param["url"] = attachment.url
-        if attachment.reference_url is not None:
-            param["reference_url"] = attachment.reference_url
-        if attachment.reference_type is not None:
-            param["reference_type"] = attachment.reference_type
-        return param
+        return AttachmentParam(
+            **attachment.model_dump(
+                include=set(AttachmentParam.__annotations__),
+                exclude_none=True,
+            )
+        )
 
     async def _extract_tool_history(
         self,
@@ -94,23 +86,23 @@ class BaseDeploymentTool(StagedBaseTool):
         if not tool_name:
             return []
 
-        messages = self.__messages
-
         # Build map: tool_call_id -> (content, custom_content)
         tool_result_by_id: dict[str, tuple[str, Any]] = {}
-        for msg in messages:
+        for msg in self.__messages:
             if msg.role == Role.TOOL and msg.tool_call_id and msg.content:
-                content = msg.content if isinstance(msg.content, str) else str(msg.content)
+                content = str(msg.content) if not isinstance(msg.content, str) else msg.content
                 tool_result_by_id[msg.tool_call_id] = (content, msg.custom_content)
 
-        # Walk ASSISTANT messages, find tool_calls matching tool_name
+        # Walk ASSISTANT messages, find completed tool_calls matching tool_name
         history: list[UserMessageParam | AssistantMessageParam] = []
-        for msg in messages:
+        for msg in self.__messages:
             if msg.role != Role.ASSISTANT or not msg.tool_calls:
                 continue
+
             for tc in msg.tool_calls:
                 if tc.function.name != tool_name:
                     continue
+
                 result_entry = tool_result_by_id.get(tc.id)
                 if result_entry is None:
                     # Current call — its TOOL result hasn't been appended yet
@@ -118,44 +110,52 @@ class BaseDeploymentTool(StagedBaseTool):
 
                 tool_content, tool_custom_content = result_entry
 
-                # --- Request side: build UserMessageParam ---
-                try:
-                    args = json.loads(tc.function.arguments)
-                    query = args.get(CONTENT_PARAM, "")
-                    attachment_urls: list[str] | None = args.get(ATTACHMENT_PARAM)
-                except (json.JSONDecodeError, AttributeError):
-                    query = ""
-                    attachment_urls = None
-
-                if query or attachment_urls:
-                    user_msg = UserMessageParam(role="user", content=query or "")
-                    if attachment_urls:
-                        resolved = await self.__dial_completion_service.resolve_attachment_urls(
-                            attachment_urls
-                        )
-                        if resolved:
-                            user_msg["custom_content"] = CustomContentParam(attachments=resolved)
+                user_msg = await self._build_user_message_from_tool_call(tc.function.arguments)
+                if user_msg is not None:
                     history.append(user_msg)
 
-                # --- Response side: build AssistantMessageParam ---
                 if tool_content:
-                    assistant_msg = AssistantMessageParam(role="assistant", content=tool_content)
-
-                    if tool_custom_content:
-                        cc_param = CustomContentParam()
-                        if tool_custom_content.attachments:
-                            cc_param["attachments"] = [
-                                self._sdk_attachment_to_param(a)
-                                for a in tool_custom_content.attachments
-                            ]
-                        if tool_custom_content.state is not None:
-                            cc_param["state"] = tool_custom_content.state
-                        if cc_param:
-                            assistant_msg["custom_content"] = cc_param
-
+                    assistant_msg = self._build_assistant_message(tool_content, tool_custom_content)
                     history.append(assistant_msg)
 
         return history
+
+    async def _build_user_message_from_tool_call(
+        self, raw_arguments: str
+    ) -> UserMessageParam | None:
+        try:
+            args = json.loads(raw_arguments)
+            query: str = args.get(CONTENT_PARAM, "")
+            attachment_urls: list[str] | None = args.get(ATTACHMENT_PARAM)
+        except (json.JSONDecodeError, AttributeError):
+            return None
+
+        if not query and not attachment_urls:
+            return None
+
+        user_msg = UserMessageParam(role="user", content=query or "")
+        if attachment_urls:
+            resolved = await self.__dial_completion_service.resolve_attachment_urls(attachment_urls)
+            if resolved:
+                user_msg["custom_content"] = CustomContentParam(attachments=resolved)
+        return user_msg
+
+    @classmethod
+    def _build_assistant_message(cls, content: str, custom_content: Any) -> AssistantMessageParam:
+        assistant_msg = AssistantMessageParam(role="assistant", content=content)
+
+        if custom_content:
+            cc_param = CustomContentParam()
+            if custom_content.attachments:
+                cc_param["attachments"] = [
+                    cls._sdk_attachment_to_param(a) for a in custom_content.attachments
+                ]
+            if custom_content.state is not None:
+                cc_param["state"] = custom_content.state
+            if cc_param:
+                assistant_msg["custom_content"] = cc_param
+
+        return assistant_msg
 
     def _pre_process_params(self, **kwargs: Any) -> Any:
 

--- a/src/quickapp/dial_deployment_tooling/deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/deployment_tool.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from aidial_sdk.chat_completion import Message
 from injector import AssistedBuilder, inject
 from pydantic import BaseModel, Field
 
@@ -26,6 +27,7 @@ class DeploymentTool(BaseDeploymentTool):
         tool_config: DialDeploymentTool,
         content_propagation: Optional[ContentPropagation],
         dial_completion_service: DialCompletionService,
+        messages: list[Message],
         stage_wrapper_builder: AssistedBuilder[DeploymentStageWrapper],
         perf_timer: PerformanceTimer,
     ):
@@ -34,6 +36,7 @@ class DeploymentTool(BaseDeploymentTool):
             application_name=application_name,
             content_propagation=content_propagation,
             dial_completion_service=dial_completion_service,
+            messages=messages,
             tool_config=tool_config,
             stage_wrapper_builder=stage_wrapper_builder,
             description=description,

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Dict, Iterable, List, Tuple
 
 from aidial_client import AsyncDial
 from aidial_client.resources import AsyncMetadata
@@ -33,7 +33,7 @@ class _StreamResult:
     content: str = ""
     attachments: list[Any] = field(default_factory=list)
     state: Any = None
-    usage: Optional[CompletionUsage] = None
+    usage: CompletionUsage | None = None
     statistics: dict[str, Any] = field(default_factory=dict)
 
 
@@ -44,7 +44,7 @@ class DialCompletionService:
         self.__dial_client: AsyncDial = dial_client
 
     @staticmethod
-    def _prepare_custom_fields(items: Iterable[Tuple[str, Any]]) -> Optional[Dict[str, Any]]:
+    def _prepare_custom_fields(items: Iterable[Tuple[str, Any]]) -> Dict[str, Any] | None:
         # kept for backward compatibility in rare cases
         normalized: dict[str, Any] = {}
         for k, v in items:
@@ -63,9 +63,9 @@ class DialCompletionService:
         params: Dict[str, Any],
         deployment_id: str,
         deployment_name: str,
-        stage_wrapper: Optional[BaseStageWrapper],
-        relative_attachment_urls: Optional[list[str]] = None,
-        history: Optional[list[UserMessageParam | AssistantMessageParam]] = None,
+        stage_wrapper: BaseStageWrapper | None,
+        relative_attachment_urls: list[str] | None = None,
+        history: list[UserMessageParam | AssistantMessageParam] | None = None,
     ) -> CompletionResult:
         # Expect params to be pre-processed by BaseDeploymentTool._pre_process_params
         content = params.get(CONTENT_PARAM, "")
@@ -138,7 +138,7 @@ class DialCompletionService:
     async def _consume_stream(
         self,
         chunks: Any,
-        stage_wrapper: Optional[BaseStageWrapper],
+        stage_wrapper: BaseStageWrapper | None,
     ) -> _StreamResult:
         result = _StreamResult()
         content_parts: list[str] = []
@@ -178,11 +178,11 @@ class DialCompletionService:
 
     @staticmethod
     def __get_deployment_usage(
-        usage: Optional[CompletionUsage],
-        statistics: Optional[dict],
+        usage: CompletionUsage | None,
+        statistics: dict | None,
         deployment_id: str,
         deployment_name: str,
-    ) -> Optional[List[DeploymentUsage]]:
+    ) -> List[DeploymentUsage] | None:
         if statistics:
             result = []
             for model_usage in statistics:
@@ -212,8 +212,8 @@ class DialCompletionService:
     async def __build_request_messages(
         self,
         content: str,
-        relative_attachment_urls: Optional[list[str]] = None,
-        history: Optional[list[UserMessageParam | AssistantMessageParam]] = None,
+        relative_attachment_urls: list[str] | None = None,
+        history: list[UserMessageParam | AssistantMessageParam] | None = None,
     ) -> list[UserMessageParam | AssistantMessageParam]:
         messages: list[UserMessageParam | AssistantMessageParam] = []
         if history:
@@ -226,20 +226,20 @@ class DialCompletionService:
         return messages
 
     async def __user_message_from_content_and_attachments(
-        self, content, relative_attachment_urls: Optional[list[str]] = None
+        self, content, relative_attachment_urls: list[str] | None = None
     ) -> UserMessageParam:
         message = UserMessageParam(role="user", content=content)
-        attachments = await self.__attachment_params_from_urls(relative_attachment_urls)
+        attachments = await self.resolve_attachment_urls(relative_attachment_urls)
         if attachments and len(attachments) > 0:
             message[CUSTOM_CONTENT] = CustomContentParam(attachments=attachments)
         return message
 
-    async def __attachment_params_from_urls(
-        self, relative_attachment_urls: Optional[list[str]]
+    async def resolve_attachment_urls(
+        self, relative_attachment_urls: list[str] | None
     ) -> list[AttachmentParam]:
-        return [await self.__attachment_param(url) for url in (relative_attachment_urls or [])]
+        return [await self._resolve_attachment(url) for url in (relative_attachment_urls or [])]
 
-    async def __attachment_param(self, file_relative_url: str) -> AttachmentParam:
+    async def _resolve_attachment(self, file_relative_url: str) -> AttachmentParam:
         metadata: AsyncMetadata = self.__dial_client.metadata
         fileinfo = await metadata.get("files", file_relative_url)
         return AttachmentParam(

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -1,4 +1,5 @@
 import logging
+from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 from aidial_client import AsyncDial
@@ -9,33 +10,38 @@ from aidial_client.types.chat.request_param import (
     CustomContentParam,
     UserMessageParam,
 )
-from aidial_client.types.chat.response import Attachment, ChatCompletionResponse, CompletionUsage
-from aidial_sdk.chat_completion import CustomContent, Message, Role
+from aidial_client.types.chat.response import Attachment, CompletionUsage
 from injector import inject
 
 from quickapp.common import CompletionResult
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.deployment_usage import DeploymentUsage
 from quickapp.common.utils import to_plain_dict
-from quickapp.config.tools.deployment import ContentPropagation
 from quickapp.dial_deployment_tooling.constants import (
     ATTACHMENT_PARAM,
     CONFIGURATION,
     CONTENT_PARAM,
     CUSTOM_CONTENT,
     EXTRA_BODY,
-    USAGE_PARAM,
 )
 
 logger = logging.getLogger(__name__)
 
 
+@dataclass
+class _StreamResult:
+    content: str = ""
+    attachments: list[Any] = field(default_factory=list)
+    state: Any = None
+    usage: Optional[CompletionUsage] = None
+    statistics: dict[str, Any] = field(default_factory=dict)
+
+
 @inject
 class DialCompletionService:
 
-    def __init__(self, dial_client: AsyncDial, messages: list[Message]):
+    def __init__(self, dial_client: AsyncDial):
         self.__dial_client: AsyncDial = dial_client
-        self.__history: list[Message] = messages[:-1] if messages and len(messages) > 0 else []
 
     @staticmethod
     def _prepare_custom_fields(items: Iterable[Tuple[str, Any]]) -> Optional[Dict[str, Any]]:
@@ -57,20 +63,39 @@ class DialCompletionService:
         params: Dict[str, Any],
         deployment_id: str,
         deployment_name: str,
-        content_propagation: Optional[ContentPropagation],
         stage_wrapper: Optional[BaseStageWrapper],
         relative_attachment_urls: Optional[list[str]] = None,
+        history: Optional[list[UserMessageParam | AssistantMessageParam]] = None,
     ) -> CompletionResult:
         # Expect params to be pre-processed by BaseDeploymentTool._pre_process_params
         content = params.get(CONTENT_PARAM, "")
         if not content:
             logger.warning(
-                "Tool call content is empty. Check the tool configuration, it should use `query` parameter"
+                "Tool call content is empty. Check the tool configuration,"
+                " it should use `query` parameter"
             )
-        messages = await self.__build_request_messages(
-            content, content_propagation, relative_attachment_urls
+
+        messages = await self.__build_request_messages(content, relative_attachment_urls, history)
+        chat_params = self._build_chat_completion_params(params, deployment_id, messages)
+        chunks = await self.__dial_client.chat.completions.create(**chat_params)
+        result = await self._consume_stream(chunks, stage_wrapper)
+
+        return CompletionResult(
+            content=result.content,
+            content_type="text/markdown",
+            attachments=result.attachments,
+            state=result.state,
+            usage=self.__get_deployment_usage(
+                result.usage, result.statistics, deployment_id, deployment_name
+            ),
         )
 
+    @staticmethod
+    def _build_chat_completion_params(
+        params: Dict[str, Any],
+        deployment_id: str,
+        messages: list[UserMessageParam | AssistantMessageParam],
+    ) -> dict[str, Any]:
         chat_completion_params: dict[str, Any] = {
             "deployment_name": deployment_id,
             "stream": True,
@@ -88,54 +113,68 @@ class DialCompletionService:
         if extra_body:
             chat_completion_params[EXTRA_BODY] = extra_body
 
-        chunks = await self.__dial_client.chat.completions.create(**chat_completion_params)
+        return chat_completion_params
 
-        content_parts = []
-        custom_content: CustomContent = CustomContent(attachments=[])
-        usage: Optional[CompletionUsage] = None
-        statistics: dict[str, Any] = {}
+    @staticmethod
+    def _fix_attachment(attachment: Any) -> None:
+        """Bugfix issue#16: if attachment has no data and no url, use reference_url as url."""
+        if attachment.data is None and attachment.url is None:
+            if attachment.reference_url is None:
+                attachment["data"] = ""
+            else:
+                attachment.url = attachment.reference_url
+
+    @staticmethod
+    def _to_client_attachment(attachment: Any) -> Attachment:
+        return Attachment(
+            type=attachment.type,
+            title=attachment.title,
+            data=attachment.data,
+            url=attachment.url,
+            reference_url=attachment.reference_url,
+            reference_type=attachment.reference_type,
+        )
+
+    async def _consume_stream(
+        self,
+        chunks: Any,
+        stage_wrapper: Optional[BaseStageWrapper],
+    ) -> _StreamResult:
+        result = _StreamResult()
+        content_parts: list[str] = []
 
         if stage_wrapper:
             stage_wrapper.append_stage_content("> #### Response:\n")
-        async for chunk in chunks:
-            if chunk.choices and len(chunk.choices) > 0:
-                delta = chunk.choices[0].delta
-                if delta:
-                    if delta.content:
-                        if stage_wrapper:
-                            stage_wrapper.append_stage_content(delta.content)
-                        content_parts.append(delta.content)
-                    if delta.custom_content and delta.custom_content.attachments:
-                        attachments = delta.custom_content.attachments
-                        custom_content.attachments.extend(attachments)
-                        if stage_wrapper:
-                            for attachment in attachments:
-                                # bugfix issue#16 - if attachment has no data and no url, but has reference_url, use it as url
-                                if attachment.data is None and attachment.url is None:
-                                    if attachment.reference_url is None:
-                                        attachment['data'] = ''
-                                    else:
-                                        attachment.url = attachment.reference_url
-                                stage_wrapper.add_stage_attachment(
-                                    Attachment(
-                                        type=attachment.type,
-                                        title=attachment.title,
-                                        data=attachment.data,
-                                        url=attachment.url,
-                                        reference_url=attachment.reference_url,
-                                        reference_type=attachment.reference_type,
-                                    )
-                                )
-                if chunk.usage:
-                    usage = chunk.usage
-                statistics = chunk.model_extra.get("statistics", {}).get("usage_per_model", {})
 
-        return CompletionResult(
-            content="".join(content_parts),
-            content_type="text/markdown",
-            attachments=custom_content.attachments,
-            usage=self.__get_deployment_usage(usage, statistics, deployment_id, deployment_name),
-        )
+        async for chunk in chunks:
+            if not chunk.choices:
+                continue
+
+            delta = chunk.choices[0].delta
+            if delta:
+                if delta.content:
+                    if stage_wrapper:
+                        stage_wrapper.append_stage_content(delta.content)
+                    content_parts.append(delta.content)
+
+                if delta.custom_content and delta.custom_content.attachments:
+                    attachments = delta.custom_content.attachments
+                    result.attachments.extend(attachments)
+                    if stage_wrapper:
+                        for attachment in attachments:
+                            self._fix_attachment(attachment)
+                            stage_wrapper.add_stage_attachment(
+                                self._to_client_attachment(attachment)
+                            )
+                elif delta.custom_content and delta.custom_content.state:
+                    result.state = delta.custom_content.state
+
+            if chunk.usage:
+                result.usage = chunk.usage
+            result.statistics = chunk.model_extra.get("statistics", {}).get("usage_per_model", {})
+
+        result.content = "".join(content_parts)
+        return result
 
     @staticmethod
     def __get_deployment_usage(
@@ -173,38 +212,18 @@ class DialCompletionService:
     async def __build_request_messages(
         self,
         content: str,
-        content_propagation: Optional[ContentPropagation],
         relative_attachment_urls: Optional[list[str]] = None,
+        history: Optional[list[UserMessageParam | AssistantMessageParam]] = None,
     ) -> list[UserMessageParam | AssistantMessageParam]:
         messages: list[UserMessageParam | AssistantMessageParam] = []
-        if content_propagation and content_propagation.propagate_history:
-            messages.extend(self.__build_message_params_from_history())
+        if history:
+            messages.extend(history)
         messages.append(
             await self.__user_message_from_content_and_attachments(
                 content, relative_attachment_urls
             )
         )
         return messages
-
-    def __build_message_params_from_history(
-        self,
-    ) -> list[UserMessageParam | AssistantMessageParam]:
-        return [
-            (
-                UserMessageParam(role="user", content=message.content)
-                if message.role == Role.USER
-                else AssistantMessageParam(role="assistant", content=message.content)
-            )
-            for message in self.__history
-            if message.content
-        ]
-
-    @staticmethod
-    def __get_attachments_from_response(
-        response: ChatCompletionResponse,
-    ) -> Optional[list[Attachment]]:
-        custom_content = response.choices[0].message.custom_content
-        return custom_content.attachments if custom_content and custom_content.attachments else None
 
     async def __user_message_from_content_and_attachments(
         self, content, relative_attachment_urls: Optional[list[str]] = None
@@ -228,13 +247,3 @@ class DialCompletionService:
             title=fileinfo.name,
             url=fileinfo.url,
         )
-
-    def _build_result_message(self, content, attachments, deployment_usage):
-        m = Message(
-            role=Role.TOOL,
-            content=content,
-            custom_content=CustomContent(
-                attachments=attachments, state={USAGE_PARAM: deployment_usage}
-            ),
-        )
-        return m

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -31,10 +31,15 @@ logger = logging.getLogger(__name__)
 @dataclass
 class _StreamResult:
     content: str = ""
-    attachments: list[Any] = field(default_factory=list)
+    attachments: list[Any] | None = None
     state: Any = None
     usage: CompletionUsage | None = None
     statistics: dict[str, Any] = field(default_factory=dict)
+
+    def extend_attachments(self, attachments: list[Any]) -> None:
+        if self.attachments is None:
+            self.attachments = []
+        self.attachments.extend(attachments)
 
 
 @inject
@@ -159,7 +164,7 @@ class DialCompletionService:
 
                 if delta.custom_content and delta.custom_content.attachments:
                     attachments = delta.custom_content.attachments
-                    result.attachments.extend(attachments)
+                    result.extend_attachments(attachments)
                     if stage_wrapper:
                         for attachment in attachments:
                             self._fix_attachment(attachment)

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -1,0 +1,303 @@
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.chat_completion.request import (
+    Attachment as SdkAttachment,
+    CustomContent,
+    FunctionCall,
+    ToolCall,
+)
+from pydantic import StrictStr
+
+from quickapp.dial_deployment_tooling.base_deployment_tool import BaseDeploymentTool
+
+
+def _make_tool_call(
+    tool_call_id: str,
+    name: str,
+    query: str,
+    attachment_urls: list[str] | None = None,
+) -> ToolCall:
+    args: dict[str, Any] = {"query": query}
+    if attachment_urls is not None:
+        args["attachment_urls"] = attachment_urls
+    return ToolCall(
+        id=tool_call_id,
+        type="function",
+        function=FunctionCall(name=name, arguments=json.dumps(args)),
+    )
+
+
+def _make_assistant_with_tool_calls(tool_calls: list[ToolCall]) -> Message:
+    return Message(
+        role=Role.ASSISTANT,
+        content=StrictStr(" "),
+        tool_calls=tool_calls,
+    )
+
+
+def _make_tool_result(
+    tool_call_id: str,
+    content: str,
+    custom_content: CustomContent | None = None,
+) -> Message:
+    return Message(
+        role=Role.TOOL,
+        content=StrictStr(content),
+        tool_call_id=tool_call_id,
+        custom_content=custom_content,
+    )
+
+
+def _build_tool(
+    messages: list[Message],
+    dial_completion_service: Any = None,
+) -> BaseDeploymentTool:
+    """Build a BaseDeploymentTool with minimal mocks for testing _extract_tool_history."""
+    if dial_completion_service is None:
+        dial_completion_service = MagicMock()
+    tool_config = MagicMock()
+    tool_config.display = None
+    tool_config.attachment = MagicMock()
+    tool_config.attachment.supported_types = []
+    tool_config.attachment.propagate_types_to_choice = []
+    tool_config.fallback_configuration = None
+    return BaseDeploymentTool(
+        application_id="test-app",
+        application_name="Test App",
+        tool_config=tool_config,
+        content_propagation=None,
+        dial_completion_service=dial_completion_service,
+        messages=messages,
+        perf_timer=MagicMock(),
+        stage_wrapper_builder=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_extract_single_tool_history():
+    """Single tool with two prior interactions extracts correctly."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Help me")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc1", "my_tool", "First question"),
+        ]),
+        _make_tool_result("tc1", "First answer"),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc2", "my_tool", "Second question"),
+        ]),
+        _make_tool_result("tc2", "Second answer"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert len(history) == 4
+    assert history[0]["role"] == "user"
+    assert history[0]["content"] == "First question"
+    assert history[1]["role"] == "assistant"
+    assert history[1]["content"] == "First answer"
+    assert history[2]["role"] == "user"
+    assert history[2]["content"] == "Second question"
+    assert history[3]["role"] == "assistant"
+    assert history[3]["content"] == "Second answer"
+
+
+@pytest.mark.asyncio
+async def test_extract_filters_by_tool_name():
+    """Only interactions for the target tool are included; other tools are excluded."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Start")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc_a1", "tool_a", "question for A"),
+            _make_tool_call("tc_b1", "tool_b", "question for B"),
+        ]),
+        _make_tool_result("tc_a1", "answer from A"),
+        _make_tool_result("tc_b1", "answer from B"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("tool_a")
+
+    assert len(history) == 2
+    assert history[0]["content"] == "question for A"
+    assert history[1]["content"] == "answer from A"
+
+
+@pytest.mark.asyncio
+async def test_extract_excludes_current_call():
+    """Tool call without a TOOL result yet is excluded (current invocation)."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc1", "my_tool", "old question"),
+        ]),
+        _make_tool_result("tc1", "old answer"),
+        # Current call — no TOOL result appended yet
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc2", "my_tool", "current question"),
+        ]),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    # Only the first completed interaction
+    assert len(history) == 2
+    assert history[0]["content"] == "old question"
+    assert history[1]["content"] == "old answer"
+
+
+@pytest.mark.asyncio
+async def test_extract_live_mutations():
+    """Messages appended after list creation are visible (live reference)."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+    ]
+
+    # Simulate orchestrator appending messages after list creation
+    messages.append(
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc_late", "my_tool", "late question"),
+        ])
+    )
+    messages.append(_make_tool_result("tc_late", "late answer"))
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert len(history) == 2
+    assert history[0]["content"] == "late question"
+    assert history[1]["content"] == "late answer"
+
+
+@pytest.mark.asyncio
+async def test_extract_empty_when_no_matches():
+    """No matching tool calls returns empty list."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc1", "other_tool", "question"),
+        ]),
+        _make_tool_result("tc1", "answer"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert history == []
+
+
+@pytest.mark.asyncio
+async def test_extract_empty_tool_name():
+    """Empty tool name returns empty list."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("")
+
+    assert history == []
+
+
+@pytest.mark.asyncio
+async def test_extract_preserves_response_attachments():
+    """TOOL message with custom_content.attachments → AssistantMessageParam has attachments."""
+    sdk_attachment = SdkAttachment(
+        type="image/png",
+        title="screenshot.png",
+        url="files/abc/screenshot.png",
+        reference_url="https://example.com/screenshot.png",
+        reference_type="storage",
+    )
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc1", "my_tool", "describe image"),
+        ]),
+        _make_tool_result(
+            "tc1",
+            "It shows a chart",
+            custom_content=CustomContent(attachments=[sdk_attachment]),
+        ),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert len(history) == 2
+    assistant_msg = history[1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] == "It shows a chart"
+    cc = assistant_msg["custom_content"]
+    assert len(cc["attachments"]) == 1
+    att = cc["attachments"][0]
+    assert att["type"] == "image/png"
+    assert att["title"] == "screenshot.png"
+    assert att["url"] == "files/abc/screenshot.png"
+    assert att["reference_url"] == "https://example.com/screenshot.png"
+    assert att["reference_type"] == "storage"
+
+
+@pytest.mark.asyncio
+async def test_extract_preserves_response_state():
+    """TOOL message with custom_content.state → AssistantMessageParam has state."""
+    state_data = {"cursor": 42, "mode": "streaming"}
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call("tc1", "my_tool", "continue"),
+        ]),
+        _make_tool_result(
+            "tc1",
+            "partial result",
+            custom_content=CustomContent(state=state_data),
+        ),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert len(history) == 2
+    assistant_msg = history[1]
+    cc = assistant_msg["custom_content"]
+    assert cc["state"] == {"cursor": 42, "mode": "streaming"}
+
+
+@pytest.mark.asyncio
+async def test_extract_resolves_request_attachments():
+    """Tool call args with attachment_urls → UserMessageParam has resolved attachments."""
+    mock_service = MagicMock()
+    mock_service.resolve_attachment_urls = AsyncMock(
+        return_value=[
+            {"type": "application/pdf", "title": "doc.pdf", "url": "files/xyz/doc.pdf"},
+        ]
+    )
+
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+        _make_assistant_with_tool_calls([
+            _make_tool_call(
+                "tc1", "my_tool", "summarize this", attachment_urls=["files/xyz/doc.pdf"]
+            ),
+        ]),
+        _make_tool_result("tc1", "Summary of the doc"),
+    ]
+
+    tool = _build_tool(messages, dial_completion_service=mock_service)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert len(history) == 2
+    user_msg = history[0]
+    assert user_msg["role"] == "user"
+    assert user_msg["content"] == "summarize this"
+    cc = user_msg["custom_content"]
+    assert len(cc["attachments"]) == 1
+    assert cc["attachments"][0]["type"] == "application/pdf"
+    assert cc["attachments"][0]["title"] == "doc.pdf"
+
+    mock_service.resolve_attachment_urls.assert_awaited_once_with(["files/xyz/doc.pdf"])

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
@@ -1,9 +1,10 @@
 import pytest
+from aidial_client.types.chat.request_param import (
+    AssistantMessageParam,
+    UserMessageParam,
+)
 from unittest.mock import AsyncMock, MagicMock, call
-from aidial_sdk.chat_completion import Message, Role
-from pydantic import StrictStr
 
-from quickapp.config.tools.deployment import ContentPropagation
 from quickapp.dial_deployment_tooling.constants import EXTRA_BODY
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
 
@@ -27,17 +28,8 @@ def dial_client():
 
 
 @pytest.fixture
-def history_messages():
-    return [
-        Message(role=Role.USER, content=StrictStr("First message")),
-        Message(role=Role.ASSISTANT, content=StrictStr("First response")),
-        Message(role=Role.USER, content=StrictStr("Current message"))
-    ]
-
-
-@pytest.fixture
-def completion_service(dial_client, history_messages):
-    return DialCompletionService(dial_client, history_messages)
+def completion_service(dial_client):
+    return DialCompletionService(dial_client)
 
 
 @pytest.fixture
@@ -50,52 +42,81 @@ def mock_stage_wrapper():
 
 @pytest.mark.asyncio
 async def test_history_propagation_enabled(completion_service, dial_client, mock_stage_wrapper):
-    # Act
+    # Act — pass pre-built history directly
+    history = [
+        UserMessageParam(role="user", content="First question"),
+        AssistantMessageParam(role="assistant", content="First answer"),
+        UserMessageParam(role="user", content="Second question"),
+        AssistantMessageParam(role="assistant", content="Second answer"),
+    ]
     await completion_service.complete_request_async(
         params={"query": "Test query"},
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=ContentPropagation(propagate_history=True),
-        stage_wrapper=mock_stage_wrapper
+        stage_wrapper=mock_stage_wrapper,
+        history=history,
     )
 
-    # Assert
+    # Assert — 4 history messages + current query
     call_args = dial_client.chat.completions.create.call_args[1]
-    assert len(call_args["messages"]) == 3
-    assert call_args["messages"][0]["content"] == "First message"
-    assert call_args["messages"][1]["content"] == "First response"
-    assert call_args["messages"][2]["content"] == "Test query"
+    assert len(call_args["messages"]) == 5
+    assert call_args["messages"][0]["content"] == "First question"
+    assert call_args["messages"][0]["role"] == "user"
+    assert call_args["messages"][1]["content"] == "First answer"
+    assert call_args["messages"][1]["role"] == "assistant"
+    assert call_args["messages"][2]["content"] == "Second question"
+    assert call_args["messages"][2]["role"] == "user"
+    assert call_args["messages"][3]["content"] == "Second answer"
+    assert call_args["messages"][3]["role"] == "assistant"
+    assert call_args["messages"][4]["content"] == "Test query"
+    assert call_args["messages"][4]["role"] == "user"
 
 
 @pytest.mark.asyncio
-async def test_history_propagation_disabled(completion_service, dial_client, mock_stage_wrapper):
-    # Act
+async def test_no_history(completion_service, dial_client, mock_stage_wrapper):
+    # Act — no history passed
     await completion_service.complete_request_async(
         params={"query": "Test query"},
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=ContentPropagation(propagate_history=False),
-        stage_wrapper=mock_stage_wrapper
+        stage_wrapper=mock_stage_wrapper,
     )
 
-    # Assert
+    # Assert — only current query
     call_args = dial_client.chat.completions.create.call_args[1]
     assert len(call_args["messages"]) == 1
     assert call_args["messages"][0]["content"] == "Test query"
 
 
 @pytest.mark.asyncio
-async def test_content_propagation_none(completion_service, dial_client, mock_stage_wrapper):
-    # Act
+async def test_empty_history(completion_service, dial_client, mock_stage_wrapper):
+    # Act — empty history list
     await completion_service.complete_request_async(
         params={"query": "Test query"},
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=None,
-        stage_wrapper=mock_stage_wrapper
+        stage_wrapper=mock_stage_wrapper,
+        history=[],
     )
 
-    # Assert
+    # Assert — only current query
+    call_args = dial_client.chat.completions.create.call_args[1]
+    assert len(call_args["messages"]) == 1
+    assert call_args["messages"][0]["content"] == "Test query"
+
+
+@pytest.mark.asyncio
+async def test_history_none_explicitly(completion_service, dial_client, mock_stage_wrapper):
+    # Act — explicitly pass None
+    await completion_service.complete_request_async(
+        params={"query": "Test query"},
+        deployment_id="test-deployment",
+        deployment_name="Test Deployment",
+        stage_wrapper=mock_stage_wrapper,
+        history=None,
+    )
+
+    # Assert — only current query
     call_args = dial_client.chat.completions.create.call_args[1]
     assert len(call_args["messages"]) == 1
     assert call_args["messages"][0]["content"] == "Test query"
@@ -107,8 +128,7 @@ async def test_stage_wrapper_none(completion_service, dial_client):
         params={"query": "Test query"},
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=None,
-        stage_wrapper=None
+        stage_wrapper=None,
     )
 
     # Assert
@@ -123,8 +143,7 @@ async def test_stage_wrapper_content_streaming(completion_service, dial_client, 
         params={"query": "Test query"},
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=None,
-        stage_wrapper=mock_stage_wrapper
+        stage_wrapper=mock_stage_wrapper,
     )
 
     # Assert - Check that both calls were made: first the header, then the content
@@ -150,7 +169,6 @@ async def test_extra_params_go_to_extra_body_not_top_level(
         },
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=None,
         stage_wrapper=mock_stage_wrapper,
     )
 
@@ -181,7 +199,6 @@ async def test_extra_body_from_params_merged_with_other_params(
         },
         deployment_id="test-deployment",
         deployment_name="Test Deployment",
-        content_propagation=None,
         stage_wrapper=mock_stage_wrapper,
     )
 

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
@@ -1,6 +1,8 @@
 import pytest
 from aidial_client.types.chat.request_param import (
     AssistantMessageParam,
+    AttachmentParam,
+    CustomContentParam,
     UserMessageParam,
 )
 from unittest.mock import AsyncMock, MagicMock, call
@@ -207,3 +209,58 @@ async def test_extra_body_from_params_merged_with_other_params(
     assert extra_body["custom_fields"] == {"key": "from_deployment"}
     assert extra_body["temperature"] == 0.5
     assert "query" not in extra_body
+
+
+@pytest.mark.asyncio
+async def test_history_with_custom_content_passed_through(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """History entries with custom_content appear unchanged in messages sent to the API."""
+    history = [
+        UserMessageParam(
+            role="user",
+            content="Describe the image",
+            custom_content=CustomContentParam(
+                attachments=[
+                    AttachmentParam(type="image/png", title="img.png", url="files/abc/img.png")
+                ]
+            ),
+        ),
+        AssistantMessageParam(
+            role="assistant",
+            content="It shows a chart",
+            custom_content=CustomContentParam(
+                attachments=[
+                    AttachmentParam(type="image/png", title="annotated.png", url="files/out.png")
+                ],
+                state={"cursor": 10},
+            ),
+        ),
+    ]
+    await completion_service.complete_request_async(
+        params={"query": "Follow up question"},
+        deployment_id="test-deployment",
+        deployment_name="Test Deployment",
+        stage_wrapper=mock_stage_wrapper,
+        history=history,
+    )
+
+    call_args = dial_client.chat.completions.create.call_args[1]
+    msgs = call_args["messages"]
+    assert len(msgs) == 3
+
+    # User history message preserves custom_content
+    user_msg = msgs[0]
+    assert user_msg["content"] == "Describe the image"
+    assert user_msg["custom_content"]["attachments"][0]["type"] == "image/png"
+    assert user_msg["custom_content"]["attachments"][0]["url"] == "files/abc/img.png"
+
+    # Assistant history message preserves custom_content
+    assistant_msg = msgs[1]
+    assert assistant_msg["content"] == "It shows a chart"
+    assert assistant_msg["custom_content"]["attachments"][0]["title"] == "annotated.png"
+    assert assistant_msg["custom_content"]["state"] == {"cursor": 10}
+
+    # Current query is the last message
+    assert msgs[2]["content"] == "Follow up question"
+    assert msgs[2]["role"] == "user"


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #85 

### Description of changes

This PR refactors how deployment tools handle conversation history propagation, adds support for forwarding agent state from sub-deployment responses, and enriches propagated history with attachments and state.

**Key changes:**

1. **Tool-scoped history extraction** (`base_deployment_tool.py`):
   History propagation logic has been moved out of `DialCompletionService` and into `BaseDeploymentTool._extract_tool_history()`. Instead of forwarding the entire user/assistant message history, the new approach walks the orchestrator message list and extracts only the prior invocations of the *same* tool (matched by `tool_name`). Each past tool call's `query` argument becomes a `user` message and its result becomes an `assistant` message, producing a focused, tool-specific conversation history.

2. **Attachment and state propagation in history** (`base_deployment_tool.py`, `dial_completion_service.py`):
   `_extract_tool_history` now preserves structured data that was previously dropped:
   - **Request side**: `attachment_urls` from tool call arguments are resolved via `DialCompletionService.resolve_attachment_urls()` and included as `custom_content.attachments` on the reconstructed `UserMessageParam`.
   - **Response side**: `custom_content.attachments` and `custom_content.state` from TOOL result messages are carried over to the reconstructed `AssistantMessageParam` (SDK `Attachment` objects are converted to client `AttachmentParam` dicts via `_sdk_attachment_to_param()`).
   - The method is now an async instance method (instead of static) to access the completion service for attachment URL resolution.

3. **State propagation from sub-deployments** (`completion_result.py`, `dial_completion_service.py`):
   `CompletionResult` now carries an optional `state` field. During stream consumption, if the sub-deployment returns `custom_content.state`, it is captured and propagated back through the `CompletionResult` into the tool message's `CustomContent.state`. This allows downstream consumers (e.g. the chat UI) to receive state information from agent sub-deployments.

4. **`DialCompletionService` simplification** (`dial_completion_service.py`):
   - The service no longer receives or stores the full `messages` list; history is now passed in as a pre-built parameter.
   - Stream consumption logic has been extracted into `_consume_stream()` with a dedicated `_StreamResult` dataclass.
   - Chat completion parameter building has been extracted into `_build_chat_completion_params()`.
   - Attachment fix-up logic has been extracted into `_fix_attachment()` and `_to_client_attachment()` static methods.
   - Unused methods (`_build_result_message`, `__get_attachments_from_response`, `__build_message_params_from_history`) have been removed.
   - `__attachment_params_from_urls` / `__attachment_param` renamed to `resolve_attachment_urls` / `_resolve_attachment` (public API for reuse by `BaseDeploymentTool`).

5. **Tests**:
   - `test_completion_service.py`: Tests rewritten to reflect the new API. New test cases cover empty/`None` history scenarios and `custom_content` passthrough verification.
   - `test_base_deployment_tool.py` (new): Unit tests for `_extract_tool_history` covering single/multi-tool history, filtering by tool name, current-call exclusion, live mutations, and the new attachment/state preservation paths.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.