### PR TITLE
fix: enhance tool call accumulation logic when streaming #107

### DIFF
--- a/src/quickapp/agent/_models/__init__.py
+++ b/src/quickapp/agent/_models/__init__.py
@@ -1,0 +1,2 @@
+from .accumulated_tool_call import AccumulatedToolCall
+from .assistant_call_result import AssistantCallResult, Usage

--- a/src/quickapp/agent/_models/accumulated_tool_call.py
+++ b/src/quickapp/agent/_models/accumulated_tool_call.py
@@ -1,0 +1,51 @@
+from aidial_sdk.chat_completion import FunctionCall, ToolCall
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
+
+
+class AccumulatedToolCall:
+    def __init__(self) -> None:
+        self._id: str | None = None
+        self._name: str | None = None
+        self._arguments: str | None = None
+
+    @property
+    def id(self) -> str:
+        if self._id is None:
+            raise ValueError("Tool call id has not been received yet")
+        return self._id
+
+    @property
+    def name(self) -> str:
+        if self._name is None:
+            raise ValueError("Tool call name has not been received yet")
+        return self._name
+
+    @property
+    def arguments(self) -> str:
+        if self._arguments is None:
+            raise ValueError("Tool call arguments have not been received yet")
+        return self._arguments
+
+    def append_delta(self, delta: ChoiceDeltaToolCall) -> None:
+        def append_field(current: str | None, chunk: str | None) -> str | None:
+            if chunk is None:
+                return current
+            return chunk if current is None else current + chunk
+
+        self._id = append_field(self._id, delta.id)
+        if delta.function:
+            self._name = append_field(self._name, delta.function.name)
+            self._arguments = append_field(self._arguments, delta.function.arguments)
+
+    def to_sdk_tool_call(self):
+        return ToolCall(
+            id=self.id,
+            type="function",
+            function=FunctionCall(name=self.name, arguments=self.arguments),
+        )
+
+    @staticmethod
+    def to_sdk_tool_calls(tool_calls: list["AccumulatedToolCall"] | None) -> list[ToolCall] | None:
+        if tool_calls is None:
+            return None
+        return [tc.to_sdk_tool_call() for tc in tool_calls]

--- a/src/quickapp/agent/_models/assistant_call_result.py
+++ b/src/quickapp/agent/_models/assistant_call_result.py
@@ -1,0 +1,50 @@
+from aidial_sdk.chat_completion import Attachment
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
+
+from .accumulated_tool_call import AccumulatedToolCall
+
+
+class Usage:
+    def __init__(self, prompt_tokens: int, completion_tokens: int):
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class AssistantCallResult:
+    def __init__(self):
+        self.__content = ""
+        self.__attachments: list[Attachment] = []
+        self.__accumulated_tool_calls: dict[int, AccumulatedToolCall] = {}
+        self.__usage: Usage | None = None
+
+    @property
+    def content(self):
+        return self.__content
+
+    def append_content(self, content: str) -> None:
+        self.__content += content
+
+    @property
+    def attachments(self):
+        return self.__attachments
+
+    def append_attachment(self, attachment: Attachment) -> None:
+        self.__attachments.append(attachment)
+
+    @property
+    def tool_calls(self) -> list[AccumulatedToolCall] | None:
+        values = list(self.__accumulated_tool_calls.values())
+        return values if values else None
+
+    def append_tool_call_delta(self, tool_call_delta: ChoiceDeltaToolCall) -> None:
+        index = tool_call_delta.index
+        if index not in self.__accumulated_tool_calls:
+            self.__accumulated_tool_calls[index] = AccumulatedToolCall()
+        self.__accumulated_tool_calls[index].append_delta(tool_call_delta)
+
+    @property
+    def usage(self):
+        return self.__usage
+
+    def set_usage(self, usage: Usage) -> None:
+        self.__usage = usage

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from aidial_sdk.chat_completion import Attachment, Choice, Stage, ToolCall
+from aidial_sdk.chat_completion import Attachment, Choice, FunctionCall, Stage, ToolCall
 from injector import inject
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
@@ -18,7 +18,7 @@ class AssistantCallResult:
     def __init__(self):
         self.__content = ""
         self.__attachments: list[Attachment] = []
-        self.__tool_calls: Dict[int, ToolCall] = {}
+        self.__tool_calls_data: Dict[int, Dict[str, Any]] = {}
         self.__usage: Optional[Usage] = None
 
     @property
@@ -37,18 +37,43 @@ class AssistantCallResult:
 
     @property
     def tool_calls(self):
-        values = list(self.__tool_calls.values())
-        return values if values else None
+        if not self.__tool_calls_data:
+            return None
+
+        # Convert accumulated dict data to ToolCall objects
+        tool_calls = []
+        for data in self.__tool_calls_data.values():
+            tool_calls.append(ToolCall(
+                id=data['id'],
+                type=data['type'],
+                function=FunctionCall(
+                    name=data['function']['name'],
+                    arguments=data['function']['arguments']
+                )
+            ))
+        return tool_calls
 
     def append_tool_call_delta(self, tool_call_delta: ChoiceDeltaToolCall) -> None:
+        index = tool_call_delta.index
+
+        # Initialize tool call data if this is the first delta (has id)
         if tool_call_delta.id:
-            tool_call = ToolCall(**tool_call_delta.model_dump())
-            self.__tool_calls[tool_call_delta.index] = tool_call
+            self.__tool_calls_data[index] = {
+                'id': tool_call_delta.id,
+                'type': tool_call_delta.type,
+                'function': {
+                    'name': tool_call_delta.function.name if tool_call_delta.function else None,
+                    'arguments': ''
+                }
+            }
         else:
-            tool_call = self.__tool_calls[tool_call_delta.index]
-            if tool_call_delta.function:
-                argument_chunk = tool_call_delta.function.arguments or ''
-                tool_call.function.arguments += argument_chunk
+            # Update existing tool call data
+            if index in self.__tool_calls_data:
+                if tool_call_delta.function:
+                    if tool_call_delta.function.name:
+                        self.__tool_calls_data[index]['function']['name'] = tool_call_delta.function.name
+                    if tool_call_delta.function.arguments:
+                        self.__tool_calls_data[index]['function']['arguments'] += tool_call_delta.function.arguments
 
     @property
     def usage(self):

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -43,14 +43,15 @@ class AssistantCallResult:
         # Convert accumulated dict data to ToolCall objects
         tool_calls = []
         for data in self.__tool_calls_data.values():
-            tool_calls.append(ToolCall(
-                id=data['id'],
-                type=data['type'],
-                function=FunctionCall(
-                    name=data['function']['name'],
-                    arguments=data['function']['arguments']
+            tool_calls.append(
+                ToolCall(
+                    id=data['id'],
+                    type=data['type'],
+                    function=FunctionCall(
+                        name=data['function']['name'], arguments=data['function']['arguments']
+                    ),
                 )
-            ))
+            )
         return tool_calls
 
     def append_tool_call_delta(self, tool_call_delta: ChoiceDeltaToolCall) -> None:
@@ -63,17 +64,21 @@ class AssistantCallResult:
                 'type': tool_call_delta.type,
                 'function': {
                     'name': tool_call_delta.function.name if tool_call_delta.function else None,
-                    'arguments': ''
-                }
+                    'arguments': '',
+                },
             }
         else:
             # Update existing tool call data
             if index in self.__tool_calls_data:
                 if tool_call_delta.function:
                     if tool_call_delta.function.name:
-                        self.__tool_calls_data[index]['function']['name'] = tool_call_delta.function.name
+                        self.__tool_calls_data[index]['function'][
+                            'name'
+                        ] = tool_call_delta.function.name
                     if tool_call_delta.function.arguments:
-                        self.__tool_calls_data[index]['function']['arguments'] += tool_call_delta.function.arguments
+                        self.__tool_calls_data[index]['function'][
+                            'arguments'
+                        ] += tool_call_delta.function.arguments
 
     @property
     def usage(self):

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from aidial_sdk.chat_completion import Attachment, Choice, FunctionCall, Stage, ToolCall
+from aidial_sdk.chat_completion import Attachment, Choice, Stage
 from injector import inject
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
@@ -14,11 +14,44 @@ class Usage:
         self.completion_tokens = completion_tokens
 
 
+class AccumulatedToolCall:
+    def __init__(self) -> None:
+        self.id: str = ""
+        self.type: str = "function"
+        self._name: str | None = None
+        self._arguments: str | None = None
+
+    @property
+    def name(self) -> str:
+        if self._name is None:
+            raise ValueError("Tool call name has not been received yet")
+        return self._name
+
+    @property
+    def arguments(self) -> str:
+        if self._arguments is None:
+            raise ValueError("Tool call arguments have not been received yet")
+        return self._arguments
+
+    def append_delta(self, delta: ChoiceDeltaToolCall) -> None:
+        if delta.id:
+            self.id = delta.id
+        if delta.type:
+            self.type = delta.type
+        if delta.function:
+            if delta.function.name:
+                self._name = delta.function.name
+            if delta.function.arguments:
+                if self._arguments is None:
+                    self._arguments = ""
+                self._arguments += delta.function.arguments
+
+
 class AssistantCallResult:
     def __init__(self):
         self.__content = ""
         self.__attachments: list[Attachment] = []
-        self.__tool_calls_data: Dict[int, Dict[str, Any]] = {}
+        self.__accumulated_tool_calls: Dict[int, AccumulatedToolCall] = {}
         self.__usage: Optional[Usage] = None
 
     @property
@@ -36,49 +69,15 @@ class AssistantCallResult:
         self.__attachments.append(attachment)
 
     @property
-    def tool_calls(self):
-        if not self.__tool_calls_data:
-            return None
-
-        # Convert accumulated dict data to ToolCall objects
-        tool_calls = []
-        for data in self.__tool_calls_data.values():
-            tool_calls.append(
-                ToolCall(
-                    id=data['id'],
-                    type=data['type'],
-                    function=FunctionCall(
-                        name=data['function']['name'], arguments=data['function']['arguments']
-                    ),
-                )
-            )
-        return tool_calls
+    def tool_calls(self) -> list[AccumulatedToolCall] | None:
+        values = list(self.__accumulated_tool_calls.values())
+        return values if values else None
 
     def append_tool_call_delta(self, tool_call_delta: ChoiceDeltaToolCall) -> None:
         index = tool_call_delta.index
-
-        # Initialize tool call data if this is the first delta (has id)
-        if tool_call_delta.id:
-            self.__tool_calls_data[index] = {
-                'id': tool_call_delta.id,
-                'type': tool_call_delta.type,
-                'function': {
-                    'name': tool_call_delta.function.name if tool_call_delta.function else None,
-                    'arguments': '',
-                },
-            }
-        else:
-            # Update existing tool call data
-            if index in self.__tool_calls_data:
-                if tool_call_delta.function:
-                    if tool_call_delta.function.name:
-                        self.__tool_calls_data[index]['function'][
-                            'name'
-                        ] = tool_call_delta.function.name
-                    if tool_call_delta.function.arguments:
-                        self.__tool_calls_data[index]['function'][
-                            'arguments'
-                        ] += tool_call_delta.function.arguments
+        if index not in self.__accumulated_tool_calls:
+            self.__accumulated_tool_calls[index] = AccumulatedToolCall()
+        self.__accumulated_tool_calls[index].append_delta(tool_call_delta)
 
     @property
     def usage(self):
@@ -158,7 +157,7 @@ class ChunkProcessor:
         if result.tool_calls:
             logger.debug(" ------ tool_calls:")
             for tool in result.tool_calls:
-                logger.debug(f" -------- {tool.function.name} - {tool.function.arguments} - {tool}")
+                logger.debug(f" -------- {tool.name} - {tool.arguments} - {tool}")
 
         if result.attachments:
             logger.debug(f" ------ attachments: {result.attachments}")

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -16,10 +16,15 @@ class Usage:
 
 class AccumulatedToolCall:
     def __init__(self) -> None:
-        self.id: str = ""
-        self.type: str = "function"
+        self._id: str | None = None
         self._name: str | None = None
         self._arguments: str | None = None
+
+    @property
+    def id(self) -> str:
+        if self._id is None:
+            raise ValueError("Tool call id has not been received yet")
+        return self._id
 
     @property
     def name(self) -> str:
@@ -34,17 +39,15 @@ class AccumulatedToolCall:
         return self._arguments
 
     def append_delta(self, delta: ChoiceDeltaToolCall) -> None:
-        if delta.id:
-            self.id = delta.id
-        if delta.type:
-            self.type = delta.type
+        def append_field(current: str | None, chunk: str | None) -> str | None:
+            if chunk is None:
+                return current
+            return chunk if current is None else current + chunk
+
+        self._id = append_field(self._id, delta.id)
         if delta.function:
-            if delta.function.name:
-                self._name = delta.function.name
-            if delta.function.arguments:
-                if self._arguments is None:
-                    self._arguments = ""
-                self._arguments += delta.function.arguments
+            self._name = append_field(self._name, delta.function.name)
+            self._arguments = append_field(self._arguments, delta.function.arguments)
 
 
 class AssistantCallResult:

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -1,107 +1,12 @@
 import logging
-from typing import Any, Dict, Optional
+from typing import Any
 
-from aidial_sdk.chat_completion import Attachment, Choice, FunctionCall, Stage, ToolCall
+from aidial_sdk.chat_completion import Choice, Stage
 from injector import inject
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
-from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
 
-
-class Usage:
-    def __init__(self, prompt_tokens: int, completion_tokens: int):
-        self.prompt_tokens = prompt_tokens
-        self.completion_tokens = completion_tokens
-
-
-class AccumulatedToolCall:
-    def __init__(self) -> None:
-        self._id: str | None = None
-        self._name: str | None = None
-        self._arguments: str | None = None
-
-    @property
-    def id(self) -> str:
-        if self._id is None:
-            raise ValueError("Tool call id has not been received yet")
-        return self._id
-
-    @property
-    def name(self) -> str:
-        if self._name is None:
-            raise ValueError("Tool call name has not been received yet")
-        return self._name
-
-    @property
-    def arguments(self) -> str:
-        if self._arguments is None:
-            raise ValueError("Tool call arguments have not been received yet")
-        return self._arguments
-
-    def append_delta(self, delta: ChoiceDeltaToolCall) -> None:
-        def append_field(current: str | None, chunk: str | None) -> str | None:
-            if chunk is None:
-                return current
-            return chunk if current is None else current + chunk
-
-        self._id = append_field(self._id, delta.id)
-        if delta.function:
-            self._name = append_field(self._name, delta.function.name)
-            self._arguments = append_field(self._arguments, delta.function.arguments)
-
-    def to_sdk_tool_call(self):
-        return ToolCall(
-            id=self.id,
-            type="function",
-            function=FunctionCall(name=self.name, arguments=self.arguments),
-        )
-
-    @staticmethod
-    def to_sdk_tool_calls(tool_calls: list["AccumulatedToolCall"] | None) -> list[ToolCall] | None:
-        if tool_calls is None:
-            return None
-        return [tc.to_sdk_tool_call() for tc in tool_calls]
-
-
-class AssistantCallResult:
-    def __init__(self):
-        self.__content = ""
-        self.__attachments: list[Attachment] = []
-        self.__accumulated_tool_calls: Dict[int, AccumulatedToolCall] = {}
-        self.__usage: Optional[Usage] = None
-
-    @property
-    def content(self):
-        return self.__content
-
-    def append_content(self, content: str) -> None:
-        self.__content += content
-
-    @property
-    def attachments(self):
-        return self.__attachments
-
-    def append_attachment(self, attachment: Attachment) -> None:
-        self.__attachments.append(attachment)
-
-    @property
-    def tool_calls(self) -> list[AccumulatedToolCall] | None:
-        values = list(self.__accumulated_tool_calls.values())
-        return values if values else None
-
-    def append_tool_call_delta(self, tool_call_delta: ChoiceDeltaToolCall) -> None:
-        index = tool_call_delta.index
-        if index not in self.__accumulated_tool_calls:
-            self.__accumulated_tool_calls[index] = AccumulatedToolCall()
-        self.__accumulated_tool_calls[index].append_delta(tool_call_delta)
-
-    @property
-    def usage(self):
-        return self.__usage
-
-    def set_usage(self, usage: Usage) -> None:
-        self.__usage = usage
-
+from ._models import AssistantCallResult, Usage
 
 logger = logging.getLogger(__name__)
 

--- a/src/quickapp/agent/chunk_processor.py
+++ b/src/quickapp/agent/chunk_processor.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Dict, Optional
 
-from aidial_sdk.chat_completion import Attachment, Choice, Stage
+from aidial_sdk.chat_completion import Attachment, Choice, FunctionCall, Stage, ToolCall
 from injector import inject
 from openai import AsyncStream
 from openai.types.chat import ChatCompletionChunk
@@ -48,6 +48,19 @@ class AccumulatedToolCall:
         if delta.function:
             self._name = append_field(self._name, delta.function.name)
             self._arguments = append_field(self._arguments, delta.function.arguments)
+
+    def to_sdk_tool_call(self):
+        return ToolCall(
+            id=self.id,
+            type="function",
+            function=FunctionCall(name=self.name, arguments=self.arguments),
+        )
+
+    @staticmethod
+    def to_sdk_tool_calls(tool_calls: list["AccumulatedToolCall"] | None) -> list[ToolCall] | None:
+        if tool_calls is None:
+            return None
+        return [tc.to_sdk_tool_call() for tc in tool_calls]
 
 
 class AssistantCallResult:

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -2,7 +2,7 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from aidial_sdk.chat_completion import Choice
+from aidial_sdk.chat_completion import Choice, FunctionCall, ToolCall
 from aidial_sdk.chat_completion.request import CustomContent, Message, Role
 from injector import ProviderOf, inject
 
@@ -98,12 +98,26 @@ class Orchestrator:
         if assistant_call_result is None:
             raise RuntimeError("Assistant invocation returned no result.")
 
+        tool_calls = assistant_call_result.tool_calls
+        sdk_tool_calls = (
+            [
+                ToolCall(
+                    id=tc.id,
+                    type="function",
+                    function=FunctionCall(name=tc.name, arguments=tc.arguments),
+                )
+                for tc in tool_calls
+            ]
+            if tool_calls
+            else None
+        )
+
         self.__messages_context.append_message(
             Message(
                 role=Role.ASSISTANT,
                 content=assistant_call_result.content or " ",
                 custom_content=CustomContent(attachments=assistant_call_result.attachments),
-                tool_calls=assistant_call_result.tool_calls,
+                tool_calls=sdk_tool_calls,
             )
         )
         if assistant_call_result.usage and self.__SHOW_USAGE_STATISTICS:
@@ -117,7 +131,6 @@ class Orchestrator:
         self.__perf_timer.add_milestone(period, "assistant_response_received")
         logger.debug(f"Message from agent: {self.__messages_context.messages}")
 
-        tool_calls = assistant_call_result.tool_calls
         if not tool_calls:
             return False
 

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -2,12 +2,12 @@ import logging
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
-from aidial_sdk.chat_completion import Choice, FunctionCall, ToolCall
+from aidial_sdk.chat_completion import Choice
 from aidial_sdk.chat_completion.request import CustomContent, Message, Role
 from injector import ProviderOf, inject
 
 from quickapp.agent.assistant_invoker import AssistantInvoker
-from quickapp.agent.chunk_processor import ChunkProcessor
+from quickapp.agent.chunk_processor import AccumulatedToolCall, ChunkProcessor
 from quickapp.agent.models import TOOL_EXECUTION_HISTORY
 from quickapp.agent.tool_executor import ToolExecutor
 from quickapp.common import DeploymentUsage
@@ -105,7 +105,7 @@ class Orchestrator:
                 role=Role.ASSISTANT,
                 content=assistant_call_result.content or " ",
                 custom_content=CustomContent(attachments=assistant_call_result.attachments),
-                tool_calls=self._to_sdk_tool_calls(tool_calls),
+                tool_calls=AccumulatedToolCall.to_sdk_tool_calls(tool_calls),
             )
         )
         if assistant_call_result.usage and self.__SHOW_USAGE_STATISTICS:
@@ -155,16 +155,3 @@ class Orchestrator:
                 history.append(msg.model_dump(mode="json", exclude_none=True))
 
         return history[::-1]
-
-    @staticmethod
-    def _to_sdk_tool_calls(tool_calls: list | None) -> list[ToolCall] | None:
-        if not tool_calls:
-            return None
-        return [
-            ToolCall(
-                id=tc.id,
-                type="function",
-                function=FunctionCall(name=tc.name, arguments=tc.arguments),
-            )
-            for tc in tool_calls
-        ]

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -7,7 +7,7 @@ from aidial_sdk.chat_completion.request import CustomContent, Message, Role
 from injector import ProviderOf, inject
 
 from quickapp.agent.assistant_invoker import AssistantInvoker
-from quickapp.agent.chunk_processor import AccumulatedToolCall, ChunkProcessor
+from quickapp.agent.chunk_processor import ChunkProcessor
 from quickapp.agent.models import TOOL_EXECUTION_HISTORY
 from quickapp.agent.tool_executor import ToolExecutor
 from quickapp.common import DeploymentUsage
@@ -18,6 +18,8 @@ from quickapp.common.presentation_settings import PresentationSettings
 from quickapp.common.state_holder import StateHolder
 from quickapp.config.application import ApplicationConfig
 from quickapp.usage_statistics.usage_statistics_service import UsageStatisticsService
+
+from ._models import AccumulatedToolCall
 
 logger = logging.getLogger(__name__)
 

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -99,25 +99,13 @@ class Orchestrator:
             raise RuntimeError("Assistant invocation returned no result.")
 
         tool_calls = assistant_call_result.tool_calls
-        sdk_tool_calls = (
-            [
-                ToolCall(
-                    id=tc.id,
-                    type="function",
-                    function=FunctionCall(name=tc.name, arguments=tc.arguments),
-                )
-                for tc in tool_calls
-            ]
-            if tool_calls
-            else None
-        )
 
         self.__messages_context.append_message(
             Message(
                 role=Role.ASSISTANT,
                 content=assistant_call_result.content or " ",
                 custom_content=CustomContent(attachments=assistant_call_result.attachments),
-                tool_calls=sdk_tool_calls,
+                tool_calls=self._to_sdk_tool_calls(tool_calls),
             )
         )
         if assistant_call_result.usage and self.__SHOW_USAGE_STATISTICS:
@@ -167,3 +155,16 @@ class Orchestrator:
                 history.append(msg.model_dump(mode="json", exclude_none=True))
 
         return history[::-1]
+
+    @staticmethod
+    def _to_sdk_tool_calls(tool_calls: list | None) -> list[ToolCall] | None:
+        if not tool_calls:
+            return None
+        return [
+            ToolCall(
+                id=tc.id,
+                type="function",
+                function=FunctionCall(name=tc.name, arguments=tc.arguments),
+            )
+            for tc in tool_calls
+        ]

--- a/src/quickapp/agent/tool_executor.py
+++ b/src/quickapp/agent/tool_executor.py
@@ -1,10 +1,11 @@
 import asyncio
+import json
 import logging
 from typing import Dict, List
 
-from aidial_sdk.chat_completion import ToolCall
 from injector import inject
 
+from quickapp.agent.chunk_processor import AccumulatedToolCall
 from quickapp.common import CompletionResult, StagedBaseTool
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import sanitize_toolname
@@ -20,17 +21,14 @@ class ToolExecutor:
         self.__perf_timer: PerformanceTimer = perf_timer
         self.__period_name = "tool_execution"
 
-    async def execute(self, tool_call_list: List[ToolCall]) -> List[CompletionResult]:
+    async def execute(self, tool_call_list: List[AccumulatedToolCall]) -> List[CompletionResult]:
         tasks = []
         for tc in tool_call_list:
-            tool = self.__tools.get(tc.function.name)
+            tool = self.__tools.get(tc.name)
 
-            # tc.function.arguments from agent returns json-like string
-            import json
+            args = json.loads(tc.arguments)
 
-            args = json.loads(tc.function.arguments)
-
-            logger.debug(f"Making tool calls: {tc.function.name} with args:{args}")
+            logger.debug(f"Making tool calls: {tc.name} with args:{args}")
             if tool:
                 tasks.append(tool.arun(tool_call_id=tc.id, **args))
 
@@ -56,7 +54,9 @@ class ToolExecutor:
         return tool_dict
 
     @staticmethod
-    def _find_tool_call_by_id(tool_call_id, tool_call_list: List[ToolCall]):
+    def _find_tool_call_by_id(
+        tool_call_id: str, tool_call_list: List[AccumulatedToolCall]
+    ) -> AccumulatedToolCall:
         for tc in tool_call_list:
             if tc.id == tool_call_id:
                 return tc

--- a/src/quickapp/agent/tool_executor.py
+++ b/src/quickapp/agent/tool_executor.py
@@ -52,12 +52,3 @@ class ToolExecutor:
                 tool_name = sanitize_toolname(function.name)
                 tool_dict[tool_name] = tool
         return tool_dict
-
-    @staticmethod
-    def _find_tool_call_by_id(
-        tool_call_id: str, tool_call_list: List[AccumulatedToolCall]
-    ) -> AccumulatedToolCall:
-        for tc in tool_call_list:
-            if tc.id == tool_call_id:
-                return tc
-        raise RuntimeError(f"The {tool_call_id} is not found in the {tool_call_list}")

--- a/src/quickapp/agent/tool_executor.py
+++ b/src/quickapp/agent/tool_executor.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 
 from injector import inject
 
-from quickapp.agent.chunk_processor import AccumulatedToolCall
+from quickapp.agent._models import AccumulatedToolCall
 from quickapp.common import CompletionResult, StagedBaseTool
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import sanitize_toolname

--- a/src/tests/unit_tests/agent_tests/test_orchestrator.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator.py
@@ -4,9 +4,20 @@ from unittest.mock import Mock, AsyncMock
 
 from aidial_sdk.chat_completion.request import FunctionCall, Message, Role, ToolCall
 
+from quickapp.agent.chunk_processor import AccumulatedToolCall
 from quickapp.agent.orchestrator import Orchestrator
 from quickapp.agent.models import TOOL_EXECUTION_HISTORY
 from quickapp.common import DeploymentUsage
+
+
+def _make_accumulated_tool_call(
+    id: str, name: str, arguments: str = "{}"
+) -> AccumulatedToolCall:
+    tc = AccumulatedToolCall()
+    tc._id = id
+    tc._name = name
+    tc._arguments = arguments
+    return tc
 
 
 @pytest.mark.asyncio
@@ -101,9 +112,7 @@ async def test_invoke_with_tool_calls_executes_tools_and_updates_state_and_messa
     assistant_result_with_tools = SimpleNamespace(
         content="call tool",
         attachments=[],
-        tool_calls=[
-            SimpleNamespace(id="tc-1", type="function", name="tool_a", arguments="{}")
-        ],
+        tool_calls=[_make_accumulated_tool_call(id="tc-1", name="tool_a")],
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
     assistant_result_no_tools = SimpleNamespace(
@@ -210,9 +219,7 @@ async def test_invoke_tool_calls_returns_no_results_raises_runtime_error():
     assistant_result_with_tools = SimpleNamespace(
         content="call tool",
         attachments=[],
-        tool_calls=[
-            SimpleNamespace(id="tc-1", type="function", name="tool_a", arguments="{}")
-        ],
+        tool_calls=[_make_accumulated_tool_call(id="tc-1", name="tool_a")],
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
 

--- a/src/tests/unit_tests/agent_tests/test_orchestrator.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator.py
@@ -4,15 +4,13 @@ from unittest.mock import Mock, AsyncMock
 
 from aidial_sdk.chat_completion.request import FunctionCall, Message, Role, ToolCall
 
-from quickapp.agent.chunk_processor import AccumulatedToolCall
+from quickapp.agent._models import AccumulatedToolCall
 from quickapp.agent.orchestrator import Orchestrator
 from quickapp.agent.models import TOOL_EXECUTION_HISTORY
 from quickapp.common import DeploymentUsage
 
 
-def _make_accumulated_tool_call(
-    id: str, name: str, arguments: str = "{}"
-) -> AccumulatedToolCall:
+def _make_accumulated_tool_call(id: str, name: str, arguments: str = "{}") -> AccumulatedToolCall:
     tc = AccumulatedToolCall()
     tc._id = id
     tc._name = name
@@ -61,7 +59,9 @@ async def test_invoke_no_tool_calls_processes_usage_and_sets_state():
     tool_executor = Mock()
 
     app_config = SimpleNamespace(
-        orchestrator=SimpleNamespace(max_iterations=5, deployment=SimpleNamespace(name="test-model"))
+        orchestrator=SimpleNamespace(
+            max_iterations=5, deployment=SimpleNamespace(name="test-model")
+        )
     )
 
     orchestrator = Orchestrator(
@@ -243,7 +243,9 @@ async def test_invoke_tool_calls_returns_no_results_raises_runtime_error():
     tool_executor.execute = AsyncMock(return_value=[])
 
     app_config = SimpleNamespace(
-        orchestrator=SimpleNamespace(max_iterations=5, deployment=SimpleNamespace(name="test-model"))
+        orchestrator=SimpleNamespace(
+            max_iterations=5, deployment=SimpleNamespace(name="test-model")
+        )
     )
 
     orchestrator = Orchestrator(

--- a/src/tests/unit_tests/agent_tests/test_orchestrator.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator.py
@@ -102,11 +102,7 @@ async def test_invoke_with_tool_calls_executes_tools_and_updates_state_and_messa
         content="call tool",
         attachments=[],
         tool_calls=[
-            {
-                "id": "tc-1",
-                "type": "function",
-                "function": {"name": "tool_a", "arguments": "{}"},
-            }
+            SimpleNamespace(id="tc-1", type="function", name="tool_a", arguments="{}")
         ],
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )
@@ -215,7 +211,7 @@ async def test_invoke_tool_calls_returns_no_results_raises_runtime_error():
         content="call tool",
         attachments=[],
         tool_calls=[
-            {"id": "tc-1", "type": "function", "function": {"name": "tool_a", "arguments": "{}"}}
+            SimpleNamespace(id="tc-1", type="function", name="tool_a", arguments="{}")
         ],
         usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
     )

--- a/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
@@ -1,0 +1,78 @@
+"""Test script to verify tool call accumulation works correctly."""
+import sys
+
+from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
+
+from quickapp.agent.chunk_processor import AssistantCallResult
+
+def test_tool_call_accumulation():
+    """Test that tool calls are accumulated correctly from deltas."""
+    result = AssistantCallResult()
+
+    # Simulate the streaming deltas shown in the logs
+    delta1 = ChoiceDeltaToolCall(
+        index=0,
+        id='chatcmpl-tool-a89453224f0a3994',
+        function=ChoiceDeltaToolCallFunction(arguments=None, name='geo_code_de9a'),
+        type='function'
+    )
+
+    delta2 = ChoiceDeltaToolCall(
+        index=0,
+        id=None,
+        function=ChoiceDeltaToolCallFunction(arguments='{"q": "', name=None),
+        type=None
+    )
+
+    delta3 = ChoiceDeltaToolCall(
+        index=0,
+        id=None,
+        function=ChoiceDeltaToolCallFunction(arguments='NY', name=None),
+        type=None
+    )
+
+    delta4 = ChoiceDeltaToolCall(
+        index=0,
+        id=None,
+        function=ChoiceDeltaToolCallFunction(arguments='"}', name=None),
+        type=None
+    )
+
+    # Apply all deltas
+    print("Applying delta 1...")
+    result.append_tool_call_delta(delta1)
+
+    print("Applying delta 2...")
+    result.append_tool_call_delta(delta2)
+
+    print("Applying delta 3...")
+    result.append_tool_call_delta(delta3)
+
+    print("Applying delta 4...")
+    result.append_tool_call_delta(delta4)
+
+    # Get the final tool calls
+    tool_calls = result.tool_calls
+
+    print("\n=== Results ===")
+    if tool_calls:
+        for tool_call in tool_calls:
+            print(f"Tool Call ID: {tool_call.id}")
+            print(f"Type: {tool_call.type}")
+            print(f"Function Name: {tool_call.function.name}")
+            print(f"Function Arguments: {tool_call.function.arguments}")
+
+            # Verify expected values
+            assert tool_call.id == 'chatcmpl-tool-a89453224f0a3994'
+            assert tool_call.type == 'function'
+            assert tool_call.function.name == 'geo_code_de9a'
+            assert tool_call.function.arguments == '{"q": "NY"}'
+
+        print("\n✓ Test passed! Tool call accumulated correctly.")
+    else:
+        print("✗ Test failed! No tool calls found.")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    test_tool_call_accumulation()
+

--- a/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
@@ -1,9 +1,10 @@
 """Test script to verify tool call accumulation works correctly."""
-import sys
 
+import pytest
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
 
-from quickapp.agent.chunk_processor import AssistantCallResult
+from quickapp.agent.chunk_processor import AccumulatedToolCall, AssistantCallResult
+
 
 def test_tool_call_accumulation():
     """Test that tool calls are accumulated correctly from deltas."""
@@ -39,40 +40,114 @@ def test_tool_call_accumulation():
     )
 
     # Apply all deltas
-    print("Applying delta 1...")
     result.append_tool_call_delta(delta1)
-
-    print("Applying delta 2...")
     result.append_tool_call_delta(delta2)
-
-    print("Applying delta 3...")
     result.append_tool_call_delta(delta3)
-
-    print("Applying delta 4...")
     result.append_tool_call_delta(delta4)
 
-    # Get the final tool calls
+    # Verify accumulated tool calls
     tool_calls = result.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 1
 
-    print("\n=== Results ===")
-    if tool_calls:
-        for tool_call in tool_calls:
-            print(f"Tool Call ID: {tool_call.id}")
-            print(f"Type: {tool_call.type}")
-            print(f"Function Name: {tool_call.function.name}")
-            print(f"Function Arguments: {tool_call.function.arguments}")
+    tc = tool_calls[0]
+    assert tc.id == 'chatcmpl-tool-a89453224f0a3994'
+    assert tc.type == 'function'
+    assert tc.name == 'geo_code_de9a'
+    assert tc.arguments == '{"q": "NY"}'
 
-            # Verify expected values
-            assert tool_call.id == 'chatcmpl-tool-a89453224f0a3994'
-            assert tool_call.type == 'function'
-            assert tool_call.function.name == 'geo_code_de9a'
-            assert tool_call.function.arguments == '{"q": "NY"}'
 
-        print("\n✓ Test passed! Tool call accumulated correctly.")
-    else:
-        print("✗ Test failed! No tool calls found.")
-        sys.exit(1)
 
-if __name__ == "__main__":
-    test_tool_call_accumulation()
+def test_multiple_tool_calls_accumulation():
+    """Test accumulation of multiple parallel tool calls."""
+    result = AssistantCallResult()
+
+    # First tool call - delta with id
+    result.append_tool_call_delta(ChoiceDeltaToolCall(
+        index=0,
+        id='call-1',
+        function=ChoiceDeltaToolCallFunction(arguments=None, name='tool_a'),
+        type='function'
+    ))
+    # Second tool call - delta with id
+    result.append_tool_call_delta(ChoiceDeltaToolCall(
+        index=1,
+        id='call-2',
+        function=ChoiceDeltaToolCallFunction(arguments=None, name='tool_b'),
+        type='function'
+    ))
+    # Arguments for the first tool call
+    result.append_tool_call_delta(ChoiceDeltaToolCall(
+        index=0,
+        id=None,
+        function=ChoiceDeltaToolCallFunction(arguments='{"x": 1}', name=None),
+        type=None
+    ))
+    # Arguments for the second tool call
+    result.append_tool_call_delta(ChoiceDeltaToolCall(
+        index=1,
+        id=None,
+        function=ChoiceDeltaToolCallFunction(arguments='{"y": 2}', name=None),
+        type=None
+    ))
+
+    tool_calls = result.tool_calls
+    assert tool_calls is not None
+    assert len(tool_calls) == 2
+
+    assert tool_calls[0].id == 'call-1'
+    assert tool_calls[0].name == 'tool_a'
+    assert tool_calls[0].arguments == '{"x": 1}'
+
+    assert tool_calls[1].id == 'call-2'
+    assert tool_calls[1].name == 'tool_b'
+    assert tool_calls[1].arguments == '{"y": 2}'
+
+
+def test_no_tool_calls_returns_none():
+    """Test that tool_calls returns None when no deltas have been appended."""
+    result = AssistantCallResult()
+    assert result.tool_calls is None
+
+
+def test_accessing_name_before_set_raises():
+    """Test that accessing a name before it has been accumulated raises ValueError."""
+    tc = AccumulatedToolCall()
+    with pytest.raises(ValueError, match="name has not been received"):
+        _ = tc.name
+
+
+def test_accessing_arguments_before_set_raises():
+    """Test that accessing arguments before they have been accumulated raises ValueError."""
+    tc = AccumulatedToolCall()
+    with pytest.raises(ValueError, match="arguments have not been received"):
+        _ = tc.arguments
+
+
+def test_arguments_accumulated_across_deltas():
+    """Test that arguments are correctly concatenated across multiple deltas."""
+    tc = AccumulatedToolCall()
+    tc.append_delta(ChoiceDeltaToolCall(
+        index=0, id='c1',
+        function=ChoiceDeltaToolCallFunction(arguments=None, name='f'),
+        type='function'
+    ))
+    # arguments still None at this point
+    with pytest.raises(ValueError):
+        _ = tc.arguments
+
+    tc.append_delta(ChoiceDeltaToolCall(
+        index=0, id=None,
+        function=ChoiceDeltaToolCallFunction(arguments='{"a":', name=None),
+        type=None
+    ))
+    assert tc.arguments == '{"a":'
+
+    tc.append_delta(ChoiceDeltaToolCall(
+        index=0, id=None,
+        function=ChoiceDeltaToolCallFunction(arguments=' 1}', name=None),
+        type=None
+    ))
+    assert tc.arguments == '{"a": 1}'
+
 

--- a/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
@@ -3,7 +3,7 @@
 import pytest
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall, ChoiceDeltaToolCallFunction
 
-from quickapp.agent.chunk_processor import AccumulatedToolCall, AssistantCallResult
+from quickapp.agent._models import AccumulatedToolCall, AssistantCallResult
 
 
 def test_tool_call_accumulation():
@@ -15,28 +15,22 @@ def test_tool_call_accumulation():
         index=0,
         id='chatcmpl-tool-a89453224f0a3994',
         function=ChoiceDeltaToolCallFunction(arguments=None, name='geo_code_de9a'),
-        type='function'
+        type='function',
     )
 
     delta2 = ChoiceDeltaToolCall(
         index=0,
         id=None,
         function=ChoiceDeltaToolCallFunction(arguments='{"q": "', name=None),
-        type=None
+        type=None,
     )
 
     delta3 = ChoiceDeltaToolCall(
-        index=0,
-        id=None,
-        function=ChoiceDeltaToolCallFunction(arguments='NY', name=None),
-        type=None
+        index=0, id=None, function=ChoiceDeltaToolCallFunction(arguments='NY', name=None), type=None
     )
 
     delta4 = ChoiceDeltaToolCall(
-        index=0,
-        id=None,
-        function=ChoiceDeltaToolCallFunction(arguments='"}', name=None),
-        type=None
+        index=0, id=None, function=ChoiceDeltaToolCallFunction(arguments='"}', name=None), type=None
     )
 
     # Apply all deltas
@@ -56,39 +50,46 @@ def test_tool_call_accumulation():
     assert tc.arguments == '{"q": "NY"}'
 
 
-
 def test_multiple_tool_calls_accumulation():
     """Test accumulation of multiple parallel tool calls."""
     result = AssistantCallResult()
 
     # First tool call - delta with id
-    result.append_tool_call_delta(ChoiceDeltaToolCall(
-        index=0,
-        id='call-1',
-        function=ChoiceDeltaToolCallFunction(arguments=None, name='tool_a'),
-        type='function'
-    ))
+    result.append_tool_call_delta(
+        ChoiceDeltaToolCall(
+            index=0,
+            id='call-1',
+            function=ChoiceDeltaToolCallFunction(arguments=None, name='tool_a'),
+            type='function',
+        )
+    )
     # Second tool call - delta with id
-    result.append_tool_call_delta(ChoiceDeltaToolCall(
-        index=1,
-        id='call-2',
-        function=ChoiceDeltaToolCallFunction(arguments=None, name='tool_b'),
-        type='function'
-    ))
+    result.append_tool_call_delta(
+        ChoiceDeltaToolCall(
+            index=1,
+            id='call-2',
+            function=ChoiceDeltaToolCallFunction(arguments=None, name='tool_b'),
+            type='function',
+        )
+    )
     # Arguments for the first tool call
-    result.append_tool_call_delta(ChoiceDeltaToolCall(
-        index=0,
-        id=None,
-        function=ChoiceDeltaToolCallFunction(arguments='{"x": 1}', name=None),
-        type=None
-    ))
+    result.append_tool_call_delta(
+        ChoiceDeltaToolCall(
+            index=0,
+            id=None,
+            function=ChoiceDeltaToolCallFunction(arguments='{"x": 1}', name=None),
+            type=None,
+        )
+    )
     # Arguments for the second tool call
-    result.append_tool_call_delta(ChoiceDeltaToolCall(
-        index=1,
-        id=None,
-        function=ChoiceDeltaToolCallFunction(arguments='{"y": 2}', name=None),
-        type=None
-    ))
+    result.append_tool_call_delta(
+        ChoiceDeltaToolCall(
+            index=1,
+            id=None,
+            function=ChoiceDeltaToolCallFunction(arguments='{"y": 2}', name=None),
+            type=None,
+        )
+    )
 
     tool_calls = result.tool_calls
     assert tool_calls is not None
@@ -133,27 +134,34 @@ def test_accessing_arguments_before_set_raises():
 def test_arguments_accumulated_across_deltas():
     """Test that arguments are correctly concatenated across multiple deltas."""
     tc = AccumulatedToolCall()
-    tc.append_delta(ChoiceDeltaToolCall(
-        index=0, id='c1',
-        function=ChoiceDeltaToolCallFunction(arguments=None, name='f'),
-        type='function'
-    ))
+    tc.append_delta(
+        ChoiceDeltaToolCall(
+            index=0,
+            id='c1',
+            function=ChoiceDeltaToolCallFunction(arguments=None, name='f'),
+            type='function',
+        )
+    )
     # arguments still None at this point
     with pytest.raises(ValueError):
         _ = tc.arguments
 
-    tc.append_delta(ChoiceDeltaToolCall(
-        index=0, id=None,
-        function=ChoiceDeltaToolCallFunction(arguments='{"a":', name=None),
-        type=None
-    ))
+    tc.append_delta(
+        ChoiceDeltaToolCall(
+            index=0,
+            id=None,
+            function=ChoiceDeltaToolCallFunction(arguments='{"a":', name=None),
+            type=None,
+        )
+    )
     assert tc.arguments == '{"a":'
 
-    tc.append_delta(ChoiceDeltaToolCall(
-        index=0, id=None,
-        function=ChoiceDeltaToolCallFunction(arguments=' 1}', name=None),
-        type=None
-    ))
+    tc.append_delta(
+        ChoiceDeltaToolCall(
+            index=0,
+            id=None,
+            function=ChoiceDeltaToolCallFunction(arguments=' 1}', name=None),
+            type=None,
+        )
+    )
     assert tc.arguments == '{"a": 1}'
-
-

--- a/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_call_accumulation.py
@@ -52,7 +52,6 @@ def test_tool_call_accumulation():
 
     tc = tool_calls[0]
     assert tc.id == 'chatcmpl-tool-a89453224f0a3994'
-    assert tc.type == 'function'
     assert tc.name == 'geo_code_de9a'
     assert tc.arguments == '{"q": "NY"}'
 
@@ -108,6 +107,13 @@ def test_no_tool_calls_returns_none():
     """Test that tool_calls returns None when no deltas have been appended."""
     result = AssistantCallResult()
     assert result.tool_calls is None
+
+
+def test_accessing_id_before_set_raises():
+    """Test that accessing id before it has been accumulated raises ValueError."""
+    tc = AccumulatedToolCall()
+    with pytest.raises(ValueError, match="id has not been received"):
+        _ = tc.id
 
 
 def test_accessing_name_before_set_raises():


### PR DESCRIPTION
### Applicable issues

https://github.com/epam/ai-dial-quickapps-backend/issues/107

### Description of changes

The fix replaces eager `ToolCall` construction with incremental accumulation.

Instead of instantiating `ToolCall` from each streaming delta (which may be partial), the code now:

- Accumulates tool call data per `index`
- Merges `name` and appends `arguments` chunks progressively
- Constructs `ToolCall` objects only after full data is assembled

This aligns tool call handling with OpenAI streaming semantics and prevents crashes on partial deltas.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
