### PR TITLE
feat: propagate stages #87 (Draft)

### DIFF
--- a/config/predefined/tool/dial_rag.json
+++ b/config/predefined/tool/dial_rag.json
@@ -10,7 +10,8 @@
   },
   "content_propagation": {
     "propagate_history": true,
-    "propagate_headers": []
+    "propagate_headers": [],
+    "propagate_stages": true
   },
   "open_ai_tool": {
     "type": "function",

--- a/docs/designs/subagent_stage_propagation.md
+++ b/docs/designs/subagent_stage_propagation.md
@@ -1,6 +1,6 @@
 # Design: Subagent Stage Propagation
 
-**Status:** Implemented
+**Status:** Draft
 
 ## Problem Statement
 
@@ -14,12 +14,15 @@ When a QuickApp invokes subagents (e.g. DIAL RAG, nested QuickApps), there is no
 - It must be **clear to the user that these stages belong to the subagent**, not to the root QuickApp. The UX must distinguish “stages of this QuickApp” from “stages of a subagent this QuickApp called” (e.g. labelling, grouping, or attribution so the source is unambiguous).
 - Propagation must be **opt-in per deployment tool** via configuration; default behaviour remains no propagation.
 - Handling of deployment stream deltas (including stages) must stay in a **single place** so the rest of the application stays agnostic to subagent internals.
+- Propagation should **stream** subagent stage updates to the root choice as deltas arrive, so users see progress during the call and the backend avoids holding unbounded per-stage buffers until end-of-stream.
 
 ---
 
 ## Proposed Design
 
-Subagent stages are propagated to the root QuickApp choice only when a deployment tool is explicitly configured to do so. A new setting under `content_propagation` controls whether stages from the deployment completion stream are surfaced. The application reacts to `custom_content.stages` in the deployment completion stream inside `DialCompletionService._consume_stream()`, creating or updating stages on the current tool’s stage wrapper. Each propagated stage’s display name is prefixed with the invoking tool’s `display.stage.name` so the source (subagent vs root) is unambiguous. The design is backend-only; the DIAL chat completion wire format for `delta.custom_content.stages` is assumed given.
+Subagent stages are propagated to the root QuickApp choice only when a deployment tool is explicitly configured to do so. A new setting under `content_propagation` controls whether stages from the deployment completion stream are surfaced. The application reacts to `custom_content.stages` in the deployment completion stream inside `DialCompletionService._consume_stream()`, **creating or resolving a propagated stage per subagent `index` on first touch and applying each delta immediately** (name parts, content, attachments, status) through the stage wrapper. **DIAL supplies only append semantics** for stage fields (no full replacement of content); the consumer always merges by appending where applicable.
+
+Each propagated stage’s display name is prefixed with the deployment tool’s **deployment name** so the source is unambiguous even when `display.stage` is omitted (display remains optional). The design is backend-only; the DIAL chat completion wire format for `delta.custom_content.stages` is assumed given.
 
 ### Concern 1: Tool config (deployment)
 
@@ -29,51 +32,113 @@ Subagent stages are propagated to the root QuickApp choice only when a deploymen
 
 **Semantics:** Add `propagate_stages: bool = False` to `ContentPropagation`. When `True`, the deployment tool instructs the completion service to interpret `delta.custom_content.stages` and propagate them to the root QuickApp choice with prefixed names. Only deployment tools that set this to `True` propagate subagent stages.
 
-**Change:** New field `propagate_stages` on `ContentPropagation` with description documenting that subagent stages from the deployment stream are propagated to the root choice with prefixed names so the source is unambiguous.
+**Change:** Field `propagate_stages` on `ContentPropagation` with description documenting that subagent stages from the deployment stream are propagated to the root choice with prefixed names so the source is unambiguous.
 
 ### Concern 2: Tool config (display)
 
-**What:** Reuse existing display stage name as the prefix for propagated stages.
+**What:** Optional display configuration for the deployment tool’s **own** stage (title/body/visibility). It is **not** required for stage propagation naming.
 
 **Owner:** `ToolDisplayConfig.stage` (`ToolStageConfig`: `name`, `body`, `show`).
 
-**Semantics:** No new config. The existing `display.stage.name` is the value used as the prefix for propagated stage names (e.g. “RAG search: › Access document '...' [0.01s]”). This reuses the existing display config and gives users clear attribution without new config surface.
+**Semantics:** `display.stage` remains optional. Propagated subagent stage titles use the **deployment name** as the prefix (see Concern 6), not `display.stage.name`, so propagation works for minimal configs. When present, `display.stage` continues to apply to the tool stage chrome as today.
 
-**Change:** None. Read-only use of `tool_config.display.stage.name` when building propagated stage names.
+**Change:** None to the schema; documentation and implementation treat display as independent of the propagation prefix rule.
 
-### Concern 3: DialCompletionService — stream consumption and stage creation
+### Concern 3: DialCompletionService — streaming consumption and stage updates
 
-**What:** In `_consume_stream()`, when stage propagation is enabled and `delta.custom_content` carries a `stages` field, accumulate by **stage index** (same index = same stage, merge; new index = new stage). After the stream, create one propagated stage per index with prefixed name and accumulated content/attachments.
+**What:** In `_consume_stream()`, when stage propagation is enabled and `delta.custom_content` carries a `stages` field, **apply each parsed stage delta immediately** to the corresponding propagated stage (create the stage on first sight of an `index`, then append updates). Do **not** accumulate full content/attachments in memory until end-of-stream for the purpose of propagation.
 
 **Owner:** `DialCompletionService` in `quickapp.dial_deployment_tooling.dial_completion_service`.
 
 **Semantics:**
 
-- **Accumulation:** For each delta with `custom_content.stages`, parse into a list of `SubagentStageDelta` (see data contracts). Group by `index`: append name parts, content, attachments; keep last status.
-- **After stream:** Create one propagated stage per index in sorted order. Display name = `{tool_stage_display_name}{separator}{concatenated name parts}`. If there are no name parts, use `"Stage {index+1}"`. Write accumulated content and attachments to each stage.
-- **Separator:** Fixed constant `PROPAGATED_STAGE_NAME_SEPARATOR` (e.g. `" › "`) from `quickapp.dial_deployment_tooling.constants`.
+- **Per delta:** Parse `custom_content.stages` into `SubagentStageDelta` items (see data contracts). For each item, resolve the propagated stage for `index` (create if missing). Apply fields present in the delta:
+  - **Name / title:** append name parts in order (same merge rule as before, but live on the stage).
+  - **Content:** append (DIAL does not send replacement content; only append).
+  - **Attachments:** extend the stage’s attachments as they appear (see Concern 7).
+  - **Status:** update to the latest value from the delta so the UI can reflect running/completed as the stream progresses.
+- **Ordering:** Process items in stream order. Stages for distinct indices appear as the stream introduces them; final ordering follows SDK/choice rules (e.g. creation order).
+- **Separator:** Fixed constant `PROPAGATED_STAGE_NAME_SEPARATOR` (e.g. `" › "`) from `quickapp.dial_deployment_tooling.constants`, used when composing the full displayed title `{deployment_name}{separator}{concatenated name parts}`. If there are no name parts yet, use a placeholder such as `"Stage {index+1}"` until name parts arrive, or the implementation’s equivalent.
 
-**Change:** Extend `complete_request_async` with optional `propagate_stages: bool = False` and `tool_stage_display_name: str | None = None`; pass them into `_consume_stream`. In `_consume_stream`, when `propagate_stages` is True and `delta.custom_content` has `stages`, accumulate by index and, after the stream, create propagated stages via the stage wrapper (child or sibling stages with prefixed names).
+**Change:** `complete_request_async` / `_consume_stream` accept `propagate_stages` and a **deployment name** (or equivalent string) for the prefix. When `propagate_stages` is True and `stages` is present, stream-apply deltas via the stage wrapper instead of batching at end-of-stream.
 
 ### Concern 4: BaseDeploymentTool — passing propagation into completion
 
-**What:** Derive `propagate_stages` and `tool_stage_display_name` from tool config and pass them into the completion service.
+**What:** Derive `propagate_stages` and the **deployment name** used for propagated stage titles, and pass them into the completion service.
 
 **Owner:** `BaseDeploymentTool` in `quickapp.dial_deployment_tooling.base_deployment_tool`.
 
-**Semantics:** In `_run_in_stage_async`, read `content_propagation.propagate_stages` and `tool_config.display.stage.name` (when present); pass them as `propagate_stages` and `tool_stage_display_name` into `complete_request_async`. When `content_propagation` is `None` or `propagate_stages` is False, pass `propagate_stages=False`; when display stage name is missing, pass `None` (fallback naming still applies).
+**Semantics:** In `_run_in_stage_async`, read `content_propagation.propagate_stages` and the tool’s **deployment name** (the same identifier users/deployers associate with the deployment — e.g. configured deployment name, not optional display). Pass `propagate_stages` and that string into `complete_request_async`. When `content_propagation` is `None` or `propagate_stages` is False, pass `propagate_stages=False`; the deployment name is only required when propagation is True (if missing, treat as configuration error or use a safe fallback documented in implementation).
 
-**Change:** Pass propagation flag and tool stage display name into `complete_request_async` so `_consume_stream` can decide whether to handle `custom_content.stages` and how to prefix names.
+**Change:** Replace or supplement any prior `tool_stage_display_name`-only wiring with **deployment name** as the authoritative prefix source for propagated stages.
 
 ### Concern 5: Stage wrapper and SDK
 
-**What:** Create or update propagated stages from the current tool stage so they appear on the root choice.
+**What:** Create propagated stages from the current tool stage and **mutate them incrementally** as stream deltas arrive.
 
-**Owner:** `BaseStageWrapper` / deployment stage wrapper; SDK `Stage` (e.g. `append_name`, `append_content`, `add_attachment`, or child stage creation).
+**Owner:** `BaseStageWrapper` / deployment stage wrapper; SDK `Stage` (e.g. `append_name`, `append_content`, `add_attachment`, status updates, or child stage creation).
 
-**Semantics:** The tool’s stage can create child stages (e.g. `create_stage(name)` if the SDK supports it), or the application creates sibling stages on the same choice with prefixed names. No change to `BaseStageWrapper` interface beyond what is strictly needed to create a propagated stage and write content/attachments to it.
+**Semantics:** On first delta for `index` *n*, create the propagated stage (child of the tool stage if supported, else sibling on the choice). On subsequent deltas for the same `index`, append name/content, add attachments, and set status. No end-of-stream bulk flush is required for correctness; optional finalization hooks depend on SDK capabilities.
 
-**Change:** Implementation-specific: use SDK support for child stages or fallback (e.g. sibling stages on the choice with prefixed names) so the root choice shows a consistent view matching the subagent’s stage structure.
+**Change:** Implementation ensures idempotent **per-index** resolution (lazy create) and streaming writes aligned with Concern 3.
+
+### Concern 6: Propagated stage naming (deployment name prefix)
+
+**What:** Stable, non-optional attribution prefix for every propagated stage title.
+
+**Owner:** `DialCompletionService` (when composing titles) together with `BaseDeploymentTool` (supplying deployment name).
+
+**Semantics:** Display name = `{deployment_name}{PROPAGATED_STAGE_NAME_SEPARATOR}{concatenated name parts from stream}` (e.g. `my-rag-deployment › Access document '...' [0.01s]`). Name parts are appended in order as deltas arrive. If there are no name parts, use `"Stage {index+1}"` (or equivalent). **Do not rely on `display.stage.name`** for this prefix, because display is optional.
+
+**Change:** Document and implement deployment name as the prefix; align tests and samples with deployment-named examples.
+
+### Concern 7: Propagated attachments
+
+**What:** Attachments may arrive incrementally across many deltas; lists can grow large; order and duplication matter for UX and resources.
+
+**Owner:** `DialCompletionService._consume_stream()` and stage wrapper attachment APIs.
+
+**Semantics:** Attachments are **appended** as they appear in each delta (streaming). **Risks:** unbounded attachment count or payload size per stage, duplicate references if the subagent retries or repeats deltas, and undefined ordering if the wire format is ambiguous.
+
+**Suggested direction:** Define caps (per stage and/or per deployment call), structured logging and metrics when caps trigger (see Concern 10), and a deduplication policy if attachments carry stable identifiers; otherwise document best-effort append order with no dedup.
+
+**Change:** Product/engineering decision on limits; implementation enforces chosen caps without failing the whole completion (degrade gracefully, e.g. skip further attachments with a log + metric).
+
+### Concern 8: Stage index identity and cardinality
+
+**What:** Correct grouping requires a stable **index** per logical subagent stage. Missing or inconsistent indices and high cardinality create wrong merges or resource pressure.
+
+**Owner:** `parse_stages` / `SubagentStageDelta` validation; `DialCompletionService` propagation path.
+
+**Semantics:** Prefer **required `index`** on each item; same index across deltas = same propagated stage. **Risks:** list-position fallbacks can mis-group if list shape varies between chunks; a buggy or hostile stream could emit huge numbers of distinct indices.
+
+**Suggested direction:** Treat missing `index` as invalid for propagation (skip item + metric) once clients are aligned, or document a strict backward-compatibility window for position fallback. Enforce a **maximum number of propagated indices** per deployment call; beyond the cap, ignore new indices with log + metric.
+
+**Change:** Config or constants for caps; metrics for skipped items and truncation.
+
+### Concern 9: Flat UI and grandchild stages
+
+**What:** When a subagent such as RAG streams **its own** internal substeps, those stages may represent work below the immediate subagent. The current product UI does **not** expose a tree of stages; propagated stages appear as a **flat** list on the choice.
+
+**Owner:** Product/UX for presentation; backend only supplies flat propagated stages with a single prefix per deployment tool call.
+
+**Semantics:** Users cannot distinguish “stage of RAG” from “stage of something RAG called” by structure alone — both appear as sibling-like entries with the same deployment name prefix. Attribution is therefore **by naming prefix only**, not by hierarchy.
+
+**Suggested direction:** Accept this limitation unless the client gains hierarchical stage rendering; avoid over-promising nested attribution in copy. Future work could add multi-segment prefixes or metadata if the wire format and UI support it.
+
+**Change:** None required beyond documentation; optional follow-up design if tree UX lands.
+
+### Concern 10: Metrics and logging
+
+**What:** Operators need visibility into propagation volume, truncation, and parse failures without logging sensitive stage bodies by default.
+
+**Owner:** `DialCompletionService` / propagation helper module; application metrics registry (concrete names TBD by implementation).
+
+**Semantics:** Emit **metrics** (counters or histograms as appropriate) for at least: stage deltas applied, propagated stages created (distinct indices), parse/skipped invalid items, attachment or index cap hits, and propagation fallback paths (e.g. stage creation failure). At **info** level, log concise, non-sensitive summaries (e.g. counts per completion, first-time propagation in a call, cap/truncation events) — **not** full concatenated content or attachment payloads unless behind a dedicated debug flag.
+
+**Suggested direction:** Define metric names and label cardinality in the implementation PR; keep logs structured and PII-safe.
+
+**Change:** Add metrics + info-level logging per above; align with existing observability patterns in the service.
 
 ### Data flow (summary)
 
@@ -84,15 +149,14 @@ sequenceDiagram
   participant Stream as Deployment completion stream
   participant Wrapper as Stage wrapper
 
-  Tool->>Svc: complete_request_async(..., propagate_stages=True, tool_stage_display_name="RAG search")
+  Tool->>Svc: complete_request_async(..., propagate_stages=True, deployment_name="my-rag")
   Svc->>Stream: consume stream
   loop Each delta
     Stream-->>Svc: delta.custom_content.stages
-    Svc->>Svc: accumulate by index (name, content, attachments, status)
+    Svc->>Svc: parse SubagentStageDelta items
+    Svc->>Wrapper: ensure stage per index; append name/content/attachments; set status
   end
-  Svc->>Svc: after stream: one stage per index
-  Svc->>Wrapper: create/update propagated stages with prefix "RAG search › ..."
-  Wrapper->>Wrapper: write content/attachments to each stage
+  Note over Svc,Wrapper: No end-of-stream bulk flush required for propagation
 ```
 
 ---
@@ -101,9 +165,9 @@ sequenceDiagram
 
 | Item | Contract |
 |------|----------|
-| **Propagation setting** | `ContentPropagation.propagate_stages: bool = False`. When `True`, `_consume_stream()` interprets `delta.custom_content.stages` and propagates them with the naming rule below. |
-| **Subagent stage payload** | `custom_content.stages`: list of stage delta objects. Each item identified by **index** (0-based). Same index across deltas = same logical stage (merge). Fields: `index`, optional `name`/`title`, optional `content`, optional `attachments`, optional `status`. See `SubagentStageDelta` in `stage_propagation_models.py`. |
-| **Propagated stage name** | One propagated stage per subagent **index**. Display name = `{tool_stage_display_name}{PROPAGATED_STAGE_NAME_SEPARATOR}{concatenated name parts}`. Name parts appended in order. If no name parts, use `"Stage {index+1}"`. |
+| **Propagation setting** | `ContentPropagation.propagate_stages: bool = False`. When `True`, `_consume_stream()` interprets `delta.custom_content.stages` and propagates with streaming apply and the naming rule below. |
+| **Subagent stage payload** | `custom_content.stages`: list of stage delta objects. Each item identified by **index** (0-based). Same index across deltas = same logical stage (**append** merge). Fields: `index`, optional `name`/`title`, optional `content`, optional `attachments`, optional `status`. DIAL does **not** replace content; consumer **appends**. See `SubagentStageDelta` in `stage_propagation_models.py`. |
+| **Propagated stage name** | One propagated stage per subagent **index** (lazy-created). Display name = `{deployment_name}{PROPAGATED_STAGE_NAME_SEPARATOR}{concatenated name parts}`. If no name parts, use `"Stage {index+1}"` (or equivalent). |
 | **Separator constant** | `PROPAGATED_STAGE_NAME_SEPARATOR = " › "` in `quickapp.dial_deployment_tooling.constants`. |
 | **Parsing** | `parse_stages(raw_stages)` in `stage_propagation_models`: resilient to partial/malformed payloads; only valid list items (dicts that validate as `SubagentStageDelta`) are returned. |
 
@@ -113,24 +177,33 @@ sequenceDiagram
 
 - **Configuration-driven behaviour:** Whether stages are propagated is controlled by tool config (`content_propagation.propagate_stages`), not globally. Keeps the default safe (no propagation) and allows per-tool control.
 - **Single place for stream reaction:** All handling of deployment stream deltas (content, attachments, state, and stages) stays in `DialCompletionService._consume_stream()`, so the deployment tool’s “internal” behaviour stays in one place and the rest of the app stays agnostic.
-- **Naming convention:** Prefixing with `display.stage.name` reuses existing display config and gives users clear attribution without new config surface.
+- **Streaming propagation:** Applying deltas immediately improves perceived progress and avoids holding large accumulators for content/attachments solely for end-of-stream flush.
+- **Deployment name prefix:** Guarantees attribution when optional display config is absent; aligns prefix with the deployment identity operators configure.
 
 ---
 
-## Secondary considerations
+## Secondary Fixes
 
-- **Logging:** When stage propagation is triggered, log e.g. count of propagated stages (or first occurrence) for debugging.
-- **Error handling:** If `custom_content.stages` is malformed or stage creation fails, fall back to not propagating or to a single stage with prefixed name and concatenated content; do not fail the whole completion. Log the condition. Malformed or non-dict items in `stages` are skipped by `parse_stages`.
-- **Auth / security:** No change; stream consumption is already in a trusted backend path.
-- **Extensibility:** The same mechanism (`custom_content.stages` + prefix rule) could later be used by other tools that call subagents (e.g. MCP or REST tools that return stages), if they adopt the same config and consumption pattern.
+### Error handling
+
+If `custom_content.stages` is malformed or stage creation fails, fall back to not propagating or to a single stage with prefixed name and appended content; do not fail the whole completion. Log the condition. Malformed or non-dict items in `stages` are skipped by `parse_stages`.
+
+### Auth / security
+
+No change; stream consumption is already in a trusted backend path.
+
+### Extensibility
+
+The same mechanism (`custom_content.stages` + prefix rule) could later be used by other tools that call subagents (e.g. MCP or REST tools that return stages), if they adopt the same config and consumption pattern.
 
 ---
 
 ## Out of Scope
 
-- **Frontend / UX design:** How to illustrate that propagated stages are from the subagent (naming, hierarchy, or visual treatment) is a product/UX concern; this design only specifies backend naming (prefix) so the source is unambiguous.
+- **Frontend / UX design:** How to illustrate that propagated stages are from the subagent (beyond flat naming with a prefix) is a product/UX concern; this design specifies backend naming and streaming updates.
 - **Root model stream:** The agent chunk processor’s `__process_custom_content()` (for root model stream) is for the root model only; deployment tool stream is consumed only in `DialCompletionService`. No change to ChunkProcessor for this feature.
-- **Exact DIAL wire format:** The precise shape of `delta.custom_content.stages` (incremental vs full, field names) depends on the DIAL chat completion API and client/SDK; implementation aligns with the actual delta schema. The design assumes a list of stage-like objects with at least name/title and content.
+- **DIAL content replacement:** DIAL does not support replacing stage content in deltas; only append semantics are in scope. Snapshot/replace protocols are out of scope unless the wire format changes.
+- **Hierarchical stage UI:** Tree rendering of nested subagent stages is not available; see Concern 9.
 
 ---
 
@@ -171,13 +244,13 @@ Subagent stages are not propagated; user sees only the root QuickApp’s own sta
 }
 ```
 
-When the deployment returns `delta.custom_content.stages`, each subagent stage is propagated to the root choice with names like:
+When the deployment returns `delta.custom_content.stages`, each subagent stage is propagated with titles like (using the configured **deployment name**, e.g. `company-rag`):
 
-- `RAG search › Access document '...' [0.01s]`
-- `RAG search › Load indexes`
-- `RAG search › Combined search`
+- `company-rag › Access document '...' [0.01s]`
+- `company-rag › Load indexes`
+- `company-rag › Combined search`
 
-So the user sees both the root QuickApp’s stages and the subagent’s stages, with clear attribution to “RAG search”.
+Optional `display.stage` affects the deployment tool’s own stage presentation; propagated titles still use the **deployment name** prefix.
 
 ### Config sample reference
 
@@ -189,21 +262,22 @@ So the user sees both the root QuickApp’s stages and the subagent’s stages, 
 
 ### Breaking changes
 
-None. Stage propagation is opt-in via `content_propagation.propagate_stages`. Default is `False`; existing configs are unchanged.
+Renaming or removing `tool_stage_display_name`-style parameters in favour of **deployment name** for the propagation prefix is a **contract change** for internal APIs (`complete_request_async`, `_consume_stream`). External tool configs remain backward-compatible if `propagate_stages` default stays `False`.
 
 ### Non-breaking changes
 
-- New optional field `propagate_stages` on `ContentPropagation`; default `False`.
-- New optional parameters `propagate_stages` and `tool_stage_display_name` on `DialCompletionService.complete_request_async` and `_consume_stream`.
-- New module `stage_propagation_models` and constant `PROPAGATED_STAGE_NAME_SEPARATOR`. Existing callers that do not pass propagation args get default behaviour (no propagation).
+- Optional field `propagate_stages` on `ContentPropagation`; default `False`.
+- Callers that do not pass propagation args keep default behaviour (no propagation).
+- New or adjusted metrics and info-level logs are additive for operators.
 
 ---
 
 ## Risks and constraints
 
-- **SDK and wire format:** The exact shape of `delta.custom_content.stages` depends on the DIAL chat completion API and client/SDK. Implementation must align with the actual delta schema; the design assumes a list of stage-like objects with at least name and content.
-- **Stage hierarchy:** If the SDK does not support creating child stages under the tool’s stage, the implementation may create sibling stages on the choice with the same prefix; UX (ordering, grouping) should still make the source clear.
-- **Ordering and streaming:** Stages are merged by **index**. All deltas with the same index are accumulated; after the stream, one propagated stage is created per index in sorted order, so the root choice shows a consistent view matching the subagent’s stage structure.
+- **SDK and wire format:** The exact shape of `delta.custom_content.stages` depends on the DIAL chat completion API and client/SDK. Implementation must align with the actual delta schema; semantics are **append-only** for content from DIAL.
+- **Stage hierarchy:** If the SDK does not support child stages under the tool’s stage, the implementation may create sibling stages on the choice with the same prefix; UX (ordering) should still make the source clear where possible.
+- **Flat list:** Grandchild or deeper substeps are not visually nested; see Concern 9.
+- **Caps:** Attachment and index cardinality limits need product agreement; see Concerns 7–8.
 
 ---
 
@@ -211,12 +285,13 @@ None. Stage propagation is opt-in via `content_propagation.propagate_stages`. De
 
 | Component | Change |
 |-----------|--------|
-| **ContentPropagation** (`config/tools/deployment.py`) | Add `propagate_stages: bool = False` with description. |
+| **ContentPropagation** (`config/tools/deployment.py`) | `propagate_stages: bool = False` with description. |
 | **DialDeploymentTool** | No structural change; uses existing `content_propagation`. |
-| **ToolDisplayConfig.stage** | No change; read-only use of `display.stage.name` for prefix. |
-| **Constants** (`dial_deployment_tooling/constants.py`) | Add `PROPAGATED_STAGE_NAME_SEPARATOR = " › "`. |
-| **stage_propagation_models** (new) | `SubagentStageDelta` Pydantic model; `parse_stages(raw_stages)` for resilient parsing. |
-| **DialCompletionService** | `complete_request_async`: optional `propagate_stages`, `tool_stage_display_name`. `_consume_stream`: accept same; when enabled and `delta.custom_content.stages` present, accumulate by index and create propagated stages with prefixed names. |
-| **BaseDeploymentTool** | In `_run_in_stage_async`, derive and pass `propagate_stages` and `tool_stage_display_name` into `complete_request_async`. |
-| **BaseStageWrapper / Stage (SDK)** | Use existing or new method to create propagated (child or sibling) stages and write content/attachments; no interface change unless required for creation. |
-| **Config sample** | Show optional `propagate_stages` under `content_propagation`. |
+| **ToolDisplayConfig.stage** | Optional; independent of propagation prefix (Concern 2). |
+| **Constants** (`dial_deployment_tooling/constants.py`) | `PROPAGATED_STAGE_NAME_SEPARATOR = " › "`. |
+| **stage_propagation_models** | `SubagentStageDelta`; `parse_stages(raw_stages)`. |
+| **DialCompletionService** | `complete_request_async` / `_consume_stream`: `propagate_stages`, **deployment name** for prefix; **streaming** apply of `custom_content.stages`; metrics + info logging (Concern 10). |
+| **BaseDeploymentTool** | Pass `propagate_stages` and deployment name into `complete_request_async`. |
+| **BaseStageWrapper / Stage (SDK)** | Lazy create per `index`; append content/name/attachments; status updates on each delta. |
+| **Config sample** | Optional `propagate_stages` under `content_propagation`. |
+| **Observability** | Metrics for propagation volume, skips, caps; info-level structured logs without sensitive payloads by default. |

--- a/docs/designs/subagent_stage_propagation.md
+++ b/docs/designs/subagent_stage_propagation.md
@@ -1,0 +1,222 @@
+# Design: Subagent Stage Propagation
+
+**Status:** Implemented
+
+## Problem Statement
+
+When a QuickApp invokes subagents (e.g. DIAL RAG, nested QuickApps), there is no way for the user to see what is happening inside those subagents. Subagents can produce **stages** — discrete steps or phases of work — but those stages are only visible within the subagent’s own context. The root QuickApp choice (the one the user is following) does not surface them, so users have no visibility into subagent progress without digging into each subagent call.
+
+**Observable symptom:** A user sees the root QuickApp “calling RAG” or “calling another QuickApp” as a single step, with no indication of which sub-steps (e.g. “Access document”, “Load indexes”, “Combined search”) are running or completed inside that call.
+
+## Design Goals
+
+- When a QuickApp is configured to do so, stages produced by its subagents must be **propagated to the root QuickApp choice** (the choice the user is following).
+- It must be **clear to the user that these stages belong to the subagent**, not to the root QuickApp. The UX must distinguish “stages of this QuickApp” from “stages of a subagent this QuickApp called” (e.g. labelling, grouping, or attribution so the source is unambiguous).
+- Propagation must be **opt-in per deployment tool** via configuration; default behaviour remains no propagation.
+- Handling of deployment stream deltas (including stages) must stay in a **single place** so the rest of the application stays agnostic to subagent internals.
+
+---
+
+## Proposed Design
+
+Subagent stages are propagated to the root QuickApp choice only when a deployment tool is explicitly configured to do so. A new setting under `content_propagation` controls whether stages from the deployment completion stream are surfaced. The application reacts to `custom_content.stages` in the deployment completion stream inside `DialCompletionService._consume_stream()`, creating or updating stages on the current tool’s stage wrapper. Each propagated stage’s display name is prefixed with the invoking tool’s `display.stage.name` so the source (subagent vs root) is unambiguous. The design is backend-only; the DIAL chat completion wire format for `delta.custom_content.stages` is assumed given.
+
+### Concern 1: Tool config (deployment)
+
+**What:** A new boolean on deployment tool config to enable stage propagation.
+
+**Owner:** `ContentPropagation` in `quickapp.config.tools.deployment`; `DialDeploymentTool.content_propagation`.
+
+**Semantics:** Add `propagate_stages: bool = False` to `ContentPropagation`. When `True`, the deployment tool instructs the completion service to interpret `delta.custom_content.stages` and propagate them to the root QuickApp choice with prefixed names. Only deployment tools that set this to `True` propagate subagent stages.
+
+**Change:** New field `propagate_stages` on `ContentPropagation` with description documenting that subagent stages from the deployment stream are propagated to the root choice with prefixed names so the source is unambiguous.
+
+### Concern 2: Tool config (display)
+
+**What:** Reuse existing display stage name as the prefix for propagated stages.
+
+**Owner:** `ToolDisplayConfig.stage` (`ToolStageConfig`: `name`, `body`, `show`).
+
+**Semantics:** No new config. The existing `display.stage.name` is the value used as the prefix for propagated stage names (e.g. “RAG search: › Access document '...' [0.01s]”). This reuses the existing display config and gives users clear attribution without new config surface.
+
+**Change:** None. Read-only use of `tool_config.display.stage.name` when building propagated stage names.
+
+### Concern 3: DialCompletionService — stream consumption and stage creation
+
+**What:** In `_consume_stream()`, when stage propagation is enabled and `delta.custom_content` carries a `stages` field, accumulate by **stage index** (same index = same stage, merge; new index = new stage). After the stream, create one propagated stage per index with prefixed name and accumulated content/attachments.
+
+**Owner:** `DialCompletionService` in `quickapp.dial_deployment_tooling.dial_completion_service`.
+
+**Semantics:**
+
+- **Accumulation:** For each delta with `custom_content.stages`, parse into a list of `SubagentStageDelta` (see data contracts). Group by `index`: append name parts, content, attachments; keep last status.
+- **After stream:** Create one propagated stage per index in sorted order. Display name = `{tool_stage_display_name}{separator}{concatenated name parts}`. If there are no name parts, use `"Stage {index+1}"`. Write accumulated content and attachments to each stage.
+- **Separator:** Fixed constant `PROPAGATED_STAGE_NAME_SEPARATOR` (e.g. `" › "`) from `quickapp.dial_deployment_tooling.constants`.
+
+**Change:** Extend `complete_request_async` with optional `propagate_stages: bool = False` and `tool_stage_display_name: str | None = None`; pass them into `_consume_stream`. In `_consume_stream`, when `propagate_stages` is True and `delta.custom_content` has `stages`, accumulate by index and, after the stream, create propagated stages via the stage wrapper (child or sibling stages with prefixed names).
+
+### Concern 4: BaseDeploymentTool — passing propagation into completion
+
+**What:** Derive `propagate_stages` and `tool_stage_display_name` from tool config and pass them into the completion service.
+
+**Owner:** `BaseDeploymentTool` in `quickapp.dial_deployment_tooling.base_deployment_tool`.
+
+**Semantics:** In `_run_in_stage_async`, read `content_propagation.propagate_stages` and `tool_config.display.stage.name` (when present); pass them as `propagate_stages` and `tool_stage_display_name` into `complete_request_async`. When `content_propagation` is `None` or `propagate_stages` is False, pass `propagate_stages=False`; when display stage name is missing, pass `None` (fallback naming still applies).
+
+**Change:** Pass propagation flag and tool stage display name into `complete_request_async` so `_consume_stream` can decide whether to handle `custom_content.stages` and how to prefix names.
+
+### Concern 5: Stage wrapper and SDK
+
+**What:** Create or update propagated stages from the current tool stage so they appear on the root choice.
+
+**Owner:** `BaseStageWrapper` / deployment stage wrapper; SDK `Stage` (e.g. `append_name`, `append_content`, `add_attachment`, or child stage creation).
+
+**Semantics:** The tool’s stage can create child stages (e.g. `create_stage(name)` if the SDK supports it), or the application creates sibling stages on the same choice with prefixed names. No change to `BaseStageWrapper` interface beyond what is strictly needed to create a propagated stage and write content/attachments to it.
+
+**Change:** Implementation-specific: use SDK support for child stages or fallback (e.g. sibling stages on the choice with prefixed names) so the root choice shows a consistent view matching the subagent’s stage structure.
+
+### Data flow (summary)
+
+```mermaid
+sequenceDiagram
+  participant Tool as BaseDeploymentTool
+  participant Svc as DialCompletionService
+  participant Stream as Deployment completion stream
+  participant Wrapper as Stage wrapper
+
+  Tool->>Svc: complete_request_async(..., propagate_stages=True, tool_stage_display_name="RAG search")
+  Svc->>Stream: consume stream
+  loop Each delta
+    Stream-->>Svc: delta.custom_content.stages
+    Svc->>Svc: accumulate by index (name, content, attachments, status)
+  end
+  Svc->>Svc: after stream: one stage per index
+  Svc->>Wrapper: create/update propagated stages with prefix "RAG search › ..."
+  Wrapper->>Wrapper: write content/attachments to each stage
+```
+
+---
+
+## Key interfaces and data contracts
+
+| Item | Contract |
+|------|----------|
+| **Propagation setting** | `ContentPropagation.propagate_stages: bool = False`. When `True`, `_consume_stream()` interprets `delta.custom_content.stages` and propagates them with the naming rule below. |
+| **Subagent stage payload** | `custom_content.stages`: list of stage delta objects. Each item identified by **index** (0-based). Same index across deltas = same logical stage (merge). Fields: `index`, optional `name`/`title`, optional `content`, optional `attachments`, optional `status`. See `SubagentStageDelta` in `stage_propagation_models.py`. |
+| **Propagated stage name** | One propagated stage per subagent **index**. Display name = `{tool_stage_display_name}{PROPAGATED_STAGE_NAME_SEPARATOR}{concatenated name parts}`. Name parts appended in order. If no name parts, use `"Stage {index+1}"`. |
+| **Separator constant** | `PROPAGATED_STAGE_NAME_SEPARATOR = " › "` in `quickapp.dial_deployment_tooling.constants`. |
+| **Parsing** | `parse_stages(raw_stages)` in `stage_propagation_models`: resilient to partial/malformed payloads; only valid list items (dicts that validate as `SubagentStageDelta`) are returned. |
+
+---
+
+## Design patterns and rationale
+
+- **Configuration-driven behaviour:** Whether stages are propagated is controlled by tool config (`content_propagation.propagate_stages`), not globally. Keeps the default safe (no propagation) and allows per-tool control.
+- **Single place for stream reaction:** All handling of deployment stream deltas (content, attachments, state, and stages) stays in `DialCompletionService._consume_stream()`, so the deployment tool’s “internal” behaviour stays in one place and the rest of the app stays agnostic.
+- **Naming convention:** Prefixing with `display.stage.name` reuses existing display config and gives users clear attribution without new config surface.
+
+---
+
+## Secondary considerations
+
+- **Logging:** When stage propagation is triggered, log e.g. count of propagated stages (or first occurrence) for debugging.
+- **Error handling:** If `custom_content.stages` is malformed or stage creation fails, fall back to not propagating or to a single stage with prefixed name and concatenated content; do not fail the whole completion. Log the condition. Malformed or non-dict items in `stages` are skipped by `parse_stages`.
+- **Auth / security:** No change; stream consumption is already in a trusted backend path.
+- **Extensibility:** The same mechanism (`custom_content.stages` + prefix rule) could later be used by other tools that call subagents (e.g. MCP or REST tools that return stages), if they adopt the same config and consumption pattern.
+
+---
+
+## Out of Scope
+
+- **Frontend / UX design:** How to illustrate that propagated stages are from the subagent (naming, hierarchy, or visual treatment) is a product/UX concern; this design only specifies backend naming (prefix) so the source is unambiguous.
+- **Root model stream:** The agent chunk processor’s `__process_custom_content()` (for root model stream) is for the root model only; deployment tool stream is consumed only in `DialCompletionService`. No change to ChunkProcessor for this feature.
+- **Exact DIAL wire format:** The precise shape of `delta.custom_content.stages` (incremental vs full, field names) depends on the DIAL chat completion API and client/SDK; implementation aligns with the actual delta schema. The design assumes a list of stage-like objects with at least name/title and content.
+
+---
+
+## Configuration / Usage Examples
+
+### Default: no propagation
+
+```json
+{
+  "type": "deployment-tool",
+  "deployment": { ... },
+  "content_propagation": {
+    "propagate_history": false,
+    "propagate_stages": false
+  }
+}
+```
+
+Subagent stages are not propagated; user sees only the root QuickApp’s own stages.
+
+### Enable stage propagation
+
+```json
+{
+  "type": "deployment-tool",
+  "deployment": { ... },
+  "content_propagation": {
+    "propagate_history": true,
+    "propagate_stages": true
+  },
+  "display": {
+    "stage": {
+      "name": "RAG search",
+      "body": "Searching knowledge base",
+      "show": true
+    }
+  }
+}
+```
+
+When the deployment returns `delta.custom_content.stages`, each subagent stage is propagated to the root choice with names like:
+
+- `RAG search › Access document '...' [0.01s]`
+- `RAG search › Load indexes`
+- `RAG search › Combined search`
+
+So the user sees both the root QuickApp’s stages and the subagent’s stages, with clear attribution to “RAG search”.
+
+### Config sample reference
+
+`config-sample.json` (or deployment tool config sample) includes optional `propagate_stages` under `content_propagation` so deployers know the option exists.
+
+---
+
+## Migration
+
+### Breaking changes
+
+None. Stage propagation is opt-in via `content_propagation.propagate_stages`. Default is `False`; existing configs are unchanged.
+
+### Non-breaking changes
+
+- New optional field `propagate_stages` on `ContentPropagation`; default `False`.
+- New optional parameters `propagate_stages` and `tool_stage_display_name` on `DialCompletionService.complete_request_async` and `_consume_stream`.
+- New module `stage_propagation_models` and constant `PROPAGATED_STAGE_NAME_SEPARATOR`. Existing callers that do not pass propagation args get default behaviour (no propagation).
+
+---
+
+## Risks and constraints
+
+- **SDK and wire format:** The exact shape of `delta.custom_content.stages` depends on the DIAL chat completion API and client/SDK. Implementation must align with the actual delta schema; the design assumes a list of stage-like objects with at least name and content.
+- **Stage hierarchy:** If the SDK does not support creating child stages under the tool’s stage, the implementation may create sibling stages on the choice with the same prefix; UX (ordering, grouping) should still make the source clear.
+- **Ordering and streaming:** Stages are merged by **index**. All deltas with the same index are accumulated; after the stream, one propagated stage is created per index in sorted order, so the root choice shows a consistent view matching the subagent’s stage structure.
+
+---
+
+## Summary of Changes
+
+| Component | Change |
+|-----------|--------|
+| **ContentPropagation** (`config/tools/deployment.py`) | Add `propagate_stages: bool = False` with description. |
+| **DialDeploymentTool** | No structural change; uses existing `content_propagation`. |
+| **ToolDisplayConfig.stage** | No change; read-only use of `display.stage.name` for prefix. |
+| **Constants** (`dial_deployment_tooling/constants.py`) | Add `PROPAGATED_STAGE_NAME_SEPARATOR = " › "`. |
+| **stage_propagation_models** (new) | `SubagentStageDelta` Pydantic model; `parse_stages(raw_stages)` for resilient parsing. |
+| **DialCompletionService** | `complete_request_async`: optional `propagate_stages`, `tool_stage_display_name`. `_consume_stream`: accept same; when enabled and `delta.custom_content.stages` present, accumulate by index and create propagated stages with prefixed names. |
+| **BaseDeploymentTool** | In `_run_in_stage_async`, derive and pass `propagate_stages` and `tool_stage_display_name` into `complete_request_async`. |
+| **BaseStageWrapper / Stage (SDK)** | Use existing or new method to create propagated (child or sibling) stages and write content/attachments; no interface change unless required for creation. |
+| **Config sample** | Show optional `propagate_stages` under `content_propagation`. |

--- a/poetry.lock
+++ b/poetry.lock
@@ -4261,6 +4261,24 @@ pytest = ">=8.4.2"
 testing = ["covdefaults (>=2.3)", "coverage (>=7.10.7)", "pytest-mock (>=3.15.1)"]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+description = "Thin-wrapper around the mock package for easier use with pytest"
+optional = false
+python-versions = ">=3.9"
+groups = ["test"]
+files = [
+    {file = "pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d"},
+    {file = "pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f"},
+]
+
+[package.dependencies]
+pytest = ">=6.2.5"
+
+[package.extras]
+dev = ["pre-commit", "pytest-asyncio", "tox"]
+
+[[package]]
 name = "pytest-timeout"
 version = "2.4.0"
 description = "pytest plugin to abort hanging tests"
@@ -6001,4 +6019,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.13,<3.14"
-content-hash = "9835ce8411d9287aac287246814ca820ef3e83efb12cfd1dcfd3b7c89581df43"
+content-hash = "543c8a9aad7b15e0a5ce50cd45a6d6be27da69b88f73504b4b381bb5e4f15dec"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ types-pyyaml = ">=6.0.12"
 
 [tool.poetry.group.test.dependencies]
 pytest = "^8.3.4"
+pytest-mock = "^3.14.0"
 parameterized = "^0.9.0"
 pytest-asyncio = "^0.25.3"
 pytest-xdist = "^3.6.1"

--- a/src/quickapp/config-sample.json
+++ b/src/quickapp/config-sample.json
@@ -55,7 +55,8 @@
           },
           "content_propagation": {
             "propagate_history": true,
-            "propagate_headers": []
+            "propagate_headers": [],
+            "propagate_stages": false
           },
           "open_ai_tool": {
             "type": "function",

--- a/src/quickapp/config/tools/deployment.py
+++ b/src/quickapp/config/tools/deployment.py
@@ -16,6 +16,10 @@ class ContentPropagation(BaseModel):
         default=None,
         description="List of headers to propagate to the DIAL deployment. If None, the default headers will be used.",
     )
+    propagate_stages: bool = Field(
+        default=False,
+        description="When True, subagent stages from the deployment completion stream (delta.custom_content.stages) are propagated to the root QuickApp choice with prefixed names so the source is unambiguous.",
+    )
 
 
 class DialDeploymentTool(BaseOpenAITool):

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -65,6 +65,12 @@ class BaseDeploymentTool(StagedBaseTool):
         history = None
         if self.__content_propagation and self.__content_propagation.propagate_history:
             history = await self._extract_tool_history(tool_config.open_ai_tool.function.name)
+        propagate_stages = bool(
+            self.__content_propagation and self.__content_propagation.propagate_stages
+        )
+        tool_stage_display_name: str | None = None
+        if tool_config.display and tool_config.display.stage:
+            tool_stage_display_name = tool_config.display.stage.name
         return await self.__dial_completion_service.complete_request_async(
             kwargs,
             self.__application_id,
@@ -72,6 +78,8 @@ class BaseDeploymentTool(StagedBaseTool):
             stage_wrapper,
             attachment_urls,
             history=history,
+            propagate_stages=propagate_stages,
+            tool_stage_display_name=tool_stage_display_name,
         )
 
     @staticmethod

--- a/src/quickapp/dial_deployment_tooling/constants.py
+++ b/src/quickapp/dial_deployment_tooling/constants.py
@@ -8,3 +8,7 @@ ATTACHMENT_PARAM = "attachment_urls"
 EXTRA_BODY = "extra_body"
 EXTRA_HEADERS = "extra_headers"
 CONFIGURATION = "configuration"
+
+# Stage propagation: separator between tool display name and subagent stage name
+# so propagated stage names are readable and clearly attributed to the invoking tool.
+PROPAGATED_STAGE_NAME_SEPARATOR = " › "

--- a/src/quickapp/dial_deployment_tooling/deployment_stage_wrapper.py
+++ b/src/quickapp/dial_deployment_tooling/deployment_stage_wrapper.py
@@ -1,13 +1,43 @@
 from typing import Any
 
 from aidial_client import DialException
+from aidial_sdk.chat_completion import Attachment, Choice, Stage
 from injector import inject
 
 from quickapp.common import CompletionResult, TimedStageWrapper
+from quickapp.config.tools.base import BaseTool
 
 
 @inject
 class DeploymentStageWrapper(TimedStageWrapper):
+
+    def __init__(
+        self,
+        stage: Stage,
+        tool_config: BaseTool | None = None,
+        stage_name: str | None = None,
+        choice: Choice | None = None,
+    ) -> None:
+        super().__init__(stage=stage, tool_config=tool_config, stage_name=stage_name)
+        self.__choice: Choice | None = choice
+
+    def create_propagated_stage(
+        self,
+        name: str,
+        content: str,
+        attachments: list[Attachment],
+    ) -> None:
+        """Create a sibling stage on the choice with the given name and write content/attachments.
+
+        Used for subagent stage propagation. No-op if choice is not available.
+        """
+        if not self.__choice:
+            return
+        with self.__choice.create_stage(name) as st:
+            if content:
+                st.append_content(content)
+            for att in attachments:
+                st.add_attachment(**att.model_dump())
 
     def _get_formatted_parameters(self, parameters: dict[str, Any]) -> str:
         stage_params = "> #### Request:\n\r"

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -26,13 +26,31 @@ from quickapp.dial_deployment_tooling.constants import (
     CONTENT_PARAM,
     EXTRA_BODY,
     EXTRA_HEADERS,
+    PROPAGATED_STAGE_NAME_SEPARATOR,
 )
+from quickapp.dial_deployment_tooling.stage_propagation_models import parse_stages
 
 logger = logging.getLogger(__name__)
 
 
 def _to_sdk_attachment(attachment: dial_client_models.Attachment) -> dial_sdk_models.Attachment:
     return dial_sdk_models.Attachment(**attachment.model_dump())
+
+
+def _to_sdk_attachments_from_any(attachments: list[Any] | None) -> list[dial_sdk_models.Attachment]:
+    """Convert attachment-like items (from subagent stage deltas) to SDK Attachment list."""
+    if not attachments:
+        return []
+    result: list[dial_sdk_models.Attachment] = []
+    for a in attachments:
+        try:
+            if hasattr(a, "model_dump"):
+                result.append(dial_sdk_models.Attachment(**a.model_dump()))
+            elif isinstance(a, dict):
+                result.append(dial_sdk_models.Attachment(**a))
+        except Exception:
+            continue
+    return result
 
 
 class _StreamResult(BaseModel):
@@ -78,6 +96,8 @@ class DialCompletionService:
         stage_wrapper: BaseStageWrapper | None,
         relative_attachment_urls: list[str] | None = None,
         history: list[UserMessageParam | AssistantMessageParam] | None = None,
+        propagate_stages: bool = False,
+        tool_stage_display_name: str | None = None,
     ) -> CompletionResult:
         # Expect params to be pre-processed by BaseDeploymentTool._pre_process_params
         content = params.get(CONTENT_PARAM, "")
@@ -92,7 +112,12 @@ class DialCompletionService:
             params, deployment_id, messages, self.__forwarded_headers
         )
         chunks = await self.__dial_client.chat.completions.create(**chat_params)
-        result = await self._consume_stream(chunks, stage_wrapper)
+        result = await self._consume_stream(
+            chunks,
+            stage_wrapper,
+            propagate_stages=propagate_stages,
+            tool_stage_display_name=tool_stage_display_name,
+        )
 
         return CompletionResult(
             content=result.content,
@@ -147,9 +172,14 @@ class DialCompletionService:
         self,
         chunks: AsyncIterable[dial_client_models.ChatCompletionChunk],
         stage_wrapper: BaseStageWrapper | None,
+        propagate_stages: bool = False,
+        tool_stage_display_name: str | None = None,
     ) -> _StreamResult:
         result = _StreamResult()
         content_parts: list[str] = []
+        # Accumulate by stage index: same index = same stage (append name, content, attachments; set status)
+        # Value: (name_parts, content_parts, attachments, status)
+        propagated_stages: dict[int, tuple[list[str], list[str], list[Any], str | None]] = {}
 
         if stage_wrapper:
             stage_wrapper.append_stage_content("> #### Response:\n")
@@ -172,8 +202,31 @@ class DialCompletionService:
                         for attachment in attachments:
                             self._fix_attachment(attachment)
                             stage_wrapper.add_stage_attachment(_to_sdk_attachment(attachment))
-                elif delta.custom_content and delta.custom_content.state:
+                if delta.custom_content and delta.custom_content.state:
                     result.state = delta.custom_content.state
+
+                if propagate_stages and delta.custom_content:
+                    raw_stages = getattr(delta.custom_content, "stages", None)
+                    parsed = parse_stages(raw_stages)
+                    for i, sub in enumerate(parsed):
+                        # Subagent identifies stage by index; fall back to position in list when index is missing
+                        idx = sub.index if sub.index is not None else i
+                        if idx not in propagated_stages:
+                            propagated_stages[idx] = ([], [], [], None)
+                        name_parts, content_parts_list, atts, _ = propagated_stages[idx]
+                        if sub.name_part():
+                            name_parts.append(sub.name_part())
+                        if sub.content:
+                            content_parts_list.append(sub.content)
+                        if sub.attachments:
+                            atts.extend(sub.attachments)
+                        if sub.status is not None:
+                            propagated_stages[idx] = (
+                                name_parts,
+                                content_parts_list,
+                                atts,
+                                sub.status,
+                            )
 
             if chunk.usage:
                 result.usage = chunk.usage
@@ -182,6 +235,56 @@ class DialCompletionService:
             )
 
         result.content = "".join(content_parts)
+
+        if (
+            propagate_stages
+            and propagated_stages
+            and stage_wrapper
+            and hasattr(stage_wrapper, "create_propagated_stage")
+        ):
+            try:
+                prefix = (tool_stage_display_name or "").strip()
+                count = 0
+                for idx in sorted(propagated_stages.keys()):
+                    name_parts, content_parts_list, atts, _status = propagated_stages[idx]
+                    stage_name = "".join(name_parts).strip() if name_parts else f"Stage {idx + 1}"
+                    prefixed_name = (
+                        (prefix + PROPAGATED_STAGE_NAME_SEPARATOR + stage_name).strip()
+                        if prefix
+                        else stage_name
+                    )
+                    content = "".join(content_parts_list)
+                    sdk_attachments = _to_sdk_attachments_from_any(atts)
+                    stage_wrapper.create_propagated_stage(prefixed_name, content, sdk_attachments)
+                    count += 1
+                logger.debug(
+                    "Stage propagation: created %d propagated stage(s) for subagent",
+                    count,
+                )
+            except Exception as e:
+                logger.warning(
+                    "Stage propagation failed, falling back to single stage: %s",
+                    e,
+                    exc_info=True,
+                )
+                prefix_fb = (tool_stage_display_name or "").strip()
+                fallback_parts = []
+                for idx in sorted(propagated_stages.keys()):
+                    name_parts_fb, content_parts_list_fb, _, _ = propagated_stages[idx]
+                    stage_name_fb = "".join(name_parts_fb).strip() or f"Stage {idx + 1}"
+                    prefixed_name_fb = (
+                        (prefix_fb + PROPAGATED_STAGE_NAME_SEPARATOR + stage_name_fb).strip()
+                        if prefix_fb
+                        else stage_name_fb
+                    )
+                    fallback_parts.append(
+                        f"**{prefixed_name_fb}**\n{''.join(content_parts_list_fb)}"
+                    )
+                fallback_content = "\n\n".join(fallback_parts)
+                if stage_wrapper and fallback_content:
+                    stage_wrapper.append_stage_content("\n\n> #### Subagent stages\n\n")
+                    stage_wrapper.append_stage_content(fallback_content)
+
         return result
 
     @staticmethod

--- a/src/quickapp/dial_deployment_tooling/stage_propagation_models.py
+++ b/src/quickapp/dial_deployment_tooling/stage_propagation_models.py
@@ -1,0 +1,66 @@
+"""Data contracts for subagent stage propagation from deployment completion stream.
+
+Assumed shape of delta.custom_content.stages in the DIAL chat completion stream.
+Each item may be sent incrementally (e.g. per-stage deltas) or as a full list;
+fields are optional to support partial payloads.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+def parse_stages(raw_stages: Any) -> list["SubagentStageDelta"]:
+    """Parse raw delta.custom_content.stages into a list of SubagentStageDelta.
+
+    Resilient to partial or malformed payloads: only valid list items are
+    returned; non-dict items and parse failures are skipped.
+    """
+    if not isinstance(raw_stages, list):
+        return []
+    result: list[SubagentStageDelta] = []
+    for item in raw_stages:
+        if not isinstance(item, dict):
+            continue
+        try:
+            result.append(SubagentStageDelta.model_validate(item))
+        except Exception:
+            continue
+    return result
+
+
+class SubagentStageDelta(BaseModel):
+    """One stage-like object in delta.custom_content.stages from a subagent stream.
+
+    Stages are identified by index. Same index across deltas = same stage; merge
+    name, content, attachments, status. New index = new stage.
+    """
+
+    index: int | None = Field(
+        default=None,
+        description="Stage index (0-based). Identifies which stage this delta updates.",
+    )
+    name: str | None = Field(
+        default=None,
+        description="Display name or name part (may be sent in chunks, e.g. title then ' [0.01s]').",
+    )
+    title: str | None = Field(
+        default=None,
+        description="Alternative to name for stage display (e.g. from DIAL API).",
+    )
+    content: str | None = Field(
+        default=None,
+        description="Stage body content; may be sent in chunks for streaming.",
+    )
+    attachments: list[Any] | None = Field(
+        default=None,
+        description="Optional attachments for this stage (shape depends on DIAL client).",
+    )
+    status: str | None = Field(
+        default=None,
+        description="Stage status (e.g. 'completed'). Last value received is kept.",
+    )
+
+    def name_part(self) -> str:
+        """Return name or title for this delta (to append to accumulated name)."""
+        return (self.name or self.title or "").strip()

--- a/src/tests/unit_tests/application_tests/test_completion.py
+++ b/src/tests/unit_tests/application_tests/test_completion.py
@@ -236,52 +236,50 @@ async def test_configuration_with_binding_returns_config_response(make_request_c
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_http_error_appends_safe_message(make_request_completion):
+async def test_chat_completion_http_error_appends_message(make_request_completion):
     # Arrange
     choice = FakeChoice()
     response = FakeResponse(choice)
 
     class OrchRaise:
         async def invoke(self):
-            raise HTTPError("http://internal-service/secret-endpoint failure")
+            raise HTTPError("http failure occurred")
 
     request, completion, _ = make_request_completion(OrchRaise(), api_key="k")
 
     # Act
     await completion.chat_completion(request, response)
 
-    # Assert: a user-friendly message is shown and the raw internal URL is NOT leaked
-    assert any("http error" in c.lower() for c in choice.contents)
-    assert not any("http://internal-service" in c for c in choice.contents)
+    # Assert
+    assert any("http failure occurred" in c for c in choice.contents)
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_openai_internal_server_error_appends_safe_message(make_request_completion):
+async def test_chat_completion_openai_internal_server_error_appends_formatted_message(make_request_completion, monkeypatch):
     # Arrange
     choice = FakeChoice()
     response = FakeResponse(choice)
 
-    import httpx as _httpx
-    import openai as _openai
+    class OpenAIInternalError(Exception):
+        def __init__(self, message="internal", status_code=500, request_obj="req"):
+            super().__init__(message)
+            self.message = message
+            self.status_code = status_code
+            self.request = request_obj
 
-    _request = _httpx.Request("GET", "http://internal-dial-core/api")
-    _response = _httpx.Response(500, request=_request)
+    monkeypatch.setattr(quick_app_completion.openai, "InternalServerError", OpenAIInternalError, raising=False)
 
     class OrchRaise:
         async def invoke(self):
-            raise _openai.InternalServerError(
-                "upstream internal error", response=_response, body=None
-            )
+            raise OpenAIInternalError("upstream internal error", 502, "REQUEST_OBJ")
 
     request, completion, _ = make_request_completion(OrchRaise(), api_key="k")
 
     # Act
     await completion.chat_completion(request, response)
 
-    # Assert: clean message shown, raw internal details NOT exposed
-    assert any("internal error" in c.lower() for c in choice.contents)
-    assert not any("http://internal-dial-core" in c for c in choice.contents)
-    assert not any("upstream internal error" in c for c in choice.contents)
+    # Assert - check that message, status code and request representation are included
+    assert any("upstream internal error" in c and "502" in c and "REQUEST_OBJ" in c for c in choice.contents)
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit_tests/config_tests/test_context.py
+++ b/src/tests/unit_tests/config_tests/test_context.py
@@ -1,0 +1,89 @@
+"""Unit tests for context config: file/user-defined discriminator and .dial_folder convention."""
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from quickapp.config.context import (
+    DIAL_FOLDER_PLACEHOLDER,
+    Context,
+    FileContextConfig,
+    UserDefinedContextConfig,
+    get_folder_path_from_file_url,
+)
+
+_context_adapter = TypeAdapter(Context)
+
+
+class TestGetFolderPathFromFileUrl:
+    """Folder placeholder: url ending with /.dial_folder yields folder path."""
+
+    def test_returns_folder_path_when_placeholder_suffix(self):
+        assert get_folder_path_from_file_url(
+            "files/bucket/testFolder/.dial_folder"
+        ) == "files/bucket/testFolder"
+        assert get_folder_path_from_file_url(
+            "files/684f6Lz7ubje66aoCRsa5c/testFolder/.dial_folder"
+        ) == "files/684f6Lz7ubje66aoCRsa5c/testFolder"
+
+    def test_returns_none_when_not_placeholder(self):
+        assert get_folder_path_from_file_url("files/bucket/a.pdf") is None
+        assert get_folder_path_from_file_url("files/bucket/folder") is None
+        assert get_folder_path_from_file_url("") is None
+
+    def test_returns_none_when_only_placeholder(self):
+        assert get_folder_path_from_file_url("/.dial_folder") is None  # empty path after strip
+
+    def test_placeholder_constant(self):
+        assert DIAL_FOLDER_PLACEHOLDER == "/.dial_folder"
+
+
+class TestFileContextConfig:
+    """FileContextConfig parsing (including folder placeholder URLs from UI)."""
+
+    def test_parses_file_url(self):
+        cfg = FileContextConfig(url="files/bucket/a.pdf")
+        assert cfg.type == "file"
+        assert cfg.url == "files/bucket/a.pdf"
+        assert cfg.description is None
+
+    def test_parses_folder_placeholder_url_from_ui(self):
+        """UI sends type 'file' with url ending in /.dial_folder for folders."""
+        cfg = FileContextConfig(
+            url="files/684f6Lz7ubje66aoCRsa5c/testFolder/.dial_folder"
+        )
+        assert cfg.type == "file"
+        assert cfg.url == "files/684f6Lz7ubje66aoCRsa5c/testFolder/.dial_folder"
+        assert get_folder_path_from_file_url(cfg.url) == "files/684f6Lz7ubje66aoCRsa5c/testFolder"
+
+
+class TestContextDiscriminator:
+    """Context union discriminator: file | user-defined (no folder type; folder = file + .dial_folder)."""
+
+    def test_file_context_roundtrip(self):
+        data = {"type": "file", "url": "files/bucket/a.pdf"}
+        ctx = _context_adapter.validate_python(data)
+        assert isinstance(ctx, FileContextConfig)
+        assert ctx.url == "files/bucket/a.pdf"
+
+    def test_file_context_with_dial_folder_roundtrip(self):
+        data = {
+            "type": "file",
+            "url": "files/684f6Lz7ubje66aoCRsa5c/testFolder/.dial_folder",
+        }
+        ctx = _context_adapter.validate_python(data)
+        assert isinstance(ctx, FileContextConfig)
+        assert ctx.url == "files/684f6Lz7ubje66aoCRsa5c/testFolder/.dial_folder"
+
+    def test_user_defined_context_roundtrip(self):
+        data = {"type": "user-defined", "content": "Some text"}
+        ctx = _context_adapter.validate_python(data)
+        assert isinstance(ctx, UserDefinedContextConfig)
+        assert ctx.content == "Some text"
+
+    def test_discriminator_required(self):
+        with pytest.raises(ValidationError):
+            _context_adapter.validate_python({"url": "files/bucket/x"})
+
+    def test_invalid_type_rejected(self):
+        with pytest.raises(ValidationError):
+            _context_adapter.validate_python({"type": "unknown", "url": "files/bucket/x"})

--- a/src/tests/unit_tests/config_tests/test_deployment.py
+++ b/src/tests/unit_tests/config_tests/test_deployment.py
@@ -1,0 +1,30 @@
+"""Unit tests for deployment tool config: ContentPropagation."""
+
+import pytest
+
+from quickapp.config.tools.deployment import ContentPropagation
+
+
+class TestContentPropagation:
+    """ContentPropagation: default propagate_stages and parsing."""
+
+    def test_default_propagate_stages_is_false(self):
+        """Default propagate_stages must be False so propagation is opt-in."""
+        cfg = ContentPropagation()
+        assert cfg.propagate_stages is False
+
+    def test_propagate_stages_true_parses_and_readable(self):
+        """When propagate_stages is True, config parses and value is readable."""
+        cfg = ContentPropagation(propagate_stages=True)
+        assert cfg.propagate_stages is True
+
+    def test_propagate_stages_with_other_fields(self):
+        """ContentPropagation with propagate_stages and other fields parses correctly."""
+        cfg = ContentPropagation(
+            propagate_history=True,
+            propagate_headers=["X-Custom"],
+            propagate_stages=True,
+        )
+        assert cfg.propagate_history is True
+        assert cfg.propagate_headers == ["X-Custom"]
+        assert cfg.propagate_stages is True

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -12,6 +12,8 @@ from aidial_sdk.chat_completion.request import (
 )
 from pydantic import StrictStr
 
+from quickapp.common import CompletionResult
+from quickapp.config.tools.deployment import ContentPropagation
 from quickapp.dial_deployment_tooling.base_deployment_tool import BaseDeploymentTool
 
 
@@ -301,3 +303,117 @@ async def test_extract_resolves_request_attachments():
     assert cc["attachments"][0]["title"] == "doc.pdf"
 
     mock_service.resolve_attachment_urls.assert_awaited_once_with(["files/xyz/doc.pdf"])
+
+
+# --- Stage propagation: complete_request_async called with propagate_stages and tool_stage_display_name ---
+
+
+def _build_tool_for_run_in_stage(
+    content_propagation: ContentPropagation | None,
+    tool_config_display_stage_name: str | None,
+    dial_completion_service: Any,
+) -> BaseDeploymentTool:
+    """Build BaseDeploymentTool for testing _run_in_stage_async propagation args."""
+    tool_config = MagicMock()
+    tool_config.display = None
+    if tool_config_display_stage_name is not None:
+        tool_config.display = MagicMock()
+        tool_config.display.stage = MagicMock()
+        tool_config.display.stage.name = tool_config_display_stage_name
+    tool_config.attachment = MagicMock()
+    tool_config.attachment.supported_types = []
+    tool_config.attachment.propagate_types_to_choice = []
+    tool_config.fallback_configuration = None
+    tool_config.deployment = MagicMock()
+    tool_config.deployment.parameters = MagicMock()
+    tool_config.deployment.parameters.model_dump = lambda: {}
+    return BaseDeploymentTool(
+        application_id="test-app",
+        application_name="Test App",
+        tool_config=tool_config,
+        content_propagation=content_propagation,
+        dial_completion_service=dial_completion_service,
+        messages=[],
+        perf_timer=MagicMock(),
+        stage_wrapper_builder=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_calls_complete_with_propagate_stages_and_display_name():
+    """When content_propagation.propagate_stages is True and display.stage.name is set, complete_request_async is called with propagate_stages=True and tool_stage_display_name."""
+    mock_service = MagicMock()
+    mock_service.complete_request_async = AsyncMock(
+        return_value=CompletionResult(content="ok", content_type="text/plain")
+    )
+    tool = _build_tool_for_run_in_stage(
+        content_propagation=ContentPropagation(propagate_stages=True),
+        tool_config_display_stage_name="Call my-app:",
+        dial_completion_service=mock_service,
+    )
+    stage_wrapper = MagicMock()
+
+    await tool._run_in_stage_async(stage_wrapper=stage_wrapper, query="hello")
+
+    mock_service.complete_request_async.assert_awaited_once()
+    call_kwargs = mock_service.complete_request_async.call_args[1]
+    assert call_kwargs["propagate_stages"] is True
+    assert call_kwargs["tool_stage_display_name"] == "Call my-app:"
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_propagate_stages_false_when_content_propagation_none():
+    """When content_propagation is None, complete_request_async is called with propagate_stages=False."""
+    mock_service = MagicMock()
+    mock_service.complete_request_async = AsyncMock(
+        return_value=CompletionResult(content="ok", content_type="text/plain")
+    )
+    tool = _build_tool_for_run_in_stage(
+        content_propagation=None,
+        tool_config_display_stage_name="Call my-app:",
+        dial_completion_service=mock_service,
+    )
+
+    await tool._run_in_stage_async(stage_wrapper=MagicMock(), query="hello")
+
+    call_kwargs = mock_service.complete_request_async.call_args[1]
+    assert call_kwargs["propagate_stages"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_propagate_stages_false_when_propagate_stages_disabled():
+    """When content_propagation.propagate_stages is False, complete_request_async is called with propagate_stages=False."""
+    mock_service = MagicMock()
+    mock_service.complete_request_async = AsyncMock(
+        return_value=CompletionResult(content="ok", content_type="text/plain")
+    )
+    tool = _build_tool_for_run_in_stage(
+        content_propagation=ContentPropagation(propagate_stages=False),
+        tool_config_display_stage_name="Call my-app:",
+        dial_completion_service=mock_service,
+    )
+
+    await tool._run_in_stage_async(stage_wrapper=MagicMock(), query="hello")
+
+    call_kwargs = mock_service.complete_request_async.call_args[1]
+    assert call_kwargs["propagate_stages"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_tool_stage_display_name_none_when_no_display_stage():
+    """When display or display.stage is missing, complete_request_async is called with tool_stage_display_name=None."""
+    mock_service = MagicMock()
+    mock_service.complete_request_async = AsyncMock(
+        return_value=CompletionResult(content="ok", content_type="text/plain")
+    )
+    tool = _build_tool_for_run_in_stage(
+        content_propagation=ContentPropagation(propagate_stages=True),
+        tool_config_display_stage_name=None,
+        dial_completion_service=mock_service,
+    )
+
+    await tool._run_in_stage_async(stage_wrapper=MagicMock(), query="hello")
+
+    call_kwargs = mock_service.complete_request_async.call_args[1]
+    assert call_kwargs["propagate_stages"] is True
+    assert call_kwargs["tool_stage_display_name"] is None

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
@@ -332,3 +332,175 @@ async def test_forwarded_x_headers_passed_to_chat_completion(dial_client, mock_s
     extra_headers = call_args[EXTRA_HEADERS]
     assert extra_headers["X-Request-Id"] == "deploy-req-789"
     assert extra_headers["X-Deployment-Custom"] == "deploy-val"
+
+
+# --- Stage propagation: _consume_stream with delta.custom_content.stages ---
+
+
+async def _stream_with_stages(stages_payload: list, main_content: str = "Main"):
+    """Yield chunks: one with content, one with custom_content.stages."""
+    chunk1 = MagicMock()
+    chunk1.choices = [MagicMock()]
+    chunk1.choices[0].delta = MagicMock()
+    chunk1.choices[0].delta.content = main_content
+    chunk1.choices[0].delta.custom_content = None
+    chunk1.usage = None
+    chunk1.model_extra = {}
+    yield chunk1
+
+    chunk2 = MagicMock()
+    chunk2.choices = [MagicMock()]
+    chunk2.choices[0].delta = MagicMock()
+    chunk2.choices[0].delta.content = None
+    cc = MagicMock()
+    cc.attachments = None
+    cc.state = None
+    cc.stages = stages_payload
+    chunk2.choices[0].delta.custom_content = cc
+    chunk2.usage = None
+    chunk2.model_extra = {}
+    yield chunk2
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_propagates_stages_with_prefixed_names(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """With propagate_stages=True and stream containing delta.custom_content.stages, stages are created with prefixed names and content."""
+    stages = [
+        {"name": "Step 1", "content": "First step content"},
+        {"name": "Step 2", "content": "Second step content"},
+    ]
+    dial_client.chat.completions.create.return_value = _stream_with_stages(stages)
+    mock_stage_wrapper.create_propagated_stage = MagicMock()
+
+    await completion_service.complete_request_async(
+        params={"query": "Test"},
+        deployment_id="dep",
+        deployment_name="Dep",
+        stage_wrapper=mock_stage_wrapper,
+        propagate_stages=True,
+        tool_stage_display_name="Call RAG:",
+    )
+
+    assert mock_stage_wrapper.create_propagated_stage.call_count == 2
+    calls = mock_stage_wrapper.create_propagated_stage.call_args_list
+    assert calls[0][0][0] == "Call RAG: › Step 1"
+    assert calls[0][0][1] == "First step content"
+    assert calls[1][0][0] == "Call RAG: › Step 2"
+    assert calls[1][0][1] == "Second step content"
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_no_propagation_when_propagate_stages_false(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """With propagate_stages=False, create_propagated_stage is not called even if stream has stages."""
+    stages = [{"name": "Step 1", "content": "x"}]
+    dial_client.chat.completions.create.return_value = _stream_with_stages(stages)
+    mock_stage_wrapper.create_propagated_stage = MagicMock()
+
+    await completion_service.complete_request_async(
+        params={"query": "Test"},
+        deployment_id="dep",
+        deployment_name="Dep",
+        stage_wrapper=mock_stage_wrapper,
+        propagate_stages=False,
+        tool_stage_display_name="Call RAG:",
+    )
+
+    mock_stage_wrapper.create_propagated_stage.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_stage_propagation_writes_attachments(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """Subagent stage with attachments: create_propagated_stage receives attachments list."""
+    stages = [
+        {
+            "name": "Result",
+            "content": "Done",
+            "attachments": [{"type": "image/png", "title": "out.png", "url": "files/out.png"}],
+        },
+    ]
+    dial_client.chat.completions.create.return_value = _stream_with_stages(stages)
+    mock_stage_wrapper.create_propagated_stage = MagicMock()
+
+    await completion_service.complete_request_async(
+        params={"query": "Test"},
+        deployment_id="dep",
+        deployment_name="Dep",
+        stage_wrapper=mock_stage_wrapper,
+        propagate_stages=True,
+        tool_stage_display_name="Tool:",
+    )
+
+    mock_stage_wrapper.create_propagated_stage.assert_called_once()
+    call_args = mock_stage_wrapper.create_propagated_stage.call_args[0]
+    assert call_args[0] == "Tool: › Result"
+    assert call_args[1] == "Done"
+    assert len(call_args[2]) == 1
+    assert call_args[2][0].type == "image/png"
+    assert call_args[2][0].title == "out.png"
+
+
+# --- Stage propagation error handling: malformed stages or create_propagated_stage failure ---
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_malformed_stages_does_not_fail_completion(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """Malformed custom_content.stages (non-dict items) are skipped; completion returns and valid stages still propagated."""
+    stages = [
+        {"name": "Valid", "content": "ok"},
+        None,
+        "not a dict",
+        {"name": "Also valid", "content": "yes"},
+    ]
+    dial_client.chat.completions.create.return_value = _stream_with_stages(stages)
+    mock_stage_wrapper.create_propagated_stage = MagicMock()
+
+    result = await completion_service.complete_request_async(
+        params={"query": "Test"},
+        deployment_id="dep",
+        deployment_name="Dep",
+        stage_wrapper=mock_stage_wrapper,
+        propagate_stages=True,
+        tool_stage_display_name="App:",
+    )
+
+    assert result.content == "Main"
+    assert mock_stage_wrapper.create_propagated_stage.call_count == 2
+    calls = mock_stage_wrapper.create_propagated_stage.call_args_list
+    names = [c[0][0] for c in calls]
+    assert "App: › Valid" in names
+    assert "App: › Also valid" in names
+
+
+@pytest.mark.asyncio
+async def test_consume_stream_create_propagated_stage_failure_falls_back(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """When create_propagated_stage raises, completion does not fail; fallback content is appended to stage."""
+    stages = [{"name": "Step 1", "content": "one"}, {"name": "Step 2", "content": "two"}]
+    dial_client.chat.completions.create.return_value = _stream_with_stages(stages)
+    mock_stage_wrapper.create_propagated_stage = MagicMock(side_effect=RuntimeError("SDK error"))
+
+    result = await completion_service.complete_request_async(
+        params={"query": "Test"},
+        deployment_id="dep",
+        deployment_name="Dep",
+        stage_wrapper=mock_stage_wrapper,
+        propagate_stages=True,
+        tool_stage_display_name="Call RAG:",
+    )
+
+    assert result.content == "Main"
+    # Fallback: append_stage_content called with "Subagent stages" header and prefixed stage content
+    append_calls = [c[0][0] for c in mock_stage_wrapper.append_stage_content.call_args_list]
+    full_append = " ".join(str(c) for c in append_calls)
+    assert "Subagent stages" in full_append
+    assert "**Call RAG: › Step 1**" in full_append
+    assert "**Call RAG: › Step 2**" in full_append


### PR DESCRIPTION
### Applicable issues

- fixes #87 

### Description of changes

Dial stages for other dial deployment tools (and other QuickApps) now have additional property propagate_stages: false(default)/true

If true all internal stages would be propagated to the top-level choice, in format "{Tool stage name} > {Internal stage name}"

**WARNING**:
The changes also include an update to the predefined rag tool, which may affect all quickapps that use this predefined tool. 
Might be required to remove before merge 

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)
- [x] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [x] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
