### PR TITLE
fix: attachment config refactor #101

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -133,14 +133,17 @@ All tools inherit from a common base class that defines:
 - A standardized execution interface
 - Lifecycle management with stage wrappers
 - Parameter preprocessing hooks
-- Attachment filtering based on configuration
+- Attachment filtering based on `supported_types` configuration (single canonical filter point)
+- Choice propagation for UI rendering based on `propagate_types_to_choice` (subset of surviving attachments)
 - Performance timing
 
 ### Tool Types
 
 Quick Apps supports several tool types:
 
-- **REST API Tools**: HTTP endpoints defined declaratively in configuration
+- **REST API Tools**: HTTP endpoints defined declaratively in configuration. Support an optional
+  `response_as_attachment` config (`enabled`, `content_types`, `include_body_as_content`) that controls whether the HTTP
+  response body is wrapped as a file attachment. Defaults to disabled — responses are returned as text only.
 - **DIAL Deployment Tools**: Invocations of other DIAL deployments (models, applications)
 - **MCP Tools**: Tools from Model Context Protocol servers
 - **Internal Tools**: Built-in tools like Python interpreter and content downloader. The context notification tool is

--- a/docs/designs/attachment_config_redesign.md
+++ b/docs/designs/attachment_config_redesign.md
@@ -1,0 +1,198 @@
+# Design: Attachment Configuration Redesign
+
+**Status:** Draft
+
+## Problem Statement
+
+The `supported_types` field on `AttachmentConfig` is overloaded — it simultaneously drives three unrelated decisions:
+
+1. Which tool-output attachments to keep (base class filter)
+2. Whether a REST API HTTP response body should be converted into an attachment (creation gate)
+3. Whether an MCP attachment should be uploaded to DIAL Core (upload gate)
+
+This causes silent response duplication in REST API tools (default `*/*` wraps every JSON response as an attachment),
+redundant double-filtering in tool subclasses, and a semantic mismatch where deployment `input_attachment_types` are
+mapped to output filtering.
+
+## Design Goals
+
+- Each attachment-related behavior is controlled by **exactly one** config field with a clear name.
+- Tool subclasses do **not** duplicate base-class filtering logic.
+- REST API tools support three distinct response modes out of the box.
+- Deployment tools correctly separate input-type declarations from output-type filtering.
+
+---
+
+## Core Model: Three Orthogonal Concerns
+
+### Concern 1: Output attachment filtering ("what to keep")
+
+**Field:** `AttachmentConfig.supported_types` (existing, name kept as-is — once the overloaded semantics are removed, the
+name is clear enough and avoiding a rename eliminates migration cost for all existing configs)
+
+**Owner:** `StagedBaseTool._run_in_stage_report_success()` — the **single, canonical** filter point.
+
+**Semantics:** After a tool produces its `CompletionResult`, the base class filters `result.attachments` to keep only
+types matching this list. This is the only place this check runs.
+
+**Change:** Remove the `supported_types` check from `_RestApiTool` (it will no longer create attachments itself — that's
+Concern 3's job). For `_MCPTool`, keep a lightweight pre-upload check as a **performance optimization** — uploading an
+attachment to DIAL Core only to have the base class discard it is wasted I/O. This check should be explicitly framed as
+upload gating (e.g., a `_should_upload(type)` helper), not as filtering logic. The base class remains the single owner
+of the actual filtering decision.
+
+### Concern 2: Choice propagation ("what to show in UI")
+
+**Field:** `AttachmentConfig.propagate_types_to_choice` (existing, unchanged)
+
+**Owner:** `StagedBaseTool._run_in_stage_report_success()` — same loop as concern 1.
+
+**Semantics:** Attachments matching this list are forwarded to the response `Choice` for UI rendering (e.g., inline
+images, Plotly charts).
+
+**Change:** Enforce as a logical subset of `supported_types` via **runtime code ordering** — the base class first filters
+by `supported_types`, then checks `propagate_types_to_choice` only on surviving attachments. No config-time validation
+needed (MIME wildcard subset checking is non-trivial and not worth the complexity).
+
+### Concern 3: Response-to-attachment conversion ("whether to create an attachment from the response")
+
+This is **REST-API-specific**. Other tool types (MCP, deployment, internal) produce attachments through their own
+natural mechanisms — they don't need a "should I wrap my text response as a file?" decision.
+
+**New field:** `RestApiTool.response_as_attachment` — a sibling of the existing `attachment` field on `RestApiTool`.
+Defined per-tool. `RestApiToolSet` gets an optional `response_as_attachment` field that serves as the default for all
+tools in the set; individual tools can override it. Override semantics are **full replacement**: if a tool defines
+`response_as_attachment`, the entire toolset default is ignored for that tool (no field-level merging).
+
+**Type:** config model with:
+
+- **`enabled`** (`bool`, default `False`) — whether to wrap the HTTP response body as an attachment at all.
+- **`content_types`** (`list[str]`, default `["*/*"]`) — which response Content-Types to convert. Uses the same MIME
+  matching logic. Only relevant when `enabled=True`.
+- **`include_body_as_content`** (`bool`, default `True`) — when an attachment is created, whether to also keep the
+  response body as `CompletionResult.content`. When `false`, content is set to a placeholder
+  (e.g., `"See attached file: {filename}"`) rather than left empty, since some LLM providers reject empty tool messages.
+
+This cleanly supports three REST API response modes:
+
+| Mode                      | `enabled` | `include_body_as_content` | Result                                           |
+|---------------------------|-----------|---------------------------|--------------------------------------------------|
+| 1. Text only              | `false`   | n/a                       | Response as text, no attachment                  |
+| 2. Attachment only        | `true`    | `false`                   | Response as attachment, placeholder text content |
+| 3. Both text + attachment | `true`    | `true`                    | Response in both forms                           |
+
+Additional patterns (like "propagation only") emerge from combining `response_as_attachment` with `propagate_types_to_choice` — these are documented in the Configuration Recipes section below.
+
+**Default behavior change:** `enabled=False` means REST API tools no longer silently duplicate responses as attachments.
+This is a breaking change for configs that rely on the current implicit behavior — a migration note is needed.
+
+---
+
+## Secondary Fixes
+
+### Deployment tool `input_attachment_types` mapping
+
+Currently `deployment.input_attachment_types` (what the deployment accepts as input) is mapped to `supported_types` (
+what the tool outputs). This is a semantic mismatch.
+
+**Fix:** When building a `DialDeploymentTool` from DIAL Core metadata:
+
+- Use `deployment.input_attachment_types` only for its actual purpose — controlling which attachments are forwarded *to*
+  the deployment (the `attachment_urls` parameter).
+- Default `supported_types` to `["*/*"]` (the `AttachmentConfig` default) for deployment tools, since we generally don't
+  know what a deployment will *return*. If DIAL Core metadata eventually exposes output types, map those instead.
+- Keep `propagate_types_to_choice` as `[]` for deployment tools. Unlike predefined tools (py_interpreter, etc.) where we
+  control the output, deployment tools return arbitrary content from external services. Automatically propagating unknown
+  attachments to the UI choice could produce unexpected rendering behavior (e.g., malformed Plotly JSON breaking the UI).
+  Config authors can opt in per-tool when appropriate.
+
+### `supported_types: None` handling
+
+Make `supported_types` non-optional: `list[str]` with default `["*/*"]`. If `None` is provided in config, the Pydantic
+validator coerces it to the default. Eliminates the silent "block everything" trap.
+
+---
+
+## Out of Scope
+
+### Pre-LLM user attachment filter (`_AttachmentFilter`)
+
+The investigation flags `_AttachmentFilter.SUPPORTED_ATTACHMENTS = ["image/*"]` as high severity — the pre-LLM filter is
+hardcoded and disconnected from tool configs. This means configuring a tool with `supported_types: ["application/pdf"]`
+doesn't help if the LLM never sees user-submitted PDFs in the first place.
+
+This is intentionally deferred. Making it configurable requires broader design work around token budget concerns (large
+PDFs shouldn't always be sent to the LLM), LLM capability detection, and file size limits. It deserves its own design
+pass.
+
+### REST API binary response handling
+
+The current `_RestApiTool` uses `response.text` to create attachments, which fails or produces garbage for binary
+responses (images, PDFs). This is a pre-existing bug, not introduced by this redesign. Since we're changing the
+attachment creation path, it's a natural time to fix it — but the fix (detecting binary Content-Types, using
+`response.content` with base64 encoding) is mechanical and orthogonal to the config model changes here.
+
+---
+
+## Configuration Recipes
+
+Common patterns that emerge from combining the orthogonal config fields:
+
+**REST API tool returning custom Plotly visualization (propagation only):**
+- `response_as_attachment.enabled = true`
+- `response_as_attachment.content_types = ["application/vnd.plotly.v1+json"]`
+- `response_as_attachment.include_body_as_content = false`
+- `propagate_types_to_choice = ["application/vnd.plotly.v1+json"]`
+- Result: Plotly JSON is wrapped as attachment, propagated to UI choice for rendering, placeholder text sent to LLM.
+
+**REST API tool returning images inline:**
+- `response_as_attachment.enabled = true`
+- `response_as_attachment.content_types = ["image/*"]`
+- `response_as_attachment.include_body_as_content = false`
+- `supported_types = ["image/*"]`
+- `propagate_types_to_choice = ["image/*"]`
+- Result: Image responses become attachments shown in UI. Non-image responses pass through as text only.
+
+---
+
+## Migration
+
+### Breaking change: REST API response-to-attachment default
+
+The new default `response_as_attachment.enabled = false` means REST API tools no longer silently create attachments from
+every HTTP response. Configs that relied on this behavior need to explicitly opt in.
+
+**Backward compatibility strategy:** Log a warning **once at startup** (config load time) for REST API tools that don't
+explicitly set `response_as_attachment`. The message should be: "REST API tool X uses the default
+`response_as_attachment.enabled=false`. If you relied on automatic attachment creation, set `enabled=true` explicitly."
+Per-response warnings would fire on every single API call (since the old `*/*` default matched everything) and produce
+pure noise.
+
+### No change: Deployment tools
+
+Deployment tool defaults are preserved (`propagate_types_to_choice = []`). The only change is that `supported_types`
+defaults to `["*/*"]` instead of being derived from `input_attachment_types`, which means deployment output attachments
+are no longer silently filtered when the deployment doesn't declare input types.
+
+### No rename
+
+`supported_types` field name is kept as-is. No config migration needed for existing users of this field.
+
+## Summary of Config Changes
+
+**`AttachmentConfig`** (all tool types):
+
+- `supported_types: list[str] = ["*/*"]` — output attachment filter (non-optional)
+- `propagate_types_to_choice: list[str] = [...]` — UI choice propagation (unchanged)
+
+**`RestApiTool`** (REST API only, new):
+
+- `response_as_attachment.enabled: bool = False`
+- `response_as_attachment.content_types: list[str] = ["*/*"]`
+- `response_as_attachment.include_body_as_content: bool = True`
+
+**`ToolConfigCoreService`** (deployment tools):
+
+- Stop mapping `input_attachment_types` → `supported_types`; default to `["*/*"]`
+- Keep `propagate_types_to_choice = []` (intentional for deployment tools)
+- Use `input_attachment_types` only for controlling which attachments are forwarded to the deployment

--- a/docs/designs/attachment_config_redesign.md
+++ b/docs/designs/attachment_config_redesign.md
@@ -1,6 +1,6 @@
 # Design: Attachment Configuration Redesign
 
-**Status:** Draft
+**Status:** Implemented
 
 ## Problem Statement
 
@@ -23,7 +23,10 @@ mapped to output filtering.
 
 ---
 
-## Core Model: Three Orthogonal Concerns
+## Proposed Design
+
+The design decomposes the current overloaded `supported_types` into three orthogonal concerns, each controlled by
+exactly one config field.
 
 ### Concern 1: Output attachment filtering ("what to keep")
 
@@ -36,10 +39,12 @@ name is clear enough and avoiding a rename eliminates migration cost for all exi
 types matching this list. This is the only place this check runs.
 
 **Change:** Remove the `supported_types` check from `_RestApiTool` (it will no longer create attachments itself — that's
-Concern 3's job). For `_MCPTool`, keep a lightweight pre-upload check as a **performance optimization** — uploading an
-attachment to DIAL Core only to have the base class discard it is wasted I/O. This check should be explicitly framed as
-upload gating (e.g., a `_should_upload(type)` helper), not as filtering logic. The base class remains the single owner
-of the actual filtering decision.
+Concern 3's job). For `_MCPTool`, replace `_maybe_upload_attachment` with a `_should_upload(type)` helper that gates
+**both** the upload and the append. Currently, `_MCPTool` unconditionally appends every attachment to the result list
+even when the upload is skipped — these unuploaded objects linger in memory until the base-class filter discards them.
+The new helper should short-circuit: if the type won't survive `supported_types` filtering, skip both upload and append.
+This is framed as a **performance optimization** — the base class remains the single owner of the actual filtering
+decision.
 
 ### Concern 2: Choice propagation ("what to show in UI")
 
@@ -50,19 +55,30 @@ of the actual filtering decision.
 **Semantics:** Attachments matching this list are forwarded to the response `Choice` for UI rendering (e.g., inline
 images, Plotly charts).
 
-**Change:** Enforce as a logical subset of `supported_types` via **runtime code ordering** — the base class first filters
-by `supported_types`, then checks `propagate_types_to_choice` only on surviving attachments. No config-time validation
-needed (MIME wildcard subset checking is non-trivial and not worth the complexity).
+**Change (bug fix):** The current code in `StagedBaseTool._run_in_stage_report_success` runs the `supported_types` and
+`propagate_types_to_choice` checks as two independent `if` statements in the same loop. An attachment that fails
+`supported_types` but matches `propagate_types_to_choice` is still added to `propagate_to_choice` — it leaks to the UI
+choice despite being filtered from `result.attachments`. This is an existing bug.
+
+Fix: restructure the loop so that `propagate_types_to_choice` is checked **only on surviving attachments** (i.e., those
+that already passed the `supported_types` filter). This enforces propagation as a logical subset of filtering via runtime
+code ordering. No config-time validation is needed (MIME wildcard subset checking is non-trivial and not worth the
+complexity).
 
 ### Concern 3: Response-to-attachment conversion ("whether to create an attachment from the response")
 
 This is **REST-API-specific**. Other tool types (MCP, deployment, internal) produce attachments through their own
 natural mechanisms — they don't need a "should I wrap my text response as a file?" decision.
 
-**New field:** `RestApiTool.response_as_attachment` — a sibling of the existing `attachment` field on `RestApiTool`.
-Defined per-tool. `RestApiToolSet` gets an optional `response_as_attachment` field that serves as the default for all
-tools in the set; individual tools can override it. Override semantics are **full replacement**: if a tool defines
-`response_as_attachment`, the entire toolset default is ignored for that tool (no field-level merging).
+**New field:** `RestApiTool.response_as_attachment` — a new field on `RestApiTool`, alongside the inherited `attachment`
+config from `BaseTool`. Defined per-tool. `RestApiToolSet` gets an optional `response_as_attachment` field that serves as
+the default for all tools in the set; individual tools can override it. Override semantics are **full replacement**: if a
+tool defines `response_as_attachment`, the entire toolset default is ignored for that tool (no field-level merging).
+
+Note: `RestApiToolSet` currently has no toolset-level attachment defaults — this is new plumbing. `MCPToolSet` already has
+a similar pattern (toolset-level `attachment: AttachmentConfig` propagated in `_MCPToolInitializer`). The REST API
+propagation should follow the same approach: resolve the toolset default during tool initialization and copy it to each
+tool that doesn't define its own override.
 
 **Type:** config model with:
 
@@ -81,7 +97,7 @@ This cleanly supports three REST API response modes:
 | 2. Attachment only        | `true`    | `false`                   | Response as attachment, placeholder text content |
 | 3. Both text + attachment | `true`    | `true`                    | Response in both forms                           |
 
-Additional patterns (like "propagation only") emerge from combining `response_as_attachment` with `propagate_types_to_choice` — these are documented in the Configuration Recipes section below.
+Additional patterns (like "propagation only") emerge from combining `response_as_attachment` with `propagate_types_to_choice` — these are documented in the Configuration / Usage Examples section below.
 
 **Default behavior change:** `enabled=False` means REST API tools no longer silently duplicate responses as attachments.
 This is a breaking change for configs that rely on the current implicit behavior — a migration note is needed.
@@ -93,7 +109,10 @@ This is a breaking change for configs that rely on the current implicit behavior
 ### Deployment tool `input_attachment_types` mapping
 
 Currently `deployment.input_attachment_types` (what the deployment accepts as input) is mapped to `supported_types` (
-what the tool outputs). This is a semantic mismatch.
+what the tool outputs). This is a semantic mismatch — and also a **bug**: when a deployment has no
+`input_attachment_types`, `ToolConfigCoreService` sets `supported_types=deployment.input_attachment_types or []`, which
+evaluates to `[]`. Since `matches_type(mime_type, [])` returns `False` for all types, this silently blocks **all** output
+attachments from deployments that don't declare input types.
 
 **Fix:** When building a `DialDeploymentTool` from DIAL Core metadata:
 
@@ -134,9 +153,14 @@ attachment creation path, it's a natural time to fix it — but the fix (detecti
 
 ---
 
-## Configuration Recipes
+## Configuration / Usage Examples
 
 Common patterns that emerge from combining the orthogonal config fields:
+
+**REST API tool returning JSON data (text only — the new default, no config needed):**
+- `response_as_attachment` is omitted (defaults to `enabled = false`)
+- Result: HTTP response body is returned as `CompletionResult.content` text. No attachment is created. This is the most
+  common case for REST API tools that return structured data for the LLM to process.
 
 **REST API tool returning custom Plotly visualization (propagation only):**
 - `response_as_attachment.enabled = true`
@@ -157,28 +181,32 @@ Common patterns that emerge from combining the orthogonal config fields:
 
 ## Migration
 
-### Breaking change: REST API response-to-attachment default
+### Breaking changes
 
-The new default `response_as_attachment.enabled = false` means REST API tools no longer silently create attachments from
-every HTTP response. Configs that relied on this behavior need to explicitly opt in.
+**REST API response-to-attachment default.** The new default `response_as_attachment.enabled = false` means REST API
+tools no longer silently create attachments from every HTTP response. Configs that relied on this behavior need to
+explicitly opt in.
 
-**Backward compatibility strategy:** Log a warning **once at startup** (config load time) for REST API tools that don't
-explicitly set `response_as_attachment`. The message should be: "REST API tool X uses the default
-`response_as_attachment.enabled=false`. If you relied on automatic attachment creation, set `enabled=true` explicitly."
-Per-response warnings would fire on every single API call (since the old `*/*` default matched everything) and produce
-pure noise.
+**Backward compatibility strategy:** Log a warning **once at startup** (config load time) for REST API tools where
+`response_as_attachment` is absent from the config input. Detection uses Pydantic's `model_fields_set`: if
+`"response_as_attachment"` is not in the set, the field was never provided and the warning fires. If a user explicitly
+writes `response_as_attachment: {enabled: false}`, they made a deliberate choice and should **not** see the warning. The
+message should be: "REST API tool X uses the default `response_as_attachment.enabled=false`. If you relied on automatic
+attachment creation, set `enabled=true` explicitly." Per-response warnings would fire on every single API call (since
+the old `*/*` default matched everything) and produce pure noise.
 
-### No change: Deployment tools
+### Non-breaking changes
 
-Deployment tool defaults are preserved (`propagate_types_to_choice = []`). The only change is that `supported_types`
-defaults to `["*/*"]` instead of being derived from `input_attachment_types`, which means deployment output attachments
-are no longer silently filtered when the deployment doesn't declare input types.
+**Deployment tools.** Deployment tool defaults are preserved (`propagate_types_to_choice = []`). The only change is that
+`supported_types` defaults to `["*/*"]` instead of being derived from `input_attachment_types`, which means deployment
+output attachments are no longer silently filtered when the deployment doesn't declare input types.
 
-### No rename
+**Field naming.** `supported_types` field name is kept as-is. No config migration needed for existing users of this
+field.
 
-`supported_types` field name is kept as-is. No config migration needed for existing users of this field.
+---
 
-## Summary of Config Changes
+## Summary of Changes
 
 **`AttachmentConfig`** (all tool types):
 
@@ -196,3 +224,4 @@ are no longer silently filtered when the deployment doesn't declare input types.
 - Stop mapping `input_attachment_types` → `supported_types`; default to `["*/*"]`
 - Keep `propagate_types_to_choice = []` (intentional for deployment tools)
 - Use `input_attachment_types` only for controlling which attachments are forwarded to the deployment
+

--- a/src/quickapp/common/staged_base_tool.py
+++ b/src/quickapp/common/staged_base_tool.py
@@ -44,43 +44,31 @@ class StagedBaseTool(ABC, BaseModel, extra='allow'):
         raise NotImplementedError("Use only async version")
 
     async def arun(self, tool_call_id: str, *args: Any, **kwargs: Any) -> CompletionResult:
-        if (
-            self._tool_config
-            and self._tool_config.display
-            and self._tool_config.display.stage
-            and not self._tool_config.display.stage.show
-        ):
+        display = self._tool_config.display
+        if display and display.stage and not display.stage.show:
             return await self._run_in_stage_report_success(tool_call_id, None, *args, **kwargs)
-        else:
-            stage_wrapper = self.__stage_wrapper_builder.build(
-                tool_config=self._tool_config,
-                stage_name=self.stage_name_component,
-            )
-            with stage_wrapper:
-                try:
-                    return await self._run_in_stage_report_success(
-                        tool_call_id, stage_wrapper, *args, **kwargs
+
+        stage_wrapper = self.__stage_wrapper_builder.build(
+            tool_config=self._tool_config,
+            stage_name=self.stage_name_component,
+        )
+        with stage_wrapper:
+            try:
+                return await self._run_in_stage_report_success(
+                    tool_call_id, stage_wrapper, *args, **kwargs
+                )
+            except Exception as e:
+                logger.exception("Error occurred while running tool")
+                fallback = self._tool_config.fallback_configuration
+                if fallback.display_error_in_stage:
+                    stage_wrapper.add_exception(e)
+                else:
+                    stage_wrapper.add_exception(
+                        Exception("An error occurred while executing the tool.")
                     )
-                except Exception as e:
-                    logger.exception("Error occurred while running tool")
-                    if (
-                        self._tool_config
-                        and self._tool_config.fallback_configuration
-                        and self._tool_config.fallback_configuration.display_error_in_stage
-                    ):
-                        stage_wrapper.add_exception(e)
-                    else:
-                        stage_wrapper.add_exception(
-                            Exception("An error occurred while executing the tool.")
-                        )
-                    if self._tool_config and self._tool_config.fallback_configuration:
-                        return FallbackProcessor.process_fallback(
-                            self._tool_config.fallback_configuration.strategies, tool_call_id, e
-                        )
-                    raise e
+                return FallbackProcessor.process_fallback(fallback.strategies, tool_call_id, e)
 
     def _pre_process_params(self, **kwargs: Any) -> Any:
-        # No preprocessing of parameters by default. return parameters "as is"
         return kwargs
 
     async def _run_in_stage_report_success(
@@ -101,16 +89,16 @@ class StagedBaseTool(ABC, BaseModel, extra='allow'):
             result: CompletionResult = await self._run_in_stage_async(
                 stage_wrapper, *args, **params
             )
-            result.tool_call_id = tool_call_id  # Set result as response to specific tool call.
-            # filter attachments to fit only supported_attachments
+            result.tool_call_id = tool_call_id
             if result.attachments:
-                filtered_attachments = []
+                attachment_cfg = self._tool_config.attachment
+                filtered: list = []
                 for a in result.attachments:
-                    if matches_type(a.type, self._tool_config.attachment.supported_types):
-                        filtered_attachments.append(a)
-                    if matches_type(a.type, self._tool_config.attachment.propagate_types_to_choice):
-                        result.propagate_to_choice.append(a)
-                result.attachments = filtered_attachments
+                    if matches_type(a.type, attachment_cfg.supported_types):
+                        filtered.append(a)
+                        if matches_type(a.type, attachment_cfg.propagate_types_to_choice):
+                            result.propagate_to_choice.append(a)
+                result.attachments = filtered
             logger.debug(f"Tool call {tool_call_id} finished with result {result}")
 
             return result

--- a/src/quickapp/config/tools/base.py
+++ b/src/quickapp/config/tools/base.py
@@ -3,7 +3,7 @@ from enum import Enum
 from hashlib import sha256
 from typing import Annotated, Any, Generic, List, Literal, Optional, TypeVar, Union
 
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, Field, field_validator, model_validator
 
 from quickapp.config.tools.const import ALL_MIME_TYPES
 from quickapp.config.tools.display.paramenter import ParameterDisplayConfig
@@ -165,7 +165,7 @@ DEFAULT_PROPAGATE_TO_CHOICE = ["image/*", "application/vnd.plotly.v1+json"]
 
 
 class AttachmentConfig(BaseModel):
-    supported_types: Optional[List[str]] = Field(
+    supported_types: list[str] = Field(
         default_factory=lambda: [ALL_MIME_TYPES],
         description="List of supported attachment types.",
     )
@@ -174,12 +174,19 @@ class AttachmentConfig(BaseModel):
         description="List of attachment types to propagate from stage to choice.",
     )
 
-    @model_validator(mode='after')
-    def set_default_values(self):
-        # No need to set supported_types default here anymore
-        if not self.propagate_types_to_choice:
-            self.propagate_types_to_choice = DEFAULT_PROPAGATE_TO_CHOICE
-        return self
+    @field_validator("supported_types", mode="before")
+    @classmethod
+    def coerce_none_supported_types(cls, v: list[str] | None) -> list[str]:
+        if v is None:
+            return [ALL_MIME_TYPES]
+        return v
+
+    @field_validator("propagate_types_to_choice", mode="before")
+    @classmethod
+    def coerce_none_propagate_types(cls, v: list[str] | None) -> list[str]:
+        if v is None:
+            return DEFAULT_PROPAGATE_TO_CHOICE
+        return v
 
 
 class OpenAiToolConfig(

--- a/src/quickapp/config/tools/rest_api.py
+++ b/src/quickapp/config/tools/rest_api.py
@@ -10,6 +10,7 @@ from quickapp.config.tools.base import (
     ConfigurableSchemaObject,
     ConfigurableSchemaSimpleType,
 )
+from quickapp.config.tools.const import ALL_MIME_TYPES
 
 
 class ToolEndpointParamType(str, Enum):
@@ -56,6 +57,20 @@ class RestApiEndpointMethodInfo(BaseModel):
     method_type: ToolEndpointInfoMethodType
 
 
+class ResponseAsAttachmentConfig(BaseModel):
+    enabled: bool = Field(
+        default=False, description="Whether to wrap the HTTP response as an attachment."
+    )
+    content_types: list[str] = Field(
+        default_factory=lambda: [ALL_MIME_TYPES],
+        description="Which response Content-Types to convert to attachments.",
+    )
+    include_body_as_content: bool = Field(
+        default=True,
+        description="When an attachment is created, whether to also keep the response body as content.",
+    )
+
+
 class RestApiTool(
     BaseOpenAITool[
         RestApiEndpointObjectParam,
@@ -66,3 +81,7 @@ class RestApiTool(
 ):
     rest_api_method_info: RestApiEndpointMethodInfo
     type: Literal["restapi-tool"] = Field(default="restapi-tool")
+    response_as_attachment: ResponseAsAttachmentConfig | None = Field(
+        default=None,
+        description="Configuration for converting HTTP responses into attachments.",
+    )

--- a/src/quickapp/config/toolsets/rest_api.py
+++ b/src/quickapp/config/toolsets/rest_api.py
@@ -3,7 +3,7 @@ from typing import Annotated, List, Literal, Union
 from pydantic import Field
 
 from quickapp.config.tools.predefined import PredefinedTool
-from quickapp.config.tools.rest_api import RestApiTool
+from quickapp.config.tools.rest_api import ResponseAsAttachmentConfig, RestApiTool
 from quickapp.config.toolsets.authorization import (
     ApiKeyAuthorization,
     BasicAuthorization,
@@ -28,6 +28,10 @@ Authorization = Annotated[
 class RestApiToolSet(BaseToolSet):
     type: Literal["rest-api"] = Field(default="rest-api", description="The type of the tool set.")
     authorization: Authorization | None = None
+    response_as_attachment: ResponseAsAttachmentConfig | None = Field(
+        default=None,
+        description="Default response-as-attachment config for all tools in this toolset.",
+    )
     tools: List[RestApiTool | PredefinedTool] = Field(
         description="Tools with their configurations."
     )

--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -91,14 +91,13 @@ class ToolConfigCoreService:
             config: The JSON response from get_deployment_config (if available).
 
         Returns:
-            A dictionary representing the final tool configuration.
+            A DialDeploymentTool representing the final tool configuration.
         """
         output_tool = DialDeploymentTool(
             display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {deployment.id}: ")),
             deployment=DialDeploymentConfig(name=deployment.id),
             attachment=AttachmentConfig(
                 propagate_types_to_choice=[],
-                supported_types=deployment.input_attachment_types or [],
             ),
             fallback_configuration=ToolFallbackConfig(strategies=[ContinueStrategyModel()]),
             open_ai_tool=OpenAiToolConfig(
@@ -112,9 +111,8 @@ class ToolConfigCoreService:
             ),
         )
 
-        properties = dict[str, Any]()
-        required_params = []
-        # Always add the 'query' parameter
+        properties: dict[str, Any] = {}
+        required_params: list[str] = []
         properties["query"] = ConfigurableSchemaSimpleType(
             type=JsonTypeEnum.string,
             description="The query for the tool.",
@@ -124,8 +122,6 @@ class ToolConfigCoreService:
 
         # Handle attachments if the tool supports them
         if deployment.input_attachment_types:
-            if output_tool.attachment:
-                output_tool.attachment.supported_types = deployment.input_attachment_types
             properties["attachment_urls"] = ConfigurableSchemaArray(
                 type=JsonTypeEnum.array,
                 items=ConfigurableSchemaSimpleType(
@@ -153,15 +149,14 @@ class ToolConfigCoreService:
                 properties[param_name] = ConfigurableSchemaSimpleType(
                     type=JsonTypeEnum.string,
                     description=param_details.get("description", ""),
-                    enum=enum_values if enum_values else None,
+                    enum=enum_values or None,
                     default=enum_values[0] if enum_values else None,
                     display=ParameterDisplayConfig(stage=FormattedParameterConfig(ignore=True)),
                 )
                 required_params.append(param_name)
 
-        # Assign the dynamically generated properties and required list
         output_tool.open_ai_tool.function.parameters.properties = properties
-        output_tool.open_ai_tool.function.parameters.required = sorted(list(set(required_params)))
+        output_tool.open_ai_tool.function.parameters.required = sorted(set(required_params))
 
         return output_tool
 
@@ -175,7 +170,7 @@ class ToolConfigCoreService:
                 info_dict = await dial_core.get_toolset_info(toolset_dial_id)
                 return ToolsetInfo.model_validate(info_dict)
             except HTTPStatusError as e:
-                logger.exception(f"Something went wrong during getting toolset {toolset_dial_id}")
+                logger.exception("Something went wrong during getting toolset %s", toolset_dial_id)
                 if e.response.status_code == 404:
                     raise ToolsetNotFoundException(
                         toolset_id=toolset_dial_id,

--- a/src/quickapp/mcp_tooling/_mcp_tool.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool.py
@@ -86,18 +86,13 @@ class _MCPTool(StagedBaseTool):
                     data=getattr(resource, "blob", None),
                 )
             msg = f"Unsupported embedded resource type: {type(resource)}"
-            logger.exception(msg)
+            logger.error(msg)
             raise NotImplementedError(msg)
 
         return None
 
-    async def _maybe_upload_attachment(self, attachment: Attachment) -> Attachment:
-        if self._tool_config and matches_type(
-            attachment.type, self._tool_config.attachment.supported_types  # type: ignore[arg-type]
-        ):
-            logger.debug(f"Attachment: {attachment.title}, Tool Config: {self._tool_config}")
-            return await self.__dial_attachment_service.upload_attachment_to_core(attachment)
-        return attachment
+    def _should_upload(self, mime_type: str | None) -> bool:
+        return matches_type(mime_type, self._tool_config.attachment.supported_types)
 
     async def _run_in_stage_async(
         self, stage_wrapper: BaseStageWrapper | None, *args: Any, **kwargs: Any
@@ -128,7 +123,7 @@ class _MCPTool(StagedBaseTool):
                 logger.warning("Unsupported content block type: %s; treating as non-text", btype)
                 non_text_contents.append(block)
 
-        tool_content = "\n\n".join([p for p in text_parts if p]) or ""
+        tool_content = "\n\n".join(p for p in text_parts if p)
 
         logger.debug(
             "Tool returned text length %d and %d non-text content blocks",
@@ -139,8 +134,10 @@ class _MCPTool(StagedBaseTool):
         attachments = []
         for content in non_text_contents:
             attachment = self._content_to_attachment(content)
-            if attachment is not None:
-                attachment = await self._maybe_upload_attachment(attachment)
+            if attachment is not None and self._should_upload(attachment.type):
+                attachment = await self.__dial_attachment_service.upload_attachment_to_core(
+                    attachment
+                )
                 attachments.append(attachment)
 
         result = CompletionResult(

--- a/src/quickapp/rest_api_tooling/_rest_api_tool.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_tool.py
@@ -71,17 +71,13 @@ class _RestApiTool(StagedBaseTool):
             )
             response.raise_for_status()
 
-            raw_mime = response.headers.get('Content-Type', None)
-
+            raw_mime = response.headers.get('Content-Type')
             mime_type = raw_mime.split(';', 1)[0].strip() if raw_mime else None
 
-            attachments = []
+            attachments: list[Attachment] = []
+            rac = self._tool_config.response_as_attachment
 
-            if (
-                self._tool_config
-                and mime_type
-                and matches_type(mime_type, self._tool_config.attachment.supported_types)
-            ):
+            if rac and rac.enabled and mime_type and matches_type(mime_type, rac.content_types):
                 title = generate_attachment_filename(
                     mime_type, base_filename=self._tool_config.open_ai_tool.function.name
                 )
@@ -90,11 +86,14 @@ class _RestApiTool(StagedBaseTool):
                 attachment = await self.__dial_attachment_service.upload_attachment_to_core(
                     attachment
                 )
-
                 attachments.append(attachment)
 
+            content = response.text
+            if attachments and rac and not rac.include_body_as_content:
+                content = f"See attached file: {attachments[0].title}"
+
             result = CompletionResult(
-                content=response.text,
+                content=content,
                 content_type=response.headers.get('Content-Type', ""),
                 attachments=attachments,
             )

--- a/src/quickapp/rest_api_tooling/rest_api_tooling_module.py
+++ b/src/quickapp/rest_api_tooling/rest_api_tooling_module.py
@@ -6,6 +6,7 @@ from injector import Binder, ClassAssistedBuilder, Module, multiprovider
 from quickapp.common import StagedBaseTool
 from quickapp.common.oauth_token_fetcher import OAuthTokenFetcher
 from quickapp.config.application import ApplicationConfig
+from quickapp.config.tools.rest_api import RestApiTool
 from quickapp.config.toolsets.rest_api import RestApiToolSet
 
 from ._request_detail_builder import _RequestDetailsBuilder
@@ -28,19 +29,38 @@ class RestApiToolingModule(Module):
     def __provide_rest_api_tools(
         self, app_config: ApplicationConfig, tool_builder: ClassAssistedBuilder[_RestApiTool]
     ) -> list[StagedBaseTool]:
-        result = []
+        result: list[StagedBaseTool] = []
         for toolset_info in app_config.tool_sets:
             if isinstance(toolset_info, RestApiToolSet) and toolset_info.enabled:
-                for tool in self.__create_rest_api_tools(toolset_info, tool_builder):
-                    result.append(tool)
+                result.extend(self.__create_rest_api_tools(toolset_info, tool_builder))
         return result
 
     @staticmethod
     def __create_rest_api_tools(
         rest_api_toolset: RestApiToolSet, tool_builder: ClassAssistedBuilder[_RestApiTool]
     ) -> list[StagedBaseTool]:
-        return [
-            tool_builder.build(tool_config=tool_config, auth_info=rest_api_toolset.authorization)
-            for tool_config in rest_api_toolset.tools
-            if tool_config.enabled
-        ]
+        result: list[StagedBaseTool] = []
+        for tool_config in rest_api_toolset.tools:
+            if not tool_config.enabled:
+                continue
+            if isinstance(tool_config, RestApiTool):
+                if (
+                    "response_as_attachment" not in tool_config.model_fields_set
+                    and rest_api_toolset.response_as_attachment is not None
+                ):
+                    tool_config = tool_config.model_copy(
+                        update={"response_as_attachment": rest_api_toolset.response_as_attachment}
+                    )
+                if "response_as_attachment" not in tool_config.model_fields_set:
+                    logger.warning(
+                        "REST API tool '%s' uses the default response_as_attachment.enabled=false. "
+                        "If you relied on automatic attachment creation, "
+                        "set enabled=true explicitly.",
+                        tool_config.open_ai_tool.function.name,
+                    )
+            result.append(
+                tool_builder.build(
+                    tool_config=tool_config, auth_info=rest_api_toolset.authorization
+                )
+            )
+        return result

--- a/src/tests/unit_tests/common/test_staged_base_tool.py
+++ b/src/tests/unit_tests/common/test_staged_base_tool.py
@@ -2,37 +2,50 @@ from typing import Any
 from unittest.mock import Mock
 
 import pytest
+from aidial_sdk.chat_completion import Attachment
 
 from injector import AssistedBuilder
 
 from quickapp.common import StagedBaseTool, CompletionResult
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
+from quickapp.config.tools.base import AttachmentConfig
 from quickapp.config.tools.tool import AnyTool
 from quickapp.config.tools.tool_fallback import ToolFallbackConfig
 
 
 class CustomTestStagedBaseTool(StagedBaseTool):
 
-    def __init__(self, stage_wrapper_builder: AssistedBuilder[BaseStageWrapper], tool_config: AnyTool, perf_timer: PerformanceTimer):
+    def __init__(
+        self,
+        stage_wrapper_builder: AssistedBuilder[BaseStageWrapper],
+        tool_config: AnyTool,
+        perf_timer: PerformanceTimer,
+        result_to_return: CompletionResult | None = None,
+    ):
         super().__init__(
             stage_wrapper_builder=stage_wrapper_builder,
             tool_config=tool_config,
             name="Test Tool",
             description="A test tool",
-            perf_timer=perf_timer
+            perf_timer=perf_timer,
         )
+        self._result_to_return = result_to_return
 
-    async def _run_in_stage_async(self, stage_wrapper, *args: Any, **kwargs: Any) -> CompletionResult:
-        return CompletionResult(
-            content="response content", content_type="application/json"
-        )
+    async def _run_in_stage_async(
+        self, stage_wrapper, *args: Any, **kwargs: Any
+    ) -> CompletionResult:
+        if self._result_to_return is not None:
+            return self._result_to_return
+        return CompletionResult(content="response content", content_type="application/json")
 
 
 @pytest.fixture
 def mock_stage_wrapper_factory():
     mock_stage_wrapper = Mock(spec=BaseStageWrapper)
+    mock_stage_wrapper.name = "test_stage"
     mock_stage_wrapper.add_parameters = Mock()
+    mock_stage_wrapper.add_result = Mock()
     mock_stage_wrapper.add_exception = Mock()
     mock_stage_wrapper.__enter__ = Mock(return_value=mock_stage_wrapper)
     mock_stage_wrapper.__exit__ = Mock(return_value=False)
@@ -45,29 +58,71 @@ def mock_stage_wrapper_factory():
 def mock_tool_config():
     mock_config = Mock(spec=AnyTool)
     mock_config.display = None
-    mock_config.fallback_configuration = ToolFallbackConfig(display_error_in_stage=True) # Add this line
+    mock_config.fallback_configuration = ToolFallbackConfig(display_error_in_stage=True)
     return mock_config
 
 
 @pytest.mark.asyncio
 async def test_exception_handled_in_staged_base_tool(mock_stage_wrapper_factory, mock_tool_config):
-    tool = CustomTestStagedBaseTool(stage_wrapper_builder=mock_stage_wrapper_factory, tool_config=mock_tool_config, perf_timer=Mock())
+    tool = CustomTestStagedBaseTool(
+        stage_wrapper_builder=mock_stage_wrapper_factory,
+        tool_config=mock_tool_config,
+        perf_timer=Mock(),
+    )
     ex = Exception("Test exception")
     mock_stage_wrapper = mock_stage_wrapper_factory.build()
     mock_stage_wrapper.add_parameters.side_effect = ex
-    ex_caught = False
-    try:
-        await tool.arun("tool_call_id_1",**{"param1": "value1"})
-    except Exception as e:
-        ex_caught = True
 
-    assert ex_caught == False
+    result = await tool.arun("tool_call_id_1", **{"param1": "value1"})
+    assert result is not None
 
 
 @pytest.mark.asyncio
 async def test_exception_on_run(mock_stage_wrapper_factory, mock_tool_config):
-    tool = CustomTestStagedBaseTool(stage_wrapper_builder=mock_stage_wrapper_factory, tool_config=mock_tool_config, perf_timer=Mock())
-    try:
+    tool = CustomTestStagedBaseTool(
+        stage_wrapper_builder=mock_stage_wrapper_factory,
+        tool_config=mock_tool_config,
+        perf_timer=Mock(),
+    )
+    with pytest.raises(NotImplementedError):
         tool._run("tool_call_id_1", **{"param1": "value1"})
-    except Exception as e:
-        assert isinstance(e, NotImplementedError)
+
+
+@pytest.mark.asyncio
+async def test_propagation_only_for_surviving_attachments(mock_stage_wrapper_factory):
+    """An attachment that fails supported_types but matches propagate_types_to_choice
+    should NOT be added to propagate_to_choice."""
+    mock_config = Mock()
+    mock_config.display = None
+    mock_config.fallback_configuration = ToolFallbackConfig(display_error_in_stage=True)
+    mock_config.attachment = AttachmentConfig(
+        supported_types=["image/*"],
+        propagate_types_to_choice=["image/*", "text/plain"],
+    )
+
+    image_attachment = Attachment(type="image/png", title="image.png", data="img_data")
+    text_attachment = Attachment(type="text/plain", title="readme.txt", data="text_data")
+
+    result_to_return = CompletionResult(
+        content="result",
+        content_type="text/plain",
+        attachments=[image_attachment, text_attachment],
+    )
+
+    tool = CustomTestStagedBaseTool(
+        stage_wrapper_builder=mock_stage_wrapper_factory,
+        tool_config=mock_config,
+        perf_timer=Mock(),
+        result_to_return=result_to_return,
+    )
+
+    result = await tool.arun("call-1")
+
+    # text/plain fails supported_types=["image/*"], so only image survives
+    assert len(result.attachments) == 1
+    assert result.attachments[0].type == "image/png"
+
+    # text/plain matches propagate_types_to_choice but was filtered out by supported_types,
+    # so it should NOT appear in propagate_to_choice
+    assert len(result.propagate_to_choice) == 1
+    assert result.propagate_to_choice[0].type == "image/png"

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+from quickapp.config.tools.const import ALL_MIME_TYPES
+from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
+
+
+def _make_deployment(
+    deployment_id: str = "test-deployment",
+    description: str = "A test deployment",
+    input_attachment_types: list[str] | None = None,
+):
+    """Create a minimal deployment-like object for ToolConfigCoreService."""
+    return SimpleNamespace(
+        id=deployment_id,
+        description=description,
+        input_attachment_types=input_attachment_types,
+        features=None,
+    )
+
+
+def test_supported_types_defaults_to_all_when_no_input_attachment_types():
+    deployment = _make_deployment(input_attachment_types=None)
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+
+    assert result.attachment.supported_types == [ALL_MIME_TYPES]
+
+
+def test_supported_types_defaults_to_all_when_empty_input_attachment_types():
+    deployment = _make_deployment(input_attachment_types=[])
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+
+    # Even with empty input_attachment_types, supported_types should default to all
+    assert result.attachment.supported_types == [ALL_MIME_TYPES]
+
+
+def test_propagate_types_to_choice_is_empty_for_deployment_tools():
+    deployment = _make_deployment(input_attachment_types=["image/*"])
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+
+    assert result.attachment.propagate_types_to_choice == []
+
+
+def test_input_attachment_types_adds_attachment_urls_param():
+    deployment = _make_deployment(input_attachment_types=["image/*"])
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+
+    assert "attachment_urls" in result.open_ai_tool.function.parameters.properties
+
+
+def test_no_input_attachment_types_no_attachment_urls_param():
+    deployment = _make_deployment(input_attachment_types=None)
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+
+    assert "attachment_urls" not in result.open_ai_tool.function.parameters.properties

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
@@ -15,6 +15,7 @@ from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.config.application import ApplicationConfig
+from quickapp.config.tools.base import AttachmentConfig
 from quickapp.config.toolsets.mcp import MCPToolSet, MCPServerInfo, MCPProtocol
 from quickapp.dial_core_services.attachment_service import AttachmentService
 from quickapp.mcp_tooling import MCPToolingModule
@@ -215,6 +216,99 @@ class MCPToolTest(unittest.IsolatedAsyncioTestCase):
                     ],
                 ),
             )
+
+        client = TestClient(app)
+        response = client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+    @patch(
+        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool",
+        new_callable=AsyncMock,
+    )
+    @patch(
+        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list",
+        new_callable=AsyncMock,
+    )
+    async def test_mcp_tool_narrow_supported_types_skips_non_matching(
+        self, mock_get_tools_list, mock_call_mcp_tool
+    ):
+        """Non-matching attachments are neither uploaded nor appended to the result."""
+        tool_1 = SimpleNamespace(name="img_tool", description="Image tool", inputSchema={})
+        mock_get_tools_list.return_value = [tool_1]
+
+        mock_stage = MagicMock(spec=Stage)
+        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock()
+
+        async def mock_upload(attachment):
+            attachment.url = "mocked_url"
+            attachment.data = None
+            attachment.title = "Attachment"
+            return attachment
+
+        mock_dial_attachment_service.upload_attachment_to_core.side_effect = mock_upload
+
+        # Tool returns both image and text attachments
+        async def _call_side_effect(tool_name, **kwargs):
+            tr = TextResourceContents(
+                mimeType="text/plain", text="some_text", uri=AnyUrl("https://example")
+            )
+            return SimpleNamespace(
+                content=[
+                    ImageContent(
+                        mimeType="image/png",
+                        data=base64.b64encode(b"img").decode("utf-8"),
+                        type="image",
+                    ),
+                    EmbeddedResource(resource=tr, type="resource"),
+                ],
+                isError=False,
+            )
+
+        mock_call_mcp_tool.side_effect = _call_side_effect
+
+        # Only allow image/* — text/plain should be skipped entirely
+        mcp_toolset = MCPToolSet(
+            type="mcp",
+            mcp_server_info=MCPServerInfo(
+                url="https://test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+            ),
+            name="mcp-toolset",
+            description="MCP toolset",
+            attachment=AttachmentConfig(supported_types=["image/*"]),
+        )
+
+        def configure(binder: Binder) -> None:
+            binder.bind(Stage, to=mock_stage)
+            binder.bind(DialSettings, DialSettings(url="https://core"))
+            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+            binder.bind(AttachmentService, mock_dial_attachment_service)
+            binder.bind(
+                ApplicationConfig,
+                to=create_app_configuration([mcp_toolset]),
+            )
+            binder.bind(PerformanceTimer, to=PerformanceTimer)
+
+        app = create_test_app([MCPToolingModule, configure])
+
+        @app.get("/")
+        async def get_method(injector: Injector = Injected(Injector)):
+            initializers = injector.get(list[CompletionInitializer])
+            await initializers[0].initialize()
+
+            tools = injector.get(list[StagedBaseTool])
+            self.assertEqual(len(tools), 1)
+
+            result = await tools[0].arun("call-1")
+
+            # Only image should survive — text/plain is skipped by _should_upload
+            self.assertIsNotNone(result.attachments)
+            self.assertEqual(len(result.attachments), 1)
+            self.assertEqual(result.attachments[0].type, "image/png")
+
+            # Upload should only be called once (for the image)
+            self.assertEqual(mock_dial_attachment_service.upload_attachment_to_core.call_count, 1)
 
         client = TestClient(app)
         response = client.get("/")

--- a/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
+++ b/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
@@ -18,6 +18,7 @@ from quickapp.config.tools.base import (
     OpenAiToolFunctionParameters,
 )
 from quickapp.config.tools.rest_api import (
+    ResponseAsAttachmentConfig,
     RestApiTool,
     RestApiEndpointMethodInfo,
     RestApiEndpointSimpleTypeParam,
@@ -26,9 +27,37 @@ from quickapp.config.tools.rest_api import (
 )
 from quickapp.config.toolsets.authorization import BearerAuthorization
 from quickapp.config.toolsets.rest_api import RestApiToolSet
+from quickapp.dial_core_services.attachment_service import AttachmentService
 from quickapp.rest_api_tooling import RestApiToolingModule
 from tests.unit_tests.common import create_test_app
 from tests.unit_tests.common.common import create_app_configuration
+
+
+def _make_rest_api_tool(url: str, method: str, **tool_kwargs) -> RestApiTool:
+    return RestApiTool(
+        rest_api_method_info=RestApiEndpointMethodInfo(
+            method_url=url, method_type=method
+        ),
+        open_ai_tool=OpenAiToolConfig(
+            function=OpenAiToolFunction(
+                name="test_function",
+                description="Test function",
+                parameters=OpenAiToolFunctionParameters(
+                    properties={
+                        "query_key": RestApiEndpointSimpleTypeParam(
+                            type="string",
+                            description="Query key",
+                            parameter_info=RestApiEndpointHeaderParamInfo(
+                                type=ToolEndpointParamType.query, key="query_key"
+                            ),
+                        )
+                    },
+                    type="object",
+                ),
+            )
+        ),
+        **tool_kwargs,
+    )
 
 
 class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
@@ -81,7 +110,6 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
             binder.bind(DialSettings, DialSettings(url="https://core"))
             binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
             binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            # binder.bind(AttachmentService, mock_dial_attachment_service)
             binder.bind(Stage, to=mock_stage)
             binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
 
@@ -94,15 +122,11 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
 
             result = await tool.arun("call-1", None, **{"query_key": "query_value"})
 
-            # Validate core completion result properties without asserting on auto-generated attachment filenames
+            # With default response_as_attachment (None/disabled), no attachment is created
             self.assertEqual(result.tool_call_id, "call-1")
             self.assertEqual(result.content, '{"some_key":"some value"}')
             self.assertEqual(result.content_type, "application/json")
-            self.assertIsNotNone(result.attachments)
-            self.assertEqual(len(result.attachments), 1)
-            self.assertIsInstance(result.attachments[0], Attachment)
-            self.assertEqual(result.attachments[0].type, "application/json")
-            self.assertEqual(result.attachments[0].data, '{"some_key":"some value"}')
+            self.assertEqual(result.attachments, [])
 
             return {"message": "success"}
 
@@ -129,3 +153,176 @@ class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
         )
         self.assertIn("Authorization", actual_request_data["headers"])
         self.assertEqual("Bearer test_token", actual_request_data["headers"]["Authorization"])
+
+    @patch("httpx.AsyncClient")
+    async def test_response_as_attachment_enabled_creates_attachment(self, mock_async_client):
+        url = "https://example.com/api"
+        mock_stage = MagicMock(spec=Stage)
+        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+
+        async def mock_upload(attachment):
+            return attachment
+
+        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
+            side_effect=mock_upload
+        )
+
+        response_data = {
+            "text": '{"data": "value"}',
+            "headers": {"Content-Type": "application/json"},
+        }
+        mock_response = AsyncMock(**response_data)
+        mock_response.raise_for_status = MagicMock()
+        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
+
+        rest_api_toolset = RestApiToolSet(
+            name="rest-api",
+            authorization=BearerAuthorization(token="test_token"),
+            tools=[
+                _make_rest_api_tool(
+                    url,
+                    "get",
+                    response_as_attachment=ResponseAsAttachmentConfig(enabled=True),
+                )
+            ],
+        )
+
+        def configure(binder: Binder):
+            binder.bind(DialSettings, DialSettings(url="https://core"))
+            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+            binder.bind(AttachmentService, mock_dial_attachment_service)
+            binder.bind(Stage, to=mock_stage)
+            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+
+        app = create_test_app([RestApiToolingModule, configure])
+
+        @app.get("/")
+        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+            self.assertEqual(len(tools), 1)
+            result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+
+            self.assertEqual(result.tool_call_id, "call-1")
+            self.assertEqual(result.content, '{"data": "value"}')
+            self.assertIsNotNone(result.attachments)
+            self.assertEqual(len(result.attachments), 1)
+            self.assertIsInstance(result.attachments[0], Attachment)
+            self.assertEqual(result.attachments[0].type, "application/json")
+            return {"message": "success"}
+
+        client = TestClient(app)
+        response = client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+    @patch("httpx.AsyncClient")
+    async def test_response_as_attachment_include_body_as_content_false(self, mock_async_client):
+        url = "https://example.com/api"
+        mock_stage = MagicMock(spec=Stage)
+        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+
+        async def mock_upload(attachment):
+            return attachment
+
+        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
+            side_effect=mock_upload
+        )
+
+        response_data = {
+            "text": '{"data": "value"}',
+            "headers": {"Content-Type": "application/json"},
+        }
+        mock_response = AsyncMock(**response_data)
+        mock_response.raise_for_status = MagicMock()
+        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
+
+        rest_api_toolset = RestApiToolSet(
+            name="rest-api",
+            authorization=BearerAuthorization(token="test_token"),
+            tools=[
+                _make_rest_api_tool(
+                    url,
+                    "get",
+                    response_as_attachment=ResponseAsAttachmentConfig(
+                        enabled=True, include_body_as_content=False
+                    ),
+                )
+            ],
+        )
+
+        def configure(binder: Binder):
+            binder.bind(DialSettings, DialSettings(url="https://core"))
+            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+            binder.bind(AttachmentService, mock_dial_attachment_service)
+            binder.bind(Stage, to=mock_stage)
+            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+
+        app = create_test_app([RestApiToolingModule, configure])
+
+        @app.get("/")
+        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+            self.assertEqual(len(tools), 1)
+            result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+
+            self.assertEqual(result.tool_call_id, "call-1")
+            self.assertTrue(result.content.startswith("See attached file:"))
+            self.assertEqual(len(result.attachments), 1)
+            return {"message": "success"}
+
+        client = TestClient(app)
+        response = client.get("/")
+        self.assertEqual(response.status_code, 200)
+
+    @patch("httpx.AsyncClient")
+    async def test_toolset_level_response_as_attachment_propagation(self, mock_async_client):
+        url = "https://example.com/api"
+        mock_stage = MagicMock(spec=Stage)
+        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+
+        async def mock_upload(attachment):
+            return attachment
+
+        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
+            side_effect=mock_upload
+        )
+
+        response_data = {
+            "text": '{"data": "value"}',
+            "headers": {"Content-Type": "application/json"},
+        }
+        mock_response = AsyncMock(**response_data)
+        mock_response.raise_for_status = MagicMock()
+        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
+
+        # Tool does NOT set response_as_attachment, but toolset does
+        rest_api_toolset = RestApiToolSet(
+            name="rest-api",
+            authorization=BearerAuthorization(token="test_token"),
+            response_as_attachment=ResponseAsAttachmentConfig(enabled=True),
+            tools=[_make_rest_api_tool(url, "get")],
+        )
+
+        def configure(binder: Binder):
+            binder.bind(DialSettings, DialSettings(url="https://core"))
+            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+            binder.bind(AttachmentService, mock_dial_attachment_service)
+            binder.bind(Stage, to=mock_stage)
+            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+
+        app = create_test_app([RestApiToolingModule, configure])
+
+        @app.get("/")
+        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+            self.assertEqual(len(tools), 1)
+            result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+
+            self.assertEqual(result.tool_call_id, "call-1")
+            self.assertIsNotNone(result.attachments)
+            self.assertEqual(len(result.attachments), 1)
+            self.assertEqual(result.attachments[0].type, "application/json")
+            return {"message": "success"}
+
+        client = TestClient(app)
+        response = client.get("/")
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
### Applicable issues

- fixes #101 

### Description of changes

Decomposes the overloaded `supported_types` field on `AttachmentConfig` into three orthogonal concerns per the [design doc](docs/designs/attachment_config_redesign.md).

**Bug fixes:**
- `propagate_types_to_choice` leaked filtered attachments to UI — nested check under `supported_types`
- Deployment `input_attachment_types` was incorrectly mapped to output `supported_types`, blocking all output when empty — now defaults to `["*/*"]`
- `propagate_types_to_choice: []` was silently overridden to defaults — replaced `model_validator` with `field_validator`
- Made `supported_types` non-optional (`list[str]`, coerces `None` to `["*/*"]`)

**New: `ResponseAsAttachmentConfig` for REST API tools:**
- `enabled` (default `false`), `content_types`, `include_body_as_content`
- Configurable at tool and toolset level (toolset defaults propagate to tools)
- Startup warning for tools without explicit config

**MCP upload gating:** replaced `_maybe_upload_attachment` with `_should_upload` that gates both upload and append.

**Breaking:** REST API tools no longer silently create attachments from every response. Set `response_as_attachment: {enabled: true}` to restore previous behavior.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
