### PR TITLE
fix: fixed post pydantic v2 switch issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,9 +26,9 @@ WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
+    PYDANTIC_V2=True \
     PREDEFINED_BASE_PATH="/app/predefined" \
     CHROME_BIN=/home/appuser/.cache/kaleido/chrome
-#ENV PYDANTIC_V2=True
 
 # Copy the sources and virtual env. No poetry.
 RUN adduser -u 1001 --disabled-password --gecos "" appuser

--- a/docker_compose_files/core/configuration/application-schemas.json
+++ b/docker_compose_files/core/configuration/application-schemas.json
@@ -1,13 +1,14 @@
 {
   "applicationTypeSchemas": [
     {
+      "dial:applicationTypeDisplayName": "Quick App 2.0",
+      "dial:appendApplicationPropertiesHeader": false,
+      "dial:applicationTypeAssistantAttachmentsInRequestSupported": true,
       "dial:applicationTypeCompletionEndpoint": "http://host.docker.internal:5000/openai/deployments/quick_apps2/chat/completions",
       "dial:applicationTypeConfigurationEndpoint": "http://host.docker.internal:5000/openai/deployments/quick_apps2/configuration",
       "dial:applicationTypeSchemaEndpoint": "http://host.docker.internal:5000/v1/configuration-support/application-schema",
       "$id": "https://mydial.epam.com/custom_application_schemas/quickapps2",
-      "$schema": "https://dial.epam.com/application_type_schemas/schema#",
-      "dial:applicationTypeDisplayName": "Quick App 2.0",
-      "dial:appendApplicationPropertiesHeader": false
+      "$schema": "https://dial.epam.com/application_type_schemas/schema#"
     }
   ]
 }

--- a/docker_compose_files/core/configuration/applications.json
+++ b/docker_compose_files/core/configuration/applications.json
@@ -66,10 +66,7 @@
       },
       "inputAttachmentTypes": [
         "*/*"
-      ],
-      "features": {
-        "assistant_attachments_in_request_supported": true
-      }
+      ]
     },
     "nested_quick_app": {
       "displayName": "NestedQuickApp",
@@ -78,9 +75,6 @@
       "inputAttachmentTypes": [
         "*/*"
       ],
-      "features": {
-        "assistant_attachments_in_request_supported": true
-      },
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
@@ -119,9 +113,6 @@
       "inputAttachmentTypes": [
         "*/*"
       ],
-      "features": {
-        "assistant_attachments_in_request_supported": true
-      },
       "applicationProperties": {
         "orchestrator": {
           "deployment": {

--- a/poetry.lock
+++ b/poetry.lock
@@ -2433,7 +2433,7 @@ version = "2.4.1"
 description = "Fundamental package for array computing in Python"
 optional = false
 python-versions = ">=3.11"
-groups = ["main", "integration"]
+groups = ["main", "dev", "integration"]
 files = [
     {file = "numpy-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:0cce2a669e3c8ba02ee563c7835f92c153cf02edff1ae05e1823f1dde21b16a5"},
     {file = "numpy-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:899d2c18024984814ac7e83f8f49d8e8180e2fbe1b2e252f2e7f1d06bea92425"},
@@ -3292,6 +3292,21 @@ test = ["hypothesis (>=6.46.1)", "pytest (>=7.3.2)", "pytest-xdist (>=2.2.0)"]
 xml = ["lxml (>=4.9.2)"]
 
 [[package]]
+name = "pandas-stubs"
+version = "3.0.0.260204"
+description = "Type annotations for pandas"
+optional = false
+python-versions = ">=3.11"
+groups = ["dev"]
+files = [
+    {file = "pandas_stubs-3.0.0.260204-py3-none-any.whl", hash = "sha256:5ab9e4d55a6e2752e9720828564af40d48c4f709e6a2c69b743014a6fcb6c241"},
+    {file = "pandas_stubs-3.0.0.260204.tar.gz", hash = "sha256:bf9294b76352effcffa9cb85edf0bed1339a7ec0c30b8e1ac3d66b4228f1fbc3"},
+]
+
+[package.dependencies]
+numpy = ">=1.23.5"
+
+[[package]]
 name = "parameterized"
 version = "0.9.0"
 description = "Parameterized testing with any Python test framework"
@@ -3535,6 +3550,18 @@ dev-core = ["pytest", "requests", "ruff (==0.11.12)"]
 dev-optional = ["anywidget", "colorcet", "fiona (<=1.9.6) ; python_version <= \"3.8\"", "geopandas", "inflect", "numpy", "orjson", "pandas", "pdfrw", "pillow", "plotly-geo", "plotly[dev-build]", "plotly[kaleido]", "polars[timezone]", "pyarrow", "pyshp", "pytz", "scikit-image", "scipy", "shapely", "statsmodels", "vaex ; python_version <= \"3.9\"", "xarray"]
 express = ["numpy"]
 kaleido = ["kaleido (>=1.1.0)"]
+
+[[package]]
+name = "plotly-stubs"
+version = "0.1.2"
+description = "Type stubs for plotly."
+optional = false
+python-versions = "<3.15,>=3.11"
+groups = ["dev"]
+files = [
+    {file = "plotly_stubs-0.1.2-py3-none-any.whl", hash = "sha256:d3ddcc534d19dec93e3f6f94e214a33209a1c20860a0c350b0c3cbdce5232123"},
+    {file = "plotly_stubs-0.1.2.tar.gz", hash = "sha256:23bb0bbb4ac5cbd7dbdae3c4d6b4ea488842a59bad7111980b2b43d6788cdd64"},
+]
 
 [[package]]
 name = "pluggy"
@@ -5547,6 +5574,21 @@ shellingham = ">=1.3.0"
 typing-extensions = ">=3.7.4.3"
 
 [[package]]
+name = "types-authlib"
+version = "1.6.8.20260215"
+description = "Typing stubs for Authlib"
+optional = false
+python-versions = ">=3.10"
+groups = ["dev"]
+files = [
+    {file = "types_authlib-1.6.8.20260215-py3-none-any.whl", hash = "sha256:644e8dbb6d59a5abd9917370c79125d630d1eefaf4a314cdf20f1b3ea982787f"},
+    {file = "types_authlib-1.6.8.20260215.tar.gz", hash = "sha256:06d81c64b11949a052b0621124b21e14881f8adbfebf8319ed8f05db913f20e5"},
+]
+
+[package.dependencies]
+cryptography = "*"
+
+[[package]]
 name = "types-requests"
 version = "2.32.4.20260107"
 description = "Typing stubs for requests"
@@ -5855,4 +5897,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "321eb4c16febc615532106a929d882c10f88d03ef3b3a25e8dd82f048084b84c"
+content-hash = "523023aa9662f16826da1178a330f518b5377a201e0c9606bc2082390f9da9b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,13 +48,16 @@ requires-poetry = '>=2.0.0,<3.0.0'
 [tool.poetry.group.dev.dependencies]
 black = { version = "^24.4.0", extras = ["jupyter"] }
 isort = "^5.13.2"
-mypy = "^1.9.0"
+mypy = "^1.19.1"
 fastmcp = "^2.12.5"
 types-requests = "^2.31.0.20240406"
 pre-commit = "^3.8.0"
 flake8 = "^7.1.2"
 autoflake = "^2.3.1"
 pyright = "^1.1.394"
+pandas-stubs = "^3.0.0.260204"
+types-authlib = "^1.6.8.20260215"
+plotly-stubs = "^0.1.2"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.4"
@@ -133,7 +136,11 @@ exclude = [
 ]
 
 [tool.mypy]
-ignore_missing_imports = true
+ignore_missing_imports = false
+
+[[tool.mypy.overrides]]
+module = ["aidial_sdk.*", "aidial_client.*"]
+follow_untyped_imports = true
 
 [tool.poetry.group.dev]
 optional = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,7 @@ exclude = [
 ]
 
 [tool.mypy]
+plugins = ["pydantic.mypy"]
 ignore_missing_imports = false
 
 [[tool.mypy.overrides]]

--- a/src/quickapp/agent/_attachment_filter.py
+++ b/src/quickapp/agent/_attachment_filter.py
@@ -28,18 +28,20 @@ class _AttachmentFilter:
         updated_attachments = []
         if message.content is None:
             message.content = ""
+        content = message.content if isinstance(message.content, str) else str(message.content)
         if self._has_attachments(message):
-            for attachment in message.custom_content.attachments:
+            for attachment in message.custom_content.attachments:  # type: ignore[union-attr]
                 if message.role == Role.USER and matches_type(
                     attachment.type, self.SUPPORTED_ATTACHMENTS
                 ):
                     updated_attachments.append(attachment)
                 # Inform agent that message had contained some attachment.
                 # As adapter would resolve the actual bytes and URL would be lost.
-                message.content += (
+                content += (
                     f"\r\nAttachment {attachment.title}, of type {attachment.type}, "
                     f"url {attachment.url}, reference_url {attachment.reference_url}\r\n"
                 )
-            message.custom_content.attachments = updated_attachments
+            message.custom_content.attachments = updated_attachments  # type: ignore[union-attr]
+        message.content = content
 
         return message

--- a/src/quickapp/agent/assistant_invoker.py
+++ b/src/quickapp/agent/assistant_invoker.py
@@ -89,7 +89,7 @@ class AssistantInvoker:
             chat_completion = await self.__azure_client.chat.completions.create(**completion_config)
         except (BadRequestError, RateLimitError) as e:
             raise InvalidRequestError(
-                message=e.code,
+                message=e.code or "Unknown error",
                 display_message=e.body["message"] if isinstance(e.body, dict) else e.body,
             )
         except Exception:

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -1,9 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from aidial_client.types.chat.response import Attachment
-from aidial_sdk.chat_completion import Choice, Stage
-from aidial_sdk.chat_completion.request import ToolCall
+from aidial_sdk.chat_completion import Attachment, Choice, Stage, ToolCall
 from injector import inject
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk

--- a/src/quickapp/application/_request_context_setup.py
+++ b/src/quickapp/application/_request_context_setup.py
@@ -47,5 +47,5 @@ class _RequestContextSetup:
         if choice:
             context.choice = choice
 
-        if getattr(request, "response_format", None):
+        if isinstance(request, Request) and request.response_format:
             context.response_format = request.response_format

--- a/src/quickapp/application/app_module.py
+++ b/src/quickapp/application/app_module.py
@@ -34,7 +34,7 @@ class AppModule(Module):
 
     def configure(self, binder: Binder) -> None:
         binder.bind(FastAPI, to=_QuickAppApplication, scope=singleton)
-        binder.bind(ChatCompletion, to=_QuickAppCompletion, scope=singleton)
+        binder.bind(ChatCompletion, to=_QuickAppCompletion, scope=singleton)  # type: ignore[type-abstract]
         binder.bind(DialSettings, to=DialSettings, scope=singleton)
         binder.bind(_OtelSettings, to=_OtelSettings, scope=singleton)
         binder.bind(_RequestContext, to=_RequestContext, scope=request_scope)

--- a/src/quickapp/common/completion_result.py
+++ b/src/quickapp/common/completion_result.py
@@ -1,7 +1,6 @@
 from typing import Any, Optional
 
-from aidial_client.types.chat.response import Attachment
-from aidial_sdk.chat_completion.request import CustomContent, Message, Role
+from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
 from pydantic import BaseModel, Field
 
 from quickapp.common.deployment_usage import DeploymentUsage

--- a/src/quickapp/common/oauth_token_fetcher.py
+++ b/src/quickapp/common/oauth_token_fetcher.py
@@ -6,7 +6,7 @@ from quickapp.config.toolsets.rest_api import ClientIdSecretAuthorization
 class OAuthTokenFetcher:
     @staticmethod
     async def fetch_oauth_token(auth_info: ClientIdSecretAuthorization) -> str:
-        async with AsyncOAuth2Client(
+        async with AsyncOAuth2Client(  # type: ignore[attr-defined]
             client_id=auth_info.client_id, client_secret=auth_info.client_secret
         ) as client:
             token = await client.fetch_token(

--- a/src/quickapp/dial_core_services/attachment_service.py
+++ b/src/quickapp/dial_core_services/attachment_service.py
@@ -2,7 +2,7 @@ import base64
 import logging
 from io import BytesIO
 
-from aidial_client.types.chat.response import Attachment
+from aidial_sdk.chat_completion import Attachment
 from injector import inject
 
 from quickapp.common import DIAL_API_KEY

--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -74,9 +74,10 @@ class ToolConfigCoreService:
                 logger.debug(f"Getting application config for {deployment}")
                 config_schema = await dial_core.get_deployment_config(deployment)
 
-            return ToolConfigCoreService._convert_to_openai_tool_format(
-                deployment_model or application_model, config_schema
-            )
+            model = deployment_model or application_model
+            if model is None:
+                raise RuntimeError(f"Neither deployment nor application found for '{deployment}'")
+            return ToolConfigCoreService._convert_to_openai_tool_format(model, config_schema)
 
     @staticmethod
     def _convert_to_openai_tool_format(

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -73,7 +73,7 @@ class BaseDeploymentTool(StagedBaseTool):
     @staticmethod
     def _sdk_attachment_to_param(attachment: SdkAttachment) -> AttachmentParam:
         return AttachmentParam(
-            **attachment.model_dump(
+            **attachment.model_dump(  # type: ignore[typeddict-item]
                 include=set(AttachmentParam.__annotations__),
                 exclude_none=True,
             )

--- a/src/quickapp/dial_deployment_tooling/constants.py
+++ b/src/quickapp/dial_deployment_tooling/constants.py
@@ -6,9 +6,4 @@ ATTACHMENT_PARAM = "attachment_urls"
 
 # Extra body / custom fields keys
 EXTRA_BODY = "extra_body"
-CUSTOM_FIELDS = "custom_fields"
 CONFIGURATION = "configuration"
-
-CUSTOM_CONTENT = "custom_content"
-
-USAGE_PARAM = "usage"

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -1,16 +1,18 @@
 import logging
+from collections.abc import AsyncIterable, Iterable
 from dataclasses import dataclass, field
-from typing import Any, Dict, Iterable, List, Tuple
+from typing import Any, Dict, List, Tuple
 
 from aidial_client import AsyncDial
 from aidial_client.resources import AsyncMetadata
+from aidial_client.types.chat import response as dial_client_models
 from aidial_client.types.chat.request_param import (
     AssistantMessageParam,
     AttachmentParam,
     CustomContentParam,
     UserMessageParam,
 )
-from aidial_client.types.chat.response import Attachment, CompletionUsage
+from aidial_sdk import chat_completion as dial_sdk_models
 from injector import inject
 
 from quickapp.common import CompletionResult
@@ -21,25 +23,28 @@ from quickapp.dial_deployment_tooling.constants import (
     ATTACHMENT_PARAM,
     CONFIGURATION,
     CONTENT_PARAM,
-    CUSTOM_CONTENT,
     EXTRA_BODY,
 )
 
 logger = logging.getLogger(__name__)
 
 
+def _to_sdk_attachment(attachment: dial_client_models.Attachment) -> dial_sdk_models.Attachment:
+    return dial_sdk_models.Attachment(**attachment.model_dump())
+
+
 @dataclass
 class _StreamResult:
     content: str = ""
-    attachments: list[Any] | None = None
-    state: Any = None
-    usage: CompletionUsage | None = None
+    attachments: list[dial_sdk_models.Attachment] | None = None
+    state: dict[str, Any] | None = None
+    usage: dial_client_models.CompletionUsage | None = None
     statistics: dict[str, Any] = field(default_factory=dict)
 
-    def extend_attachments(self, attachments: list[Any]) -> None:
+    def extend_attachments(self, attachments: list[dial_client_models.Attachment]) -> None:
         if self.attachments is None:
             self.attachments = []
-        self.attachments.extend(attachments)
+        self.attachments.extend(_to_sdk_attachment(a) for a in attachments)
 
 
 @inject
@@ -129,20 +134,9 @@ class DialCompletionService:
             else:
                 attachment.url = attachment.reference_url
 
-    @staticmethod
-    def _to_client_attachment(attachment: Any) -> Attachment:
-        return Attachment(
-            type=attachment.type,
-            title=attachment.title,
-            data=attachment.data,
-            url=attachment.url,
-            reference_url=attachment.reference_url,
-            reference_type=attachment.reference_type,
-        )
-
     async def _consume_stream(
         self,
-        chunks: Any,
+        chunks: AsyncIterable[dial_client_models.ChatCompletionChunk],
         stage_wrapper: BaseStageWrapper | None,
     ) -> _StreamResult:
         result = _StreamResult()
@@ -168,22 +162,22 @@ class DialCompletionService:
                     if stage_wrapper:
                         for attachment in attachments:
                             self._fix_attachment(attachment)
-                            stage_wrapper.add_stage_attachment(
-                                self._to_client_attachment(attachment)
-                            )
+                            stage_wrapper.add_stage_attachment(_to_sdk_attachment(attachment))
                 elif delta.custom_content and delta.custom_content.state:
                     result.state = delta.custom_content.state
 
             if chunk.usage:
                 result.usage = chunk.usage
-            result.statistics = chunk.model_extra.get("statistics", {}).get("usage_per_model", {})
+            result.statistics = (
+                (chunk.model_extra or {}).get("statistics", {}).get("usage_per_model", {})
+            )
 
         result.content = "".join(content_parts)
         return result
 
     @staticmethod
     def __get_deployment_usage(
-        usage: CompletionUsage | None,
+        usage: dial_client_models.CompletionUsage | None,
         statistics: dict | None,
         deployment_id: str,
         deployment_name: str,
@@ -236,7 +230,7 @@ class DialCompletionService:
         message = UserMessageParam(role="user", content=content)
         attachments = await self.resolve_attachment_urls(relative_attachment_urls)
         if attachments and len(attachments) > 0:
-            message[CUSTOM_CONTENT] = CustomContentParam(attachments=attachments)
+            message["custom_content"] = CustomContentParam(attachments=attachments)
         return message
 
     async def resolve_attachment_urls(
@@ -248,7 +242,7 @@ class DialCompletionService:
         metadata: AsyncMetadata = self.__dial_client.metadata
         fileinfo = await metadata.get("files", file_relative_url)
         return AttachmentParam(
-            type=fileinfo.content_type,
+            type=fileinfo.content_type or "",
             title=fileinfo.name,
-            url=fileinfo.url,
+            url=fileinfo.url or "",
         )

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/display_content_processor.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/display_content_processor.py
@@ -14,7 +14,8 @@ from aidial_client.types.chat.request_param import (
     SystemMessageParam,
     UserMessageParam,
 )
-from aidial_client.types.chat.response import Attachment, ChatCompletionResponse
+from aidial_client.types.chat.response import ChatCompletionResponse
+from aidial_sdk.chat_completion import Attachment
 from injector import inject
 
 from quickapp.common import DIAL_API_KEY
@@ -54,7 +55,7 @@ class DisplayContentProcessor:
         self.__api_key: DIAL_API_KEY = api_key
         self.__dial_client: AsyncDial = dial_client
         self.__additional_handling_model: str = py_interpreter_settings.additional_handling_model
-        pio.defaults.chromium_args = [
+        pio.defaults.chromium_args = [  # type: ignore[attr-defined]
             "--no-sandbox",
             "--disable-gpu",
             "--disable-dev-shm-usage",
@@ -78,19 +79,15 @@ class DisplayContentProcessor:
 
         for media_type, data in content_dict.items():
             if media_type in SUPPORTED_DISPLAY_MEDIA_TYPES:
-                attachment_dict = {"type": media_type}
                 bucket_info = await self._publish_to_bucket(media_type, data)
-                attachment_dict["url"] = bucket_info.get("url", "")
+                bucket_url = bucket_info.get("url", "")
 
-                if attachment_dict.get("type", None) and attachment_dict.get("url", None):
-                    # generate by content file title
-                    attachment_dict["data"] = json.dumps(data)
-                    # TODO: need to verify this part when attachments will be ready
-                    attachment = Attachment.model_validate(attachment_dict)
-                    title = await self._generate_title(attachment)
-                    # TODO: dirty fix, data and url shouldn't be both filled
-                    attachment.data = None
-                    attachment.title = title
+                if media_type and bucket_url:
+                    # Create a temporary data-only attachment for title generation
+                    temp_attachment = Attachment(type=media_type, data=json.dumps(data))
+                    title = await self._generate_title(temp_attachment)
+                    # Create the final url-only attachment
+                    attachment = Attachment(type=media_type, url=bucket_url, title=title)
 
                     attachments.append(attachment)
 
@@ -136,7 +133,7 @@ class DisplayContentProcessor:
 
                 # TODO: need to add usage statistics
 
-                return response.choices[0].message.content
+                return response.choices[0].message.content or str(uuid.uuid4())
             except Exception as e:
                 logger.exception(f"Exception during generating title for attachment: {e}")
 
@@ -148,7 +145,7 @@ class DisplayContentProcessor:
             pass
             # TODO: later will be added the flow to download files from py interpreter and then we need to handle such case
         else:
-            attachment_param = AttachmentParam(**attachment.model_dump())
+            attachment_param = AttachmentParam(**attachment.model_dump())  # type: ignore[typeddict-item]
             if attachment.type in (MediaTypes.PNG, MediaTypes.JPEG):
                 message = UserMessageParam(
                     role='user',

--- a/src/quickapp/mcp_tooling/_mcp_tool.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Optional
+from typing import Any
 
 from aidial_sdk.chat_completion import Attachment
 from injector import AssistedBuilder, inject
@@ -55,8 +55,52 @@ class _MCPTool(StagedBaseTool):
                     kwargs[key] = file_content
         return kwargs
 
+    def _content_to_attachment(self, content: Any) -> Attachment | None:
+        ctype = getattr(content, "type", None)
+
+        if ctype == "image":
+            title = generate_attachment_filename(
+                getattr(content, "mimeType", None), base_filename=self.__tool.name
+            )
+            return Attachment(
+                title=title,
+                type=getattr(content, "mimeType", None),
+                data=getattr(content, "data", None),
+            )
+
+        if ctype == "resource":
+            resource = getattr(content, "resource", None)
+            title = generate_attachment_filename(
+                getattr(resource, "mimeType", None), base_filename=self.__tool.name
+            )
+            if isinstance(resource, TextResourceContents):
+                return Attachment(
+                    title=title,
+                    type=getattr(resource, "mimeType", None),
+                    data=getattr(resource, "text", None),
+                )
+            if isinstance(resource, BlobResourceContents):
+                return Attachment(
+                    title=title,
+                    type=getattr(resource, "mimeType", None),
+                    data=getattr(resource, "blob", None),
+                )
+            msg = f"Unsupported embedded resource type: {type(resource)}"
+            logger.exception(msg)
+            raise NotImplementedError(msg)
+
+        return None
+
+    async def _maybe_upload_attachment(self, attachment: Attachment) -> Attachment:
+        if self._tool_config and matches_type(
+            attachment.type, self._tool_config.attachment.supported_types  # type: ignore[arg-type]
+        ):
+            logger.debug(f"Attachment: {attachment.title}, Tool Config: {self._tool_config}")
+            return await self.__dial_attachment_service.upload_attachment_to_core(attachment)
+        return attachment
+
     async def _run_in_stage_async(
-        self, stage_wrapper: Optional[BaseStageWrapper], *args: Any, **kwargs: Any
+        self, stage_wrapper: BaseStageWrapper | None, *args: Any, **kwargs: Any
     ) -> CompletionResult:
 
         logger.debug(f"MCP tool called with {kwargs}")
@@ -94,52 +138,9 @@ class _MCPTool(StagedBaseTool):
 
         attachments = []
         for content in non_text_contents:
-            attachment = None
-            ctype = getattr(content, "type", None)
-
-            if ctype == "image":
-                title = generate_attachment_filename(
-                    getattr(content, "mimeType", None), base_filename=self.__tool.name
-                )
-                attachment = Attachment(
-                    title=title,
-                    type=getattr(content, "mimeType", None),
-                    data=getattr(content, "data", None),
-                )
-
-            elif ctype == "resource":
-                resource = getattr(content, "resource", None)
-                title = generate_attachment_filename(
-                    getattr(resource, "mimeType", None), base_filename=self.__tool.name
-                )
-                if isinstance(resource, TextResourceContents):
-                    attachment = Attachment(
-                        title=title,
-                        type=getattr(resource, "mimeType", None),
-                        data=getattr(resource, "text", None),
-                    )
-                elif isinstance(resource, BlobResourceContents):
-                    attachment = Attachment(
-                        title=title,
-                        type=getattr(resource, "mimeType", None),
-                        data=getattr(resource, "blob", None),
-                    )
-                else:
-                    msg = f"Unsupported embedded resource type: {type(resource)}"
-                    logger.exception(msg)
-                    raise NotImplementedError(msg)
+            attachment = self._content_to_attachment(content)
             if attachment is not None:
-                if self._tool_config and matches_type(
-                    attachment.type, self._tool_config.attachment.supported_types  # type: ignore[arg-type]
-                ):
-                    # Store all supported MCP attachments in the core.
-                    logger.debug(
-                        f"Attachment: {attachment.title}, Tool Config: {self._tool_config}"
-                    )
-                    attachment = await self.__dial_attachment_service.upload_attachment_to_core(
-                        attachment
-                    )
-
+                attachment = await self._maybe_upload_attachment(attachment)
                 attachments.append(attachment)
 
         result = CompletionResult(

--- a/src/quickapp/mcp_tooling/_mcp_tool.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Optional
 
-from aidial_client.types.chat.response import Attachment
+from aidial_sdk.chat_completion import Attachment
 from injector import AssistedBuilder, inject
 from mcp.types import BlobResourceContents, TextResourceContents, Tool
 
@@ -128,18 +128,19 @@ class _MCPTool(StagedBaseTool):
                     msg = f"Unsupported embedded resource type: {type(resource)}"
                     logger.exception(msg)
                     raise NotImplementedError(msg)
-            if (
-                attachment
-                and self._tool_config
-                and matches_type(attachment.type, self._tool_config.attachment.supported_types)  # type: ignore[arg-type]
-            ):
-                # Store all supported MCP attachments in the core.
-                logger.debug(f"Attachment: {attachment.title}, Tool Config: {self._tool_config}")
-                attachment = await self.__dial_attachment_service.upload_attachment_to_core(
-                    attachment
-                )
+            if attachment is not None:
+                if self._tool_config and matches_type(
+                    attachment.type, self._tool_config.attachment.supported_types  # type: ignore[arg-type]
+                ):
+                    # Store all supported MCP attachments in the core.
+                    logger.debug(
+                        f"Attachment: {attachment.title}, Tool Config: {self._tool_config}"
+                    )
+                    attachment = await self.__dial_attachment_service.upload_attachment_to_core(
+                        attachment
+                    )
 
-            attachments.append(attachment)
+                attachments.append(attachment)
 
         result = CompletionResult(
             content=tool_content,

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -2,7 +2,7 @@ import logging
 from typing import Any, Optional
 
 import httpx
-from aidial_client.types.chat.response import Attachment
+from aidial_sdk.chat_completion import Attachment
 from injector import AssistedBuilder, inject
 
 from quickapp.common import CompletionResult, StagedBaseTool

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
@@ -3,8 +3,7 @@ import unittest
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch, AsyncMock
 
-from aidial_client.types.chat.response import Attachment
-from aidial_sdk.chat_completion import Stage
+from aidial_sdk.chat_completion import Attachment, Stage
 from fastapi_injector import Injected
 from injector import Binder, Injector, InstanceProvider
 from mcp.types import ImageContent, EmbeddedResource, TextResourceContents, BlobResourceContents
@@ -25,8 +24,14 @@ from tests.unit_tests.common.common import create_app_configuration
 
 class MCPToolTest(unittest.IsolatedAsyncioTestCase):
 
-    @patch("quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool", new_callable=AsyncMock)
-    @patch("quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list", new_callable=AsyncMock)
+    @patch(
+        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list",
+        new_callable=AsyncMock,
+    )
     async def test_mcp_tool(self, mock_get_tools_list, mock_call_mcp_tool):
         # Prepare tools metadata (no coroutines on the tool objects)
         tool_1 = SimpleNamespace(name="test_tool1", description="A test tool 1", inputSchema={})
@@ -53,23 +58,39 @@ class MCPToolTest(unittest.IsolatedAsyncioTestCase):
         async def _call_side_effect(tool_name, **kwargs):
             if tool_name == "test_tool1":
                 # text-only content
-                return SimpleNamespace(content=[SimpleNamespace(type="text", text="test_result_1")], isError=False)
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="test_result_1")], isError=False
+                )
             if tool_name == "test_tool2":
                 # image content
-                return SimpleNamespace(content=[
-                    ImageContent(mimeType="image/png", data=base64.b64encode(b"test_image_data").decode("utf-8"),
-                                 type="image")], isError=False)
+                return SimpleNamespace(
+                    content=[
+                        ImageContent(
+                            mimeType="image/png",
+                            data=base64.b64encode(b"test_image_data").decode("utf-8"),
+                            type="image",
+                        )
+                    ],
+                    isError=False,
+                )
             if tool_name == "test_tool3":
                 # embedded text resource
-                tr = TextResourceContents(mimeType="text/plain", text="test_text_content",
-                                          uri=AnyUrl("https://test_uri"))
-                return SimpleNamespace(content=[EmbeddedResource(resource=tr, type="resource")], isError=False)
+                tr = TextResourceContents(
+                    mimeType="text/plain", text="test_text_content", uri=AnyUrl("https://test_uri")
+                )
+                return SimpleNamespace(
+                    content=[EmbeddedResource(resource=tr, type="resource")], isError=False
+                )
             if tool_name == "test_tool4":
                 # embedded blob resource
-                br = BlobResourceContents(mimeType="application/octet-stream",
-                                          blob=base64.b64encode(b"test_blob_content").decode("utf-8"),
-                                          uri=AnyUrl("https://test_blob_uri"))
-                return SimpleNamespace(content=[EmbeddedResource(resource=br, type="resource")], isError=False)
+                br = BlobResourceContents(
+                    mimeType="application/octet-stream",
+                    blob=base64.b64encode(b"test_blob_content").decode("utf-8"),
+                    uri=AnyUrl("https://test_blob_uri"),
+                )
+                return SimpleNamespace(
+                    content=[EmbeddedResource(resource=br, type="resource")], isError=False
+                )
             return SimpleNamespace(content=[], isError=False)
 
         mock_call_mcp_tool.side_effect = _call_side_effect
@@ -77,9 +98,8 @@ class MCPToolTest(unittest.IsolatedAsyncioTestCase):
         mcp_toolset = MCPToolSet(
             type="mcp",
             mcp_server_info=MCPServerInfo(
-                url="https://test/mcp",
-                authorization=None,
-                protocol=MCPProtocol.streamable_http),
+                url="https://test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+            ),
             name="mcp-toolset",
             description="Set with MCP tools",
         )
@@ -113,8 +133,15 @@ class MCPToolTest(unittest.IsolatedAsyncioTestCase):
             # Use the public async entrypoint `arun(tool_call_id, ...)`
             tool_1_instance = next((t for t in tools if t.name == "test_tool1"), None)
             tool_1_result = await tool_1_instance.arun("call-1")
-            self.assertEqual(tool_1_result, CompletionResult(tool_call_id="call-1", content='test_result_1',
-                                                             content_type='text/markdown', attachments=None))
+            self.assertEqual(
+                tool_1_result,
+                CompletionResult(
+                    tool_call_id="call-1",
+                    content='test_result_1',
+                    content_type='text/markdown',
+                    attachments=None,
+                ),
+            )
 
             tool_2_instance = next((t for t in tools if t.name == "test_tool2"), None)
             tool_2_result = await tool_2_instance.arun("call-2")
@@ -124,30 +151,70 @@ class MCPToolTest(unittest.IsolatedAsyncioTestCase):
                     tool_call_id="call-2",
                     content="",
                     content_type='text/markdown',
-                    attachments=[Attachment(type='image/png',
-                                            title="Attachment",
-                                            data=None,
-                                            url="mocked_url", reference_type=None, reference_url=None)],
-                    propagate_to_choice=[Attachment(type='image/png', title='Attachment', data=None, url='mocked_url',
-                                                    reference_type=None, reference_url=None)]))
+                    attachments=[
+                        Attachment(
+                            type='image/png',
+                            title="Attachment",
+                            data=None,
+                            url="mocked_url",
+                            reference_type=None,
+                            reference_url=None,
+                        )
+                    ],
+                    propagate_to_choice=[
+                        Attachment(
+                            type='image/png',
+                            title='Attachment',
+                            data=None,
+                            url='mocked_url',
+                            reference_type=None,
+                            reference_url=None,
+                        )
+                    ],
+                ),
+            )
 
             tool_3_instance = next((t for t in tools if t.name == "test_tool3"), None)
             tool_3_result = await tool_3_instance.arun("call-3")
-            self.assertEqual(tool_3_result,
-                             CompletionResult(tool_call_id="call-3", content="", content_type='text/markdown',
-                                              attachments=[
-                                                  Attachment(type='text/plain', title="Attachment", data=None,
-                                                             url="mocked_url", reference_type=None,
-                                                             reference_url=None)]))
+            self.assertEqual(
+                tool_3_result,
+                CompletionResult(
+                    tool_call_id="call-3",
+                    content="",
+                    content_type='text/markdown',
+                    attachments=[
+                        Attachment(
+                            type='text/plain',
+                            title="Attachment",
+                            data=None,
+                            url="mocked_url",
+                            reference_type=None,
+                            reference_url=None,
+                        )
+                    ],
+                ),
+            )
 
             tool_4_instance = next((t for t in tools if t.name == "test_tool4"), None)
             tool_4_result = await tool_4_instance.arun("call-4")
-            self.assertEqual(tool_4_result,
-                             CompletionResult(tool_call_id="call-4", content="", content_type='text/markdown',
-                                              attachments=[
-                                                  Attachment(type='application/octet-stream', title="Attachment",
-                                                             data=None, url="mocked_url",
-                                                             reference_type=None, reference_url=None)]))
+            self.assertEqual(
+                tool_4_result,
+                CompletionResult(
+                    tool_call_id="call-4",
+                    content="",
+                    content_type='text/markdown',
+                    attachments=[
+                        Attachment(
+                            type='application/octet-stream',
+                            title="Attachment",
+                            data=None,
+                            url="mocked_url",
+                            reference_type=None,
+                            reference_url=None,
+                        )
+                    ],
+                ),
+            )
 
         client = TestClient(app)
         response = client.get("/")

--- a/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
+++ b/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
@@ -1,8 +1,7 @@
 import unittest
 from unittest.mock import patch, MagicMock, AsyncMock
 
-from aidial_client.types.chat.response import Attachment
-from aidial_sdk.chat_completion import Stage
+from aidial_sdk.chat_completion import Attachment, Stage
 from fastapi_injector import Injected
 from httpx import QueryParams
 from injector import Binder, InstanceProvider
@@ -10,12 +9,21 @@ from parameterized import parameterized
 from pydantic import SecretStr
 from starlette.testclient import TestClient
 
-from quickapp.common import  StagedBaseTool, DIAL_BEARER, DIAL_API_KEY
+from quickapp.common import StagedBaseTool, DIAL_BEARER, DIAL_API_KEY
 from quickapp.common.dial_settings import DialSettings
 from quickapp.config.application import ApplicationConfig
-from quickapp.config.tools.base import OpenAiToolConfig, OpenAiToolFunction, OpenAiToolFunctionParameters
-from quickapp.config.tools.rest_api import RestApiTool, RestApiEndpointMethodInfo, RestApiEndpointSimpleTypeParam, \
-    RestApiEndpointHeaderParamInfo, ToolEndpointParamType
+from quickapp.config.tools.base import (
+    OpenAiToolConfig,
+    OpenAiToolFunction,
+    OpenAiToolFunctionParameters,
+)
+from quickapp.config.tools.rest_api import (
+    RestApiTool,
+    RestApiEndpointMethodInfo,
+    RestApiEndpointSimpleTypeParam,
+    RestApiEndpointHeaderParamInfo,
+    ToolEndpointParamType,
+)
 from quickapp.config.toolsets.authorization import BearerAuthorization
 from quickapp.config.toolsets.rest_api import RestApiToolSet
 from quickapp.rest_api_tooling import RestApiToolingModule
@@ -25,24 +33,19 @@ from tests.unit_tests.common.common import create_app_configuration
 
 class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
 
-    @parameterized.expand([
-        (
-            "get",
-            "https://auth@abc.example.com:2020/index"
-        )
-    ])
+    @parameterized.expand([("get", "https://auth@abc.example.com:2020/index")])
     @patch("httpx.AsyncClient")
-    async def test_web_api_tool_2_make_correct_http_call(self, request_method, url, mock_async_client):
+    async def test_web_api_tool_2_make_correct_http_call(
+        self, request_method, url, mock_async_client
+    ):
         mock_stage = MagicMock(spec=Stage)
         response_data = {
-                    "text": '{"some_key":"some value"}',
-                    "headers": {"Content-Type": "application/json"},
-                }
+            "text": '{"some_key":"some value"}',
+            "headers": {"Content-Type": "application/json"},
+        }
         mock_response = AsyncMock(**response_data)
         mock_response.raise_for_status = MagicMock()
-        mock_async_client.return_value.__aenter__.return_value.request.return_value = (
-            mock_response
-        )
+        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
 
         rest_api_toolset = RestApiToolSet(
             name="rest-api",
@@ -50,8 +53,8 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
             tools=[
                 RestApiTool(
                     rest_api_method_info=RestApiEndpointMethodInfo(
-                        method_url=url,
-                        method_type=request_method),
+                        method_url=url, method_type=request_method
+                    ),
                     open_ai_tool=OpenAiToolConfig(
                         function=OpenAiToolFunction(
                             name="test_function",
@@ -62,18 +65,17 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
                                         type="string",
                                         description="Query key",
                                         parameter_info=RestApiEndpointHeaderParamInfo(
-                                            type=ToolEndpointParamType.query,
-                                            key="query_key"
-                                        )
+                                            type=ToolEndpointParamType.query, key="query_key"
+                                        ),
                                     )
-
                                 },
-                                type="object")
-                    ))
+                                type="object",
+                            ),
+                        )
+                    ),
                 )
-            ]
+            ],
         )
-
 
         def configure(binder: Binder):
             binder.bind(DialSettings, DialSettings(url="https://core"))
@@ -81,10 +83,7 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
             binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
             # binder.bind(AttachmentService, mock_dial_attachment_service)
             binder.bind(Stage, to=mock_stage)
-            binder.bind(
-                ApplicationConfig,
-                to=create_app_configuration([rest_api_toolset])
-            )
+            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
 
         app = create_test_app([RestApiToolingModule, configure])
 
@@ -125,6 +124,8 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
 
         self.assertEqual(expected_request_data["url"], actual_request_data["url"])
         self.assertEqual(expected_request_data["params"], actual_request_data["params"])
-        self.assertEqual(expected_request_data["method"].lower(), actual_request_data["method"].lower())
+        self.assertEqual(
+            expected_request_data["method"].lower(), actual_request_data["method"].lower()
+        )
         self.assertIn("Authorization", actual_request_data["headers"])
         self.assertEqual("Bearer test_token", actual_request_data["headers"]["Authorization"])


### PR DESCRIPTION
### Applicable issues

- fixes #60

### Description of changes

Resolves all mypy errors after enabling strict import checking for the pydantic v2 migration.

- **Mypy config**: `ignore_missing_imports = false` with `follow_untyped_imports = true` override for `aidial_sdk.*`/`aidial_client.*`. Added `pandas-stubs`, `plotly-stubs`, `types-authlib`.
- **Standardize on SDK Attachment**: Replaced `aidial_client` Attachment with `aidial_sdk` Attachment across the internal pipeline. Client types remain only at external call boundaries.
- **Type safety fixes**: Guarded nullable fields, added type ignores for untyped third-party APIs and TypedDict expansions, fixed union attribute access.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.