### PR TITLE
feat: add schema endpoint to quickapps #70

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,8 +56,7 @@ generate_dial_config: install_dev
 	$(POETRY) run python src/scripts/generate_dial_config.py --models \
 	--template docker_compose_files/core/configuration/models-template.json \
 	--config docker_compose_files/core/configuration/generated/models.json \
-	--applications dial-rag,dial-web-rag \
-    --schemas docker_compose_files/core/configuration/generated/application-schemas.json
+	--applications dial-rag,dial-web-rag
 
 start_test_server:
 	echo "Starting MCP + REST servers..."

--- a/README.md
+++ b/README.md
@@ -153,8 +153,7 @@ How to add instructions
     ```
 
    This command will generate two files in `docker_compose_files/core/configuration/generated/`:
-    - `models.json` - contains the models configuration for DIAL.
-    - `application-schemas.json` - contains the QuickApps schema.
+    - `models.json` - contains the models configuration for DIAL.    
 
 ### Run
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       'aidial.config.files': |-
         [
           "/opt/configuration/generated/models.json",
-          "/opt/configuration/generated/application-schemas.json",
+          "/opt/configuration/application-schemas.json",
           "/opt/configuration/applications.json",
           "/opt/configuration/chathub/anthropic.json",
           "/opt/configuration/chathub/gemini.json",
@@ -60,11 +60,11 @@ services:
       DIAL_URL: "http://core:8080"
       LOG_LEVEL: "INFO"
 
-  quick_apps:
-    build:
-        context: .
-        dockerfile: ./docker/Dockerfile
-    environment:
-      DIAL_URL: "http://core:8080"
-      SHOW_USAGE_STATISTICS: "true"
-      QUICKAPP_LOG_LEVEL: "DEBUG"
+#  quick_apps:
+#    build:
+#        context: .
+#        dockerfile: ./docker/Dockerfile
+#    environment:
+#      DIAL_URL: "http://core:8080"
+#      SHOW_USAGE_STATISTICS: "true"
+#      QUICKAPP_LOG_LEVEL: "DEBUG"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,11 +60,11 @@ services:
       DIAL_URL: "http://core:8080"
       LOG_LEVEL: "INFO"
 
-#  quick_apps:
-#    build:
-#        context: .
-#        dockerfile: ./docker/Dockerfile
-#    environment:
-#      DIAL_URL: "http://core:8080"
-#      SHOW_USAGE_STATISTICS: "true"
-#      QUICKAPP_LOG_LEVEL: "DEBUG"
+  quick_apps:
+    build:
+        context: .
+        dockerfile: ./docker/Dockerfile
+    environment:
+      DIAL_URL: "http://core:8080"
+      SHOW_USAGE_STATISTICS: "true"
+      QUICKAPP_LOG_LEVEL: "DEBUG"

--- a/docker_compose_files/core/configuration/application-schemas.json
+++ b/docker_compose_files/core/configuration/application-schemas.json
@@ -1,0 +1,13 @@
+{
+  "applicationTypeSchemas": [
+    {
+      "dial:applicationTypeCompletionEndpoint": "http://host.docker.internal:5000/openai/deployments/quick_apps2/chat/completions",
+      "dial:applicationTypeConfigurationEndpoint": "http://host.docker.internal:5000/openai/deployments/quick_apps2/configuration",
+      "dial:applicationTypeSchemaEndpoint": "http://host.docker.internal:5000/v1/configuration-support/application-schema",
+      "$id": "https://mydial.epam.com/custom_application_schemas/quickapps2",
+      "$schema": "https://dial.epam.com/application_type_schemas/schema#",
+      "dial:applicationTypeDisplayName": "Quick App 2.0",
+      "dial:appendApplicationPropertiesHeader": false
+    }
+  ]
+}

--- a/docker_compose_files/core/configuration/applications.json
+++ b/docker_compose_files/core/configuration/applications.json
@@ -1,21 +1,5 @@
 {
   "applications": {
-    "dial-rag": {
-      "name": "dial-rag",
-      "endpoint": "http://dial-rag:5000/openai/deployments/dial-rag/chat/completions",
-      "display_name": "DialRag App ",
-      "description": "Application that can read files",
-      "forward_auth_token": false,
-      "input_attachment_types": [
-        "*/*"
-      ],
-      "max_input_attachments": 3,
-      "defaults": {},
-      "interceptors": [],
-      "description_keywords": [],
-      "max_retry_attempts": 1,
-      "application_properties": {}
-    },
     "quick_app_2": {
       "displayName": "Quick App 2",
       "description": "The sample of Quick App v2",

--- a/docker_compose_files/core/configuration/routes.json
+++ b/docker_compose_files/core/configuration/routes.json
@@ -6,7 +6,7 @@
       "methods": ["GET", "POST", "HEAD"],
       "upstreams": [
         {
-          "endpoint": "http://docker.host.internal:5000/quickapps/v1"
+          "endpoint": "http://docker.host.internal:5000/v1"
         }
       ]
     }

--- a/docker_compose_files/core/configuration/routes.json
+++ b/docker_compose_files/core/configuration/routes.json
@@ -6,7 +6,7 @@
       "methods": ["GET", "POST", "HEAD"],
       "upstreams": [
         {
-          "endpoint": "http://dial-web-scrapper.dial-web-scrapper.svc.cluster.local"
+          "endpoint": "http://docker.host.internal:5000/quickapps/v1"
         }
       ]
     }

--- a/src/quickapp/common/base_config.py
+++ b/src/quickapp/common/base_config.py
@@ -221,7 +221,7 @@ class BaseApplicationTypeConfig(BaseModel):
 
     # Overrides schema generation to include "dial:meta" for root properties and flatten them (no $defs usage).
     @classmethod
-    def model_json_schema(cls, *args, **kwargs):
+    def model_json_schema(cls, include_dial_fields=True, *args, **kwargs):
         schema = super().model_json_schema(*args, **kwargs)
         schema = _flatten_root_properties(schema)
 
@@ -243,12 +243,13 @@ class BaseApplicationTypeConfig(BaseModel):
             }
 
         # Add DIAL-specific root properties
-        schema["$id"] = f"{_DIAL_ID_PREFIX}{cls._dial_schema_id}"
-        schema["$schema"] = _DIAL_SCHEMA_URL
-        schema["dial:applicationTypeDisplayName"] = cls._dial_application_type_display_name
-        schema["dial:appendApplicationPropertiesHeader"] = (
-            cls._dial_append_application_properties_header
-        )
+        if include_dial_fields:
+            schema["$id"] = f"{_DIAL_ID_PREFIX}{cls._dial_schema_id}"
+            schema["$schema"] = _DIAL_SCHEMA_URL
+            schema["dial:applicationTypeDisplayName"] = cls._dial_application_type_display_name
+            schema["dial:appendApplicationPropertiesHeader"] = (
+                cls._dial_append_application_properties_header
+            )
 
         # order the schema attributes and append all other attributes
         ordered_schema = {

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -22,7 +22,7 @@ class _Controller:
 
     def register_routes(self, app: FastAPI):
         @app.get(CONFIG_SUPPORT_URI + "/application-schema")
-        async def get_system_prompts():
+        async def get_app_schema():
             return ApplicationConfig.model_json_schema(include_dial_fields=False)
 
         @app.get(CONFIG_SUPPORT_URI + "/system-prompts")

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -10,7 +10,7 @@ from quickapp.config.toolsets.predefined import PredefinedToolSet
 from quickapp.config.toolsets.toolset import ToolSet
 from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
 
-CONFIG_SUPPORT_URI = "/quickapps/v1/configuration-support"
+CONFIG_SUPPORT_URI = "/v1/configuration-support"
 
 
 @inject

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -3,6 +3,7 @@ from fastapi import FastAPI, HTTPException, Request, status
 from injector import inject
 from pydantic import TypeAdapter
 
+from quickapp.config.application import ApplicationConfig
 from quickapp.config.config_template_resolver import ConfigResolver, TemplateType
 from quickapp.config.tools.deployment import DialDeploymentTool
 from quickapp.config.toolsets.predefined import PredefinedToolSet
@@ -20,6 +21,10 @@ class _Controller:
         self.__service = service
 
     def register_routes(self, app: FastAPI):
+        @app.get(CONFIG_SUPPORT_URI + "/application-schema")
+        async def get_system_prompts():
+            return ApplicationConfig.model_json_schema(include_dial_fields=False)
+
         @app.get(CONFIG_SUPPORT_URI + "/system-prompts")
         async def get_system_prompts():
             return self.__config_resolver.get_prompts()

--- a/src/quickapp/configuration_support/_initializer.py
+++ b/src/quickapp/configuration_support/_initializer.py
@@ -1,9 +1,13 @@
+import logging
+
 from fastapi import FastAPI
 from injector import inject
 
 from quickapp.common.base_initializer import StartupInitializer
 from quickapp.configuration_support import _Controller
 
+
+logger = logging.getLogger(__name__)
 
 @inject
 class _Initializer(StartupInitializer):
@@ -13,4 +17,5 @@ class _Initializer(StartupInitializer):
         self.controller = controller
 
     async def initialize(self) -> None:
+        logger.debug(f"Initializing Configuration Support API")
         self.controller.register_routes(self.app)

--- a/src/quickapp/configuration_support/_initializer.py
+++ b/src/quickapp/configuration_support/_initializer.py
@@ -6,8 +6,8 @@ from injector import inject
 from quickapp.common.base_initializer import StartupInitializer
 from quickapp.configuration_support import _Controller
 
-
 logger = logging.getLogger(__name__)
+
 
 @inject
 class _Initializer(StartupInitializer):
@@ -17,5 +17,5 @@ class _Initializer(StartupInitializer):
         self.controller = controller
 
     async def initialize(self) -> None:
-        logger.debug(f"Initializing Configuration Support API")
+        logger.debug("Initializing Configuration Support API")
         self.controller.register_routes(self.app)

--- a/src/scripts/generate_dial_config.py
+++ b/src/scripts/generate_dial_config.py
@@ -13,7 +13,6 @@ if __name__ == '__main__':
     add_src_to_system_path()
     load_env()
 
-from dump_app_schema import get_quickapp_schema
 from utils import replace_env
 
 MODEL_TYPE_TO_PATH = {
@@ -215,12 +214,7 @@ def get_config_template(path: str) -> dict:
         return json.load(fin)
 
 
-def generate_config(
-    models: bool,
-    template_path: str,
-    config_path: str,
-    app_ids: set[str]
-):
+def generate_config(models: bool, template_path: str, config_path: str, app_ids: set[str]):
     config_template = get_config_template(template_path)
     replace_envs(config_template["models"])
     if models:

--- a/src/scripts/generate_dial_config.py
+++ b/src/scripts/generate_dial_config.py
@@ -219,8 +219,7 @@ def generate_config(
     models: bool,
     template_path: str,
     config_path: str,
-    app_ids: set[str],
-    schemas_path: str | None,
+    app_ids: set[str]
 ):
     config_template = get_config_template(template_path)
     replace_envs(config_template["models"])
@@ -249,20 +248,6 @@ def generate_config(
         }
     )
     # create subfolders for config if not exists
-    os.makedirs(os.path.dirname(config_path), exist_ok=True)
-    with open(config_path, "w") as fout:
-        json.dump(config_template, fout, indent=2, skipkeys=True)
-    if schemas_path:
-        schema = get_quickapp_schema()
-        schema.update(
-            {
-                "dial:applicationTypeCompletionEndpoint": "http://quick_apps:5000/openai/deployments/quick_apps2/chat/completions",
-                "dial:applicationTypeConfigurationEndpoint": "http://quick_apps:5000/openai/deployments/quick_apps2/configuration",
-            }
-        )
-        schemas = {"applicationTypeSchemas": [schema]}
-        with open(schemas_path, "w") as fout:
-            json.dump(schemas, fout, indent=2, skipkeys=True)
 
 
 if __name__ == "__main__":
@@ -276,7 +261,6 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--template")
     parser.add_argument("-c", "--config")
     parser.add_argument("-a", "--applications", required=False)
-    parser.add_argument("-s", "--schemas", required=False)
     args = parser.parse_args()
     app_ids = set(args.applications.split(",")) if args.applications else set()
-    generate_config(args.models, args.template, args.config, app_ids, args.schemas)
+    generate_config(args.models, args.template, args.config, app_ids)


### PR DESCRIPTION
### Applicable issues

- fixes #70 

### Description of changes

Adds the new GET endpoint /v1/configuration-support/application-schema. 
This will give an option to not store the application schema on the Dial Core. 

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
