### PR TITLE
chore: update unittest to pytest dependencies #62

### DIFF
--- a/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
+++ b/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
@@ -10,7 +10,6 @@ The pipeline runs transformers sequentially via _MessagesSetup:
 """
 
 import json
-import unittest
 
 from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
 from fastapi_injector import Injected
@@ -40,79 +39,72 @@ def _attachment(title: str, url: str, mime_type: str) -> Attachment:
     )
 
 
-class TestContextPipelineDI(unittest.TestCase):
-    def setUp(self):
-        ctx = FileContextConfig(url="files/bucket/reference.pdf", description="Reference doc")
+def _make_context_app(ctx_url: str):
+    ctx = FileContextConfig(url=ctx_url, description="Reference doc")
 
-        def configure(binder: Binder):
-            app_config = create_app_configuration([])
-            app_config.contexts = [ctx]
-            binder.bind(ApplicationConfig, to=app_config)
+    def configure(binder: Binder):
+        app_config = create_app_configuration([])
+        app_config.contexts = [ctx]
+        binder.bind(ApplicationConfig, to=app_config)
 
-        self.app = create_test_app([AttachmentProcessingModule, configure])
-        self.client = TestClient(self.app)
-
-    def test_context_file_notified_via_synthetic_tool_call(self):
-        @self.app.get("/test_context")
-        async def get_method(messages_setup: _MessagesSetup = Injected(_MessagesSetup)):
-            messages = [_user_msg("hello")]
-
-            result = messages_setup.setup(messages)
-
-            # Original + synthetic assistant tool_call + tool result
-            self.assertEqual(len(result), 3)
-            self.assertEqual(result[1].role, Role.ASSISTANT)
-            self.assertEqual(result[1].tool_calls[0].function.name, AVAILABLE_CONTEXT_TOOL_NAME)
-
-            data = json.loads(result[2].content)
-            self.assertEqual(len(data["entries"]), 1)
-            self.assertEqual(data["entries"][0]["title"], "reference.pdf")
-            self.assertEqual(data["entries"][0]["url"], "files/bucket/reference.pdf")
-            self.assertEqual(data["entries"][0]["status"], "new")
-
-            return {"message": "success"}
-
-        response = self.client.get("/test_context")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"message": "success"})
+    return create_test_app([AttachmentProcessingModule, configure])
 
 
-class TestCombinedPipelineDI(unittest.TestCase):
-    def setUp(self):
-        ctx = FileContextConfig(url="files/bucket/ref.csv")
+def test_context_file_notified_via_synthetic_tool_call():
+    app = _make_context_app("files/bucket/reference.pdf")
+    client = TestClient(app)
 
-        def configure(binder: Binder):
-            app_config = create_app_configuration([])
-            app_config.contexts = [ctx]
-            binder.bind(ApplicationConfig, to=app_config)
+    @app.get("/test_context")
+    async def get_method(messages_setup: _MessagesSetup = Injected(_MessagesSetup)):
+        messages = [_user_msg("hello")]
 
-        self.app = create_test_app([AttachmentProcessingModule, configure])
-        self.client = TestClient(self.app)
+        result = messages_setup.setup(messages)
 
-    def test_user_attachment_text_and_context_tool_call(self):
-        @self.app.get("/test_combined")
-        async def get_method(messages_setup: _MessagesSetup = Injected(_MessagesSetup)):
-            messages = [
-                _user_msg(
-                    "check",
-                    [_attachment("doc.pdf", "/files/doc.pdf", "application/pdf")],
-                )
-            ]
+        # Original + synthetic assistant tool_call + tool result
+        assert len(result) == 3
+        assert result[1].role == Role.ASSISTANT
+        assert result[1].tool_calls[0].function.name == AVAILABLE_CONTEXT_TOOL_NAME
 
-            result = messages_setup.setup(messages)
+        data = json.loads(result[2].content)
+        assert len(data["entries"]) == 1
+        assert data["entries"][0]["title"] == "reference.pdf"
+        assert data["entries"][0]["url"] == "files/bucket/reference.pdf"
+        assert data["entries"][0]["status"] == "new"
 
-            # Original message + 2 synthetic messages for context
-            self.assertEqual(len(result), 3)
+        return {"message": "success"}
 
-            # Context notified via synthetic tool call
-            self.assertEqual(result[1].tool_calls[0].function.name, AVAILABLE_CONTEXT_TOOL_NAME)
-            data = json.loads(result[2].content)
-            self.assertEqual(data["entries"][0]["title"], "ref.csv")
+    response = client.get("/test_context")
 
-            return {"message": "success"}
+    assert response.status_code == 200
+    assert response.json() == {"message": "success"}
 
-        response = self.client.get("/test_combined")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"message": "success"})
+def test_user_attachment_text_and_context_tool_call():
+    app = _make_context_app("files/bucket/ref.csv")
+    client = TestClient(app)
+
+    @app.get("/test_combined")
+    async def get_method(messages_setup: _MessagesSetup = Injected(_MessagesSetup)):
+        messages = [
+            _user_msg(
+                "check",
+                [_attachment("doc.pdf", "/files/doc.pdf", "application/pdf")],
+            )
+        ]
+
+        result = messages_setup.setup(messages)
+
+        # Original message + 2 synthetic messages for context
+        assert len(result) == 3
+
+        # Context notified via synthetic tool call
+        assert result[1].tool_calls[0].function.name == AVAILABLE_CONTEXT_TOOL_NAME
+        data = json.loads(result[2].content)
+        assert data["entries"][0]["title"] == "ref.csv"
+
+        return {"message": "success"}
+
+    response = client.get("/test_combined")
+
+    assert response.status_code == 200
+    assert response.json() == {"message": "success"}

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
@@ -1,5 +1,4 @@
 import base64
-import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -25,300 +24,289 @@ from tests.unit_tests.common import create_test_app
 from tests.unit_tests.common.common import create_app_configuration
 
 
-class MCPToolTest(unittest.IsolatedAsyncioTestCase):
+@pytest.mark.asyncio
+@patch(
+    "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool",
+    new_callable=AsyncMock,
+)
+@patch(
+    "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list",
+    new_callable=AsyncMock,
+)
+async def test_mcp_tool(mock_get_tools_list, mock_call_mcp_tool):
+    # Prepare tools metadata (no coroutines on the tool objects)
+    tool_1 = SimpleNamespace(name="test_tool1", description="A test tool 1", inputSchema={})
+    tool_2 = SimpleNamespace(name="test_tool2", description="A test tool 2", inputSchema={})
+    tool_3 = SimpleNamespace(name="test_tool3", description="A test tool 3", inputSchema={})
+    tool_4 = SimpleNamespace(name="test_tool4", description="A test tool 4", inputSchema={})
 
-    @patch(
-        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool",
-        new_callable=AsyncMock,
-    )
-    @patch(
-        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list",
-        new_callable=AsyncMock,
-    )
-    async def test_mcp_tool(self, mock_get_tools_list, mock_call_mcp_tool):
-        # Prepare tools metadata (no coroutines on the tool objects)
-        tool_1 = SimpleNamespace(name="test_tool1", description="A test tool 1", inputSchema={})
-        tool_2 = SimpleNamespace(name="test_tool2", description="A test tool 2", inputSchema={})
-        tool_3 = SimpleNamespace(name="test_tool3", description="A test tool 3", inputSchema={})
-        tool_4 = SimpleNamespace(name="test_tool4", description="A test tool 4", inputSchema={})
+    mock_get_tools_list.return_value = [tool_1, tool_2, tool_3, tool_4]
 
-        mock_get_tools_list.return_value = [tool_1, tool_2, tool_3, tool_4]
+    # Mock attachment service upload
+    mock_stage = MagicMock(spec=Stage)
+    mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+    mock_dial_attachment_service.upload_attachment_to_core = AsyncMock()
 
-        # Mock attachment service upload
-        mock_stage = MagicMock(spec=Stage)
-        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
-        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock()
+    async def mock_upload(attachment):
+        attachment.url = "mocked_url"
+        attachment.data = None
+        attachment.title = "Attachment"
+        return attachment
 
-        async def mock_upload(attachment):
-            attachment.url = "mocked_url"
-            attachment.data = None
-            attachment.title = "Attachment"
-            return attachment
+    mock_dial_attachment_service.upload_attachment_to_core.side_effect = mock_upload
 
-        mock_dial_attachment_service.upload_attachment_to_core.side_effect = mock_upload
-
-        # Provide call_mcp_tool results based on tool name (simulate CallToolResult-like objects)
-        async def _call_side_effect(tool_name, **kwargs):
-            if tool_name == "test_tool1":
-                # text-only content
-                return SimpleNamespace(
-                    content=[SimpleNamespace(type="text", text="test_result_1")], isError=False
-                )
-            if tool_name == "test_tool2":
-                # image content
-                return SimpleNamespace(
-                    content=[
-                        ImageContent(
-                            mimeType="image/png",
-                            data=base64.b64encode(b"test_image_data").decode("utf-8"),
-                            type="image",
-                        )
-                    ],
-                    isError=False,
-                )
-            if tool_name == "test_tool3":
-                # embedded text resource
-                tr = TextResourceContents(
-                    mimeType="text/plain", text="test_text_content", uri=AnyUrl("https://test_uri")
-                )
-                return SimpleNamespace(
-                    content=[EmbeddedResource(resource=tr, type="resource")], isError=False
-                )
-            if tool_name == "test_tool4":
-                # embedded blob resource
-                br = BlobResourceContents(
-                    mimeType="application/octet-stream",
-                    blob=base64.b64encode(b"test_blob_content").decode("utf-8"),
-                    uri=AnyUrl("https://test_blob_uri"),
-                )
-                return SimpleNamespace(
-                    content=[EmbeddedResource(resource=br, type="resource")], isError=False
-                )
-            return SimpleNamespace(content=[], isError=False)
-
-        mock_call_mcp_tool.side_effect = _call_side_effect
-
-        mcp_toolset = MCPToolSet(
-            type="mcp",
-            mcp_server_info=MCPServerInfo(
-                url="https://test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
-            ),
-            name="mcp-toolset",
-            description="Set with MCP tools",
-        )
-
-        def configure(binder: Binder) -> None:
-            binder.bind(Stage, to=mock_stage)
-            binder.bind(DialSettings, DialSettings(url="https://core"))
-            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
-            binder.bind(AttachmentService, mock_dial_attachment_service)
-            binder.bind(
-                ApplicationConfig,
-                to=create_app_configuration([mcp_toolset]),
+    # Provide call_mcp_tool results based on tool name (simulate CallToolResult-like objects)
+    async def _call_side_effect(tool_name, **kwargs):
+        if tool_name == "test_tool1":
+            # text-only content
+            return SimpleNamespace(
+                content=[SimpleNamespace(type="text", text="test_result_1")], isError=False
             )
-            binder.bind(PerformanceTimer, to=PerformanceTimer)
-            binder.bind(ForwardedHeaders, to=InstanceProvider(None))
-            binder.multibind(list[ToolArgumentTransformer], to=[])
-
-        app = create_test_app([MCPToolingModule, configure])
-
-        @app.get("/")
-        async def get_method(injector: Injector = Injected(Injector)):
-            initializers = injector.get(list[CompletionInitializer])
-            self.assertEqual(len(initializers), 1)
-            initializer = initializers[0]
-            await initializer.initialize()
-
-            mock_get_tools_list.assert_called_once()
-
-            tools = injector.get(list[StagedBaseTool])
-            self.assertEqual(len(tools), 4)
-
-            # Use the public async entrypoint `arun(tool_call_id, ...)`
-            tool_1_instance = next((t for t in tools if t.name == "test_tool1"), None)
-            tool_1_result = await tool_1_instance.arun("call-1")
-            self.assertEqual(
-                tool_1_result,
-                CompletionResult(
-                    tool_call_id="call-1",
-                    content='test_result_1',
-                    content_type='text/markdown',
-                    attachments=None,
-                ),
-            )
-
-            tool_2_instance = next((t for t in tools if t.name == "test_tool2"), None)
-            tool_2_result = await tool_2_instance.arun("call-2")
-            self.assertEqual(
-                tool_2_result,
-                CompletionResult(
-                    tool_call_id="call-2",
-                    content="",
-                    content_type='text/markdown',
-                    attachments=[
-                        Attachment(
-                            type='image/png',
-                            title="Attachment",
-                            data=None,
-                            url="mocked_url",
-                            reference_type=None,
-                            reference_url=None,
-                        )
-                    ],
-                    propagate_to_choice=[
-                        Attachment(
-                            type='image/png',
-                            title='Attachment',
-                            data=None,
-                            url='mocked_url',
-                            reference_type=None,
-                            reference_url=None,
-                        )
-                    ],
-                ),
-            )
-
-            tool_3_instance = next((t for t in tools if t.name == "test_tool3"), None)
-            tool_3_result = await tool_3_instance.arun("call-3")
-            self.assertEqual(
-                tool_3_result,
-                CompletionResult(
-                    tool_call_id="call-3",
-                    content="",
-                    content_type='text/markdown',
-                    attachments=[
-                        Attachment(
-                            type='text/plain',
-                            title="Attachment",
-                            data=None,
-                            url="mocked_url",
-                            reference_type=None,
-                            reference_url=None,
-                        )
-                    ],
-                ),
-            )
-
-            tool_4_instance = next((t for t in tools if t.name == "test_tool4"), None)
-            tool_4_result = await tool_4_instance.arun("call-4")
-            self.assertEqual(
-                tool_4_result,
-                CompletionResult(
-                    tool_call_id="call-4",
-                    content="",
-                    content_type='text/markdown',
-                    attachments=[
-                        Attachment(
-                            type='application/octet-stream',
-                            title="Attachment",
-                            data=None,
-                            url="mocked_url",
-                            reference_type=None,
-                            reference_url=None,
-                        )
-                    ],
-                ),
-            )
-
-        client = TestClient(app)
-        response = client.get("/")
-        self.assertEqual(response.status_code, 200)
-
-    @patch(
-        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool",
-        new_callable=AsyncMock,
-    )
-    @patch(
-        "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list",
-        new_callable=AsyncMock,
-    )
-    async def test_mcp_tool_narrow_supported_types_skips_non_matching(
-        self, mock_get_tools_list, mock_call_mcp_tool
-    ):
-        """Non-matching attachments are neither uploaded nor appended to the result."""
-        tool_1 = SimpleNamespace(name="img_tool", description="Image tool", inputSchema={})
-        mock_get_tools_list.return_value = [tool_1]
-
-        mock_stage = MagicMock(spec=Stage)
-        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
-        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock()
-
-        async def mock_upload(attachment):
-            attachment.url = "mocked_url"
-            attachment.data = None
-            attachment.title = "Attachment"
-            return attachment
-
-        mock_dial_attachment_service.upload_attachment_to_core.side_effect = mock_upload
-
-        # Tool returns both image and text attachments
-        async def _call_side_effect(tool_name, **kwargs):
-            tr = TextResourceContents(
-                mimeType="text/plain", text="some_text", uri=AnyUrl("https://example")
-            )
+        if tool_name == "test_tool2":
+            # image content
             return SimpleNamespace(
                 content=[
                     ImageContent(
                         mimeType="image/png",
-                        data=base64.b64encode(b"img").decode("utf-8"),
+                        data=base64.b64encode(b"test_image_data").decode("utf-8"),
                         type="image",
-                    ),
-                    EmbeddedResource(resource=tr, type="resource"),
+                    )
                 ],
                 isError=False,
             )
+        if tool_name == "test_tool3":
+            # embedded text resource
+            tr = TextResourceContents(
+                mimeType="text/plain", text="test_text_content", uri=AnyUrl("https://test_uri")
+            )
+            return SimpleNamespace(
+                content=[EmbeddedResource(resource=tr, type="resource")], isError=False
+            )
+        if tool_name == "test_tool4":
+            # embedded blob resource
+            br = BlobResourceContents(
+                mimeType="application/octet-stream",
+                blob=base64.b64encode(b"test_blob_content").decode("utf-8"),
+                uri=AnyUrl("https://test_blob_uri"),
+            )
+            return SimpleNamespace(
+                content=[EmbeddedResource(resource=br, type="resource")], isError=False
+            )
+        return SimpleNamespace(content=[], isError=False)
 
-        mock_call_mcp_tool.side_effect = _call_side_effect
+    mock_call_mcp_tool.side_effect = _call_side_effect
 
-        # Only allow image/* — text/plain should be skipped entirely
-        mcp_toolset = MCPToolSet(
-            type="mcp",
-            mcp_server_info=MCPServerInfo(
-                url="https://test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
-            ),
-            name="mcp-toolset",
-            description="MCP toolset",
-            attachment=AttachmentConfig(supported_types=["image/*"]),
+    mcp_toolset = MCPToolSet(
+        type="mcp",
+        mcp_server_info=MCPServerInfo(
+            url="https://test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+        ),
+        name="mcp-toolset",
+        description="Set with MCP tools",
+    )
+
+    def configure(binder: Binder) -> None:
+        binder.bind(Stage, to=mock_stage)
+        binder.bind(DialSettings, DialSettings(url="https://core"))
+        binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+        binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+        binder.bind(AttachmentService, mock_dial_attachment_service)
+        binder.bind(
+            ApplicationConfig,
+            to=create_app_configuration([mcp_toolset]),
+        )
+        binder.bind(PerformanceTimer, to=PerformanceTimer)
+        binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.multibind(list[ToolArgumentTransformer], to=[])
+
+    app = create_test_app([MCPToolingModule, configure])
+
+    @app.get("/")
+    async def get_method(injector: Injector = Injected(Injector)):
+        initializers = injector.get(list[CompletionInitializer])
+        assert len(initializers) == 1
+        initializer = initializers[0]
+        await initializer.initialize()
+
+        mock_get_tools_list.assert_called_once()
+
+        tools = injector.get(list[StagedBaseTool])
+        assert len(tools) == 4
+
+        # Use the public async entrypoint `arun(tool_call_id, ...)`
+        tool_1_instance = next((t for t in tools if t.name == "test_tool1"), None)
+        tool_1_result = await tool_1_instance.arun("call-1")
+        assert tool_1_result == CompletionResult(
+            tool_call_id="call-1",
+            content='test_result_1',
+            content_type='text/markdown',
+            attachments=None,
         )
 
-        def configure(binder: Binder) -> None:
-            binder.bind(Stage, to=mock_stage)
-            binder.bind(DialSettings, DialSettings(url="https://core"))
-            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
-            binder.bind(AttachmentService, mock_dial_attachment_service)
-            binder.bind(
-                ApplicationConfig,
-                to=create_app_configuration([mcp_toolset]),
-            )
-            binder.bind(PerformanceTimer, to=PerformanceTimer)
-            binder.bind(ForwardedHeaders, to=InstanceProvider(None))
-            binder.multibind(list[ToolArgumentTransformer], to=[])
+        tool_2_instance = next((t for t in tools if t.name == "test_tool2"), None)
+        tool_2_result = await tool_2_instance.arun("call-2")
+        assert tool_2_result == CompletionResult(
+            tool_call_id="call-2",
+            content="",
+            content_type='text/markdown',
+            attachments=[
+                Attachment(
+                    type='image/png',
+                    title="Attachment",
+                    data=None,
+                    url="mocked_url",
+                    reference_type=None,
+                    reference_url=None,
+                )
+            ],
+            propagate_to_choice=[
+                Attachment(
+                    type='image/png',
+                    title='Attachment',
+                    data=None,
+                    url='mocked_url',
+                    reference_type=None,
+                    reference_url=None,
+                )
+            ],
+        )
 
-        app = create_test_app([MCPToolingModule, configure])
+        tool_3_instance = next((t for t in tools if t.name == "test_tool3"), None)
+        tool_3_result = await tool_3_instance.arun("call-3")
+        assert tool_3_result == CompletionResult(
+            tool_call_id="call-3",
+            content="",
+            content_type='text/markdown',
+            attachments=[
+                Attachment(
+                    type='text/plain',
+                    title="Attachment",
+                    data=None,
+                    url="mocked_url",
+                    reference_type=None,
+                    reference_url=None,
+                )
+            ],
+        )
 
-        @app.get("/")
-        async def get_method(injector: Injector = Injected(Injector)):
-            initializers = injector.get(list[CompletionInitializer])
-            await initializers[0].initialize()
+        tool_4_instance = next((t for t in tools if t.name == "test_tool4"), None)
+        tool_4_result = await tool_4_instance.arun("call-4")
+        assert tool_4_result == CompletionResult(
+            tool_call_id="call-4",
+            content="",
+            content_type='text/markdown',
+            attachments=[
+                Attachment(
+                    type='application/octet-stream',
+                    title="Attachment",
+                    data=None,
+                    url="mocked_url",
+                    reference_type=None,
+                    reference_url=None,
+                )
+            ],
+        )
 
-            tools = injector.get(list[StagedBaseTool])
-            self.assertEqual(len(tools), 1)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
 
-            result = await tools[0].arun("call-1")
 
-            # Only image should survive — text/plain is skipped by _should_upload
-            self.assertIsNotNone(result.attachments)
-            self.assertEqual(len(result.attachments), 1)
-            self.assertEqual(result.attachments[0].type, "image/png")
+@pytest.mark.asyncio
+@patch(
+    "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.call_mcp_tool",
+    new_callable=AsyncMock,
+)
+@patch(
+    "quickapp.mcp_tooling._mcp_tool_initializer._MCPConnectionManager.get_tools_list",
+    new_callable=AsyncMock,
+)
+async def test_mcp_tool_narrow_supported_types_skips_non_matching(
+    mock_get_tools_list, mock_call_mcp_tool
+):
+    """Non-matching attachments are neither uploaded nor appended to the result."""
+    tool_1 = SimpleNamespace(name="img_tool", description="Image tool", inputSchema={})
+    mock_get_tools_list.return_value = [tool_1]
 
-            # Upload should only be called once (for the image)
-            self.assertEqual(mock_dial_attachment_service.upload_attachment_to_core.call_count, 1)
+    mock_stage = MagicMock(spec=Stage)
+    mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+    mock_dial_attachment_service.upload_attachment_to_core = AsyncMock()
 
-        client = TestClient(app)
-        response = client.get("/")
-        self.assertEqual(response.status_code, 200)
+    async def mock_upload(attachment):
+        attachment.url = "mocked_url"
+        attachment.data = None
+        attachment.title = "Attachment"
+        return attachment
+
+    mock_dial_attachment_service.upload_attachment_to_core.side_effect = mock_upload
+
+    # Tool returns both image and text attachments
+    async def _call_side_effect(tool_name, **kwargs):
+        tr = TextResourceContents(
+            mimeType="text/plain", text="some_text", uri=AnyUrl("https://example")
+        )
+        return SimpleNamespace(
+            content=[
+                ImageContent(
+                    mimeType="image/png",
+                    data=base64.b64encode(b"img").decode("utf-8"),
+                    type="image",
+                ),
+                EmbeddedResource(resource=tr, type="resource"),
+            ],
+            isError=False,
+        )
+
+    mock_call_mcp_tool.side_effect = _call_side_effect
+
+    # Only allow image/* — text/plain should be skipped entirely
+    mcp_toolset = MCPToolSet(
+        type="mcp",
+        mcp_server_info=MCPServerInfo(
+            url="https://test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+        ),
+        name="mcp-toolset",
+        description="MCP toolset",
+        attachment=AttachmentConfig(supported_types=["image/*"]),
+    )
+
+    def configure(binder: Binder) -> None:
+        binder.bind(Stage, to=mock_stage)
+        binder.bind(DialSettings, DialSettings(url="https://core"))
+        binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+        binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+        binder.bind(AttachmentService, mock_dial_attachment_service)
+        binder.bind(
+            ApplicationConfig,
+            to=create_app_configuration([mcp_toolset]),
+        )
+        binder.bind(PerformanceTimer, to=PerformanceTimer)
+        binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.multibind(list[ToolArgumentTransformer], to=[])
+
+    app = create_test_app([MCPToolingModule, configure])
+
+    @app.get("/")
+    async def get_method(injector: Injector = Injected(Injector)):
+        initializers = injector.get(list[CompletionInitializer])
+        await initializers[0].initialize()
+
+        tools = injector.get(list[StagedBaseTool])
+        assert len(tools) == 1
+
+        result = await tools[0].arun("call-1")
+
+        # Only image should survive — text/plain is skipped by _should_upload
+        assert result.attachments is not None
+        assert len(result.attachments) == 1
+        assert result.attachments[0].type == "image/png"
+
+        # Upload should only be called once (for the image)
+        assert mock_dial_attachment_service.upload_attachment_to_core.call_count == 1
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit_tests/rest_api_tooling_tests/test_request_detalis.py
+++ b/src/tests/unit_tests/rest_api_tooling_tests/test_request_detalis.py
@@ -1,29 +1,28 @@
-import unittest
+import pytest
 from httpx import URL, Headers, QueryParams
 # noinspection PyProtectedMember
 from quickapp.rest_api_tooling._request_details import _RequestDetails
 
 
+def test_missing_url_raises_value_error():
+    with pytest.raises(ValueError) as exc_info:
+        _RequestDetails(
+            url=None,
+            method="GET",
+            headers=Headers(),
+            params=QueryParams(),
+            data={}
+        )
+    assert str(exc_info.value) == "URL must be set."
 
-class TestRequestDetailsV2(unittest.TestCase):
-    def test_missing_url_raises_value_error(self):
-        with self.assertRaises(ValueError) as context:
-            _RequestDetails(
-                url=None,
-                method="GET",
-                headers=Headers(),
-                params=QueryParams(),
-                data={}
-            )
-        self.assertEqual(str(context.exception), "URL must be set.")
 
-    def test_missing_method_raises_value_error(self):
-        with self.assertRaises(ValueError) as context:
-            _RequestDetails(
-                url=URL("https://example.com"),
-                method=None,
-                headers=Headers(),
-                params=QueryParams(),
-                data={}
-            )
-        self.assertEqual(str(context.exception), "HTTP method must be set.")
+def test_missing_method_raises_value_error():
+    with pytest.raises(ValueError) as exc_info:
+        _RequestDetails(
+            url=URL("https://example.com"),
+            method=None,
+            headers=Headers(),
+            params=QueryParams(),
+            data={}
+        )
+    assert str(exc_info.value) == "HTTP method must be set."

--- a/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
+++ b/src/tests/unit_tests/rest_api_tooling_tests/test_rest_api_tool.py
@@ -1,4 +1,3 @@
-import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6,7 +5,6 @@ from aidial_sdk.chat_completion import Attachment, Stage
 from fastapi_injector import Injected
 from httpx import QueryParams
 from injector import Binder, InstanceProvider
-from parameterized import parameterized
 from pydantic import SecretStr
 from starlette.testclient import TestClient
 
@@ -63,280 +61,285 @@ def _make_rest_api_tool(url: str, method: str, **tool_kwargs) -> RestApiTool:
     )
 
 
-class TestWebApiToolV2(unittest.IsolatedAsyncioTestCase):
+@pytest.mark.asyncio
+@pytest.mark.parametrize("request_method,url", [("get", "https://auth@abc.example.com:2020/index")])
+@patch("httpx.AsyncClient")
+async def test_web_api_tool_2_make_correct_http_call(
+    mock_async_client, request_method, url
+):
+    mock_stage = MagicMock(spec=Stage)
+    response_data = {
+        "text": '{"some_key":"some value"}',
+        "headers": {"Content-Type": "application/json"},
+    }
+    mock_response = AsyncMock(**response_data)
+    mock_response.raise_for_status = MagicMock()
+    mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
 
-    @parameterized.expand([("get", "https://auth@abc.example.com:2020/index")])
-    @patch("httpx.AsyncClient")
-    async def test_web_api_tool_2_make_correct_http_call(
-        self, request_method, url, mock_async_client
-    ):
-        mock_stage = MagicMock(spec=Stage)
-        response_data = {
-            "text": '{"some_key":"some value"}',
-            "headers": {"Content-Type": "application/json"},
-        }
-        mock_response = AsyncMock(**response_data)
-        mock_response.raise_for_status = MagicMock()
-        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
-
-        rest_api_toolset = RestApiToolSet(
-            name="rest-api",
-            authorization=BearerAuthorization(token="test_token"),
-            tools=[
-                RestApiTool(
-                    rest_api_method_info=RestApiEndpointMethodInfo(
-                        method_url=url, method_type=request_method
+    rest_api_toolset = RestApiToolSet(
+        name="rest-api",
+        authorization=BearerAuthorization(token="test_token"),
+        tools=[
+            RestApiTool(
+                rest_api_method_info=RestApiEndpointMethodInfo(
+                    method_url=url, method_type=request_method
+                ),
+                open_ai_tool=OpenAiToolConfig(
+                    function=OpenAiToolFunction(
+                        name="test_function",
+                        description="Test function",
+                        parameters=OpenAiToolFunctionParameters(
+                            properties={
+                                "query_key": RestApiEndpointSimpleTypeParam(
+                                    type="string",
+                                    description="Query key",
+                                    parameter_info=RestApiEndpointHeaderParamInfo(
+                                        type=ToolEndpointParamType.query, key="query_key"
+                                    ),
+                                )
+                            },
+                            type="object",
+                        ),
                     ),
-                    open_ai_tool=OpenAiToolConfig(
-                        function=OpenAiToolFunction(
-                            name="test_function",
-                            description="Test function",
-                            parameters=OpenAiToolFunctionParameters(
-                                properties={
-                                    "query_key": RestApiEndpointSimpleTypeParam(
-                                        type="string",
-                                        description="Query key",
-                                        parameter_info=RestApiEndpointHeaderParamInfo(
-                                            type=ToolEndpointParamType.query, key="query_key"
-                                        ),
-                                    )
-                                },
-                                type="object",
-                            ),
-                        )
-                    ),
-                )
-            ],
-        )
+                ),
+            )
+        ],
+    )
 
-        def configure(binder: Binder):
-            binder.bind(DialSettings, DialSettings(url="https://core"))
-            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
-            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            binder.bind(Stage, to=mock_stage)
-            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
-            binder.bind(ForwardedHeaders, to=InstanceProvider(None))
-            binder.multibind(list[ToolArgumentTransformer], to=[])
+    def configure(binder: Binder):
+        binder.bind(DialSettings, DialSettings(url="https://core"))
+        binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+        binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+        binder.bind(Stage, to=mock_stage)
+        binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+        binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.multibind(list[ToolArgumentTransformer], to=[])
 
-        app = create_test_app([RestApiToolingModule, configure])
+    app = create_test_app([RestApiToolingModule, configure])
 
-        @app.get("/")
-        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
-            self.assertEqual(len(tools), 1)
-            tool = tools[0]
+    @app.get("/")
+    async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+        assert len(tools) == 1
+        tool = tools[0]
 
-            result = await tool.arun("call-1", None, **{"query_key": "query_value"})
+        result = await tool.arun("call-1", None, **{"query_key": "query_value"})
 
-            # With default response_as_attachment (None/disabled), no attachment is created
-            self.assertEqual(result.tool_call_id, "call-1")
-            self.assertEqual(result.content, '{"some_key":"some value"}')
-            self.assertEqual(result.content_type, "application/json")
-            self.assertEqual(result.attachments, [])
+        # With default response_as_attachment (None/disabled), no attachment is created
+        assert result.tool_call_id == "call-1"
+        assert result.content == '{"some_key":"some value"}'
+        assert result.content_type == "application/json"
+        assert result.attachments == []
 
-            return {"message": "success"}
+        return {"message": "success"}
 
-        client = TestClient(app)
-        response = client.get("/")
+    client = TestClient(app)
+    response = client.get("/")
 
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.json(), {"message": "success"})
+    assert response.status_code == 200
+    assert response.json() == {"message": "success"}
 
-        expected_request_data = {
-            "url": url,
-            "method": request_method,
-            "params": QueryParams('query_key=query_value'),
-        }
+    expected_request_data = {
+        "url": url,
+        "method": request_method,
+        "params": QueryParams('query_key=query_value'),
+    }
 
-        actual_request_data = (
-            mock_async_client.return_value.__aenter__.return_value.request.call_args[1]
-        )
+    actual_request_data = (
+        mock_async_client.return_value.__aenter__.return_value.request.call_args[1]
+    )
 
-        self.assertEqual(expected_request_data["url"], actual_request_data["url"])
-        self.assertEqual(expected_request_data["params"], actual_request_data["params"])
-        self.assertEqual(
-            expected_request_data["method"].lower(), actual_request_data["method"].lower()
-        )
-        self.assertIn("authorization", actual_request_data["headers"])
-        self.assertEqual("Bearer test_token", actual_request_data["headers"]["authorization"])
+    assert expected_request_data["url"] == actual_request_data["url"]
+    assert expected_request_data["params"] == actual_request_data["params"]
+    assert (
+        expected_request_data["method"].lower() == actual_request_data["method"].lower()
+    )
+    assert "authorization" in actual_request_data["headers"]
+    assert "Bearer test_token" == actual_request_data["headers"]["authorization"]
 
-    @patch("httpx.AsyncClient")
-    async def test_response_as_attachment_enabled_creates_attachment(self, mock_async_client):
-        url = "https://example.com/api"
-        mock_stage = MagicMock(spec=Stage)
-        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
 
-        async def mock_upload(attachment):
-            return attachment
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_response_as_attachment_enabled_creates_attachment(mock_async_client):
+    url = "https://example.com/api"
+    mock_stage = MagicMock(spec=Stage)
+    mock_dial_attachment_service = MagicMock(spec=AttachmentService)
 
-        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
-            side_effect=mock_upload
-        )
+    async def mock_upload(attachment):
+        return attachment
 
-        response_data = {
-            "text": '{"data": "value"}',
-            "headers": {"Content-Type": "application/json"},
-        }
-        mock_response = AsyncMock(**response_data)
-        mock_response.raise_for_status = MagicMock()
-        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
+    mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
+        side_effect=mock_upload
+    )
 
-        rest_api_toolset = RestApiToolSet(
-            name="rest-api",
-            authorization=BearerAuthorization(token="test_token"),
-            tools=[
-                _make_rest_api_tool(
-                    url,
-                    "get",
-                    response_as_attachment=ResponseAsAttachmentConfig(enabled=True),
-                )
-            ],
-        )
+    response_data = {
+        "text": '{"data": "value"}',
+        "headers": {"Content-Type": "application/json"},
+    }
+    mock_response = AsyncMock(**response_data)
+    mock_response.raise_for_status = MagicMock()
+    mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
 
-        def configure(binder: Binder):
-            binder.bind(DialSettings, DialSettings(url="https://core"))
-            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
-            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            binder.bind(AttachmentService, mock_dial_attachment_service)
-            binder.bind(Stage, to=mock_stage)
-            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
-            binder.bind(ForwardedHeaders, to=InstanceProvider(None))
-            binder.multibind(list[ToolArgumentTransformer], to=[])
+    rest_api_toolset = RestApiToolSet(
+        name="rest-api",
+        authorization=BearerAuthorization(token="test_token"),
+        tools=[
+            _make_rest_api_tool(
+                url,
+                "get",
+                response_as_attachment=ResponseAsAttachmentConfig(enabled=True),
+            )
+        ],
+    )
 
-        app = create_test_app([RestApiToolingModule, configure])
+    def configure(binder: Binder):
+        binder.bind(DialSettings, DialSettings(url="https://core"))
+        binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+        binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+        binder.bind(AttachmentService, mock_dial_attachment_service)
+        binder.bind(Stage, to=mock_stage)
+        binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+        binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.multibind(list[ToolArgumentTransformer], to=[])
 
-        @app.get("/")
-        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
-            self.assertEqual(len(tools), 1)
-            result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+    app = create_test_app([RestApiToolingModule, configure])
 
-            self.assertEqual(result.tool_call_id, "call-1")
-            self.assertEqual(result.content, '{"data": "value"}')
-            self.assertIsNotNone(result.attachments)
-            self.assertEqual(len(result.attachments), 1)
-            self.assertIsInstance(result.attachments[0], Attachment)
-            self.assertEqual(result.attachments[0].type, "application/json")
-            return {"message": "success"}
+    @app.get("/")
+    async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+        assert len(tools) == 1
+        result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
 
-        client = TestClient(app)
-        response = client.get("/")
-        self.assertEqual(response.status_code, 200)
+        assert result.tool_call_id == "call-1"
+        assert result.content == '{"data": "value"}'
+        assert result.attachments is not None
+        assert len(result.attachments) == 1
+        assert isinstance(result.attachments[0], Attachment)
+        assert result.attachments[0].type == "application/json"
+        return {"message": "success"}
 
-    @patch("httpx.AsyncClient")
-    async def test_response_as_attachment_include_body_as_content_false(self, mock_async_client):
-        url = "https://example.com/api"
-        mock_stage = MagicMock(spec=Stage)
-        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
 
-        async def mock_upload(attachment):
-            return attachment
 
-        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
-            side_effect=mock_upload
-        )
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_response_as_attachment_include_body_as_content_false(mock_async_client):
+    url = "https://example.com/api"
+    mock_stage = MagicMock(spec=Stage)
+    mock_dial_attachment_service = MagicMock(spec=AttachmentService)
 
-        response_data = {
-            "text": '{"data": "value"}',
-            "headers": {"Content-Type": "application/json"},
-        }
-        mock_response = AsyncMock(**response_data)
-        mock_response.raise_for_status = MagicMock()
-        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
+    async def mock_upload(attachment):
+        return attachment
 
-        rest_api_toolset = RestApiToolSet(
-            name="rest-api",
-            authorization=BearerAuthorization(token="test_token"),
-            tools=[
-                _make_rest_api_tool(
-                    url,
-                    "get",
-                    response_as_attachment=ResponseAsAttachmentConfig(
-                        enabled=True, include_body_as_content=False
-                    ),
-                )
-            ],
-        )
+    mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
+        side_effect=mock_upload
+    )
 
-        def configure(binder: Binder):
-            binder.bind(DialSettings, DialSettings(url="https://core"))
-            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
-            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            binder.bind(AttachmentService, mock_dial_attachment_service)
-            binder.bind(Stage, to=mock_stage)
-            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
-            binder.bind(ForwardedHeaders, to=InstanceProvider(None))
-            binder.multibind(list[ToolArgumentTransformer], to=[])
+    response_data = {
+        "text": '{"data": "value"}',
+        "headers": {"Content-Type": "application/json"},
+    }
+    mock_response = AsyncMock(**response_data)
+    mock_response.raise_for_status = MagicMock()
+    mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
 
-        app = create_test_app([RestApiToolingModule, configure])
+    rest_api_toolset = RestApiToolSet(
+        name="rest-api",
+        authorization=BearerAuthorization(token="test_token"),
+        tools=[
+            _make_rest_api_tool(
+                url,
+                "get",
+                response_as_attachment=ResponseAsAttachmentConfig(
+                    enabled=True, include_body_as_content=False
+                ),
+            )
+        ],
+    )
 
-        @app.get("/")
-        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
-            self.assertEqual(len(tools), 1)
-            result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+    def configure(binder: Binder):
+        binder.bind(DialSettings, DialSettings(url="https://core"))
+        binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+        binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+        binder.bind(AttachmentService, mock_dial_attachment_service)
+        binder.bind(Stage, to=mock_stage)
+        binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+        binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.multibind(list[ToolArgumentTransformer], to=[])
 
-            self.assertEqual(result.tool_call_id, "call-1")
-            self.assertTrue(result.content.startswith("See attached file:"))
-            self.assertEqual(len(result.attachments), 1)
-            return {"message": "success"}
+    app = create_test_app([RestApiToolingModule, configure])
 
-        client = TestClient(app)
-        response = client.get("/")
-        self.assertEqual(response.status_code, 200)
+    @app.get("/")
+    async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+        assert len(tools) == 1
+        result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
 
-    @patch("httpx.AsyncClient")
-    async def test_toolset_level_response_as_attachment_propagation(self, mock_async_client):
-        url = "https://example.com/api"
-        mock_stage = MagicMock(spec=Stage)
-        mock_dial_attachment_service = MagicMock(spec=AttachmentService)
+        assert result.tool_call_id == "call-1"
+        assert result.content.startswith("See attached file:")
+        assert len(result.attachments) == 1
+        return {"message": "success"}
 
-        async def mock_upload(attachment):
-            return attachment
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
 
-        mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
-            side_effect=mock_upload
-        )
 
-        response_data = {
-            "text": '{"data": "value"}',
-            "headers": {"Content-Type": "application/json"},
-        }
-        mock_response = AsyncMock(**response_data)
-        mock_response.raise_for_status = MagicMock()
-        mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
+@pytest.mark.asyncio
+@patch("httpx.AsyncClient")
+async def test_toolset_level_response_as_attachment_propagation(mock_async_client):
+    url = "https://example.com/api"
+    mock_stage = MagicMock(spec=Stage)
+    mock_dial_attachment_service = MagicMock(spec=AttachmentService)
 
-        # Tool does NOT set response_as_attachment, but toolset does
-        rest_api_toolset = RestApiToolSet(
-            name="rest-api",
-            authorization=BearerAuthorization(token="test_token"),
-            response_as_attachment=ResponseAsAttachmentConfig(enabled=True),
-            tools=[_make_rest_api_tool(url, "get")],
-        )
+    async def mock_upload(attachment):
+        return attachment
 
-        def configure(binder: Binder):
-            binder.bind(DialSettings, DialSettings(url="https://core"))
-            binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
-            binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
-            binder.bind(AttachmentService, mock_dial_attachment_service)
-            binder.bind(Stage, to=mock_stage)
-            binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
-            binder.bind(ForwardedHeaders, to=InstanceProvider(None))
-            binder.multibind(list[ToolArgumentTransformer], to=[])
+    mock_dial_attachment_service.upload_attachment_to_core = AsyncMock(
+        side_effect=mock_upload
+    )
 
-        app = create_test_app([RestApiToolingModule, configure])
+    response_data = {
+        "text": '{"data": "value"}',
+        "headers": {"Content-Type": "application/json"},
+    }
+    mock_response = AsyncMock(**response_data)
+    mock_response.raise_for_status = MagicMock()
+    mock_async_client.return_value.__aenter__.return_value.request.return_value = mock_response
 
-        @app.get("/")
-        async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
-            self.assertEqual(len(tools), 1)
-            result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+    # Tool does NOT set response_as_attachment, but toolset does
+    rest_api_toolset = RestApiToolSet(
+        name="rest-api",
+        authorization=BearerAuthorization(token="test_token"),
+        response_as_attachment=ResponseAsAttachmentConfig(enabled=True),
+        tools=[_make_rest_api_tool(url, "get")],
+    )
 
-            self.assertEqual(result.tool_call_id, "call-1")
-            self.assertIsNotNone(result.attachments)
-            self.assertEqual(len(result.attachments), 1)
-            self.assertEqual(result.attachments[0].type, "application/json")
-            return {"message": "success"}
+    def configure(binder: Binder):
+        binder.bind(DialSettings, DialSettings(url="https://core"))
+        binder.bind(DIAL_BEARER, to=InstanceProvider(SecretStr("some_token")))
+        binder.bind(DIAL_API_KEY, SecretStr("some_api_key"))
+        binder.bind(AttachmentService, mock_dial_attachment_service)
+        binder.bind(Stage, to=mock_stage)
+        binder.bind(ApplicationConfig, to=create_app_configuration([rest_api_toolset]))
+        binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.multibind(list[ToolArgumentTransformer], to=[])
 
-        client = TestClient(app)
-        response = client.get("/")
-        self.assertEqual(response.status_code, 200)
+    app = create_test_app([RestApiToolingModule, configure])
+
+    @app.get("/")
+    async def get_method(tools: list[StagedBaseTool] = Injected(list[StagedBaseTool])):
+        assert len(tools) == 1
+        result = await tools[0].arun("call-1", None, **{"query_key": "query_value"})
+
+        assert result.tool_call_id == "call-1"
+        assert result.attachments is not None
+        assert len(result.attachments) == 1
+        assert result.attachments[0].type == "application/json"
+        return {"message": "success"}
+
+    client = TestClient(app)
+    response = client.get("/")
+    assert response.status_code == 200
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit_tests/usage_statistics_tests/test_pricing_registry.py
+++ b/src/tests/unit_tests/usage_statistics_tests/test_pricing_registry.py
@@ -1,39 +1,40 @@
-import unittest
 from unittest.mock import MagicMock
+
+import pytest
+
 # noinspection PyProtectedMember
 from quickapp.usage_statistics._pricing_registry import _PricingRegistry
 # noinspection PyProtectedMember
 from quickapp.usage_statistics._pricing import _Pricing
 
 
-class TestPricingRegistry(unittest.TestCase):
+@pytest.fixture
+def registry():
+    return _PricingRegistry()
 
-    def setUp(self):
-        self.registry = _PricingRegistry()
 
-    def test_get_model_pricing_returns_pricing_if_not_expired(self):
-        mock_pricing = MagicMock(spec=_Pricing)
-        mock_pricing.is_expired.return_value = False
-        self.registry.set_model_pricing("test_model", mock_pricing)
+def test_get_model_pricing_returns_pricing_if_not_expired(registry):
+    mock_pricing = MagicMock(spec=_Pricing)
+    mock_pricing.is_expired.return_value = False
+    registry.set_model_pricing("test_model", mock_pricing)
 
-        result = self.registry.get_model_pricing("test_model")
+    result = registry.get_model_pricing("test_model")
 
-        self.assertIs(result, mock_pricing)
-        mock_pricing.is_expired.assert_called_once()
+    assert result is mock_pricing
+    mock_pricing.is_expired.assert_called_once()
 
-    def test_get_model_pricing_returns_none_if_expired(self):
-        mock_pricing = MagicMock(spec=_Pricing)
-        mock_pricing.is_expired.return_value = True
-        self.registry.set_model_pricing("test_model", mock_pricing)
 
-        result = self.registry.get_model_pricing("test_model")
+def test_get_model_pricing_returns_none_if_expired(registry):
+    mock_pricing = MagicMock(spec=_Pricing)
+    mock_pricing.is_expired.return_value = True
+    registry.set_model_pricing("test_model", mock_pricing)
 
-        self.assertIsNone(result)
-        mock_pricing.is_expired.assert_called_once()
+    result = registry.get_model_pricing("test_model")
 
-    def test_get_model_pricing_returns_none_if_not_in_cache(self):
-        result = self.registry.get_model_pricing("nonexistent_model")
-        self.assertIsNone(result)
+    assert result is None
+    mock_pricing.is_expired.assert_called_once()
 
-if __name__ == "__main__":
-    unittest.main()
+
+def test_get_model_pricing_returns_none_if_not_in_cache(registry):
+    result = registry.get_model_pricing("nonexistent_model")
+    assert result is None


### PR DESCRIPTION
### Applicable issues

- fixes #62 

### Description of changes

Updates unit tests to get rid of unittest dependency in favor of existing pytest

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Design documented is updated/created and approved by the team (if applicable)
- [ ] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
