### PR TITLE
fix: docker quick-app service

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -4,6 +4,10 @@ PYDANTIC_V2=True
 PYTHON=python3
 POETRY=poetry
 
+# Currently DIAL does not support ARM docker images
+# Uncomment to set the platform amd64 if using Docker on ARM devices
+# DOCKER_DEFAULT_PLATFORM=linux/amd64
+
 # DIAL
 DIAL_URL=http://localhost:8090
 DIAL_API_KEY=dial_api_key

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ build
 dist
 venv
 /models/
+/reports/
 /docker_compose_files/core/data/
 /docker_compose_files/core/logs/
 /docker_compose_files/core/configuration/generated/

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ your gateways or downstream services expect.
     - Windows - recommended way to install poetry is to
       use [official installer](https://python-poetry.org/docs/#installing-with-the-official-installer)
     - Make sure that `poetry` is in the PATH and works properly (run `poetry --version`).
-    - Alternative - venv-specific (using `pip`):  
+    - Alternative - venv-specific (using `pip`):
       make sure the correct python venv is activated `make install_poetry`
 
 ### Setup
@@ -191,13 +191,23 @@ your gateways or downstream services expect.
     - Use this if you want to bring up DIAL Core, chat UI, redis, themes and adapters locally for end-to-end development
       and testing.
     - This docker-compose setup launches multiple services and uses internal hostnames (for example core, redis,
-      themes). Example:
+      themes).
+    - Setup expects the Quick Apps service to run on your host machine at `host.docker.internal:5000`
+
+      ```bash
+      python3 ./src/quickapp/app.py
+      ```
+
+    - Then start the local stack:
 
       ```bash
       docker compose up -d
       ```
 
     - Notes:
+        - If you want to run Quick Apps in Docker instead of on the host, update
+          [application-schemas.json](docker_compose_files/core/configuration/application-schemas.json) and change the Quick
+          Apps host from `host.docker.internal:5000` to `quick-apps:5000`.
         - When running via docker-compose the compose files set service hostnames (for example DIAL URL inside
           containers is http://core:8080). Those container-internal hostnames are not valid from your host machine — use
           the exposed ports (for example http://localhost:8090) when calling services from the host.
@@ -251,9 +261,9 @@ your gateways or downstream services expect.
 
    This command will set up the git hook scripts.
 
-## E2E & Integration tests:
+## E2E & Integration tests
 
-    refer to [Testing Guide](./src/tests/integration_tests/README.md) for detailed instructions on setting up and running tests.
+Refer to [Testing Guide](./src/tests/integration_tests/README.md) for detailed instructions on setting up and running tests.
 
 ## More
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -60,11 +60,12 @@ services:
       DIAL_URL: "http://core:8080"
       LOG_LEVEL: "INFO"
 
-  quick_apps:
-    build:
-        context: .
-        dockerfile: ./Dockerfile
-    environment:
-      DIAL_URL: "http://core:8080"
-      SHOW_USAGE_STATISTICS: "true"
-      QUICKAPP_LOG_LEVEL: "DEBUG"
+  # If you want to run Quick Apps in Docker instead of on the host, uncomment the following section and update the quick-apps host in application-schemas.json.
+  # quick-apps:
+  #   build:
+  #       context: .
+  #       dockerfile: ./Dockerfile
+  #   environment:
+  #     DIAL_URL: "http://core:8080"
+  #     SHOW_USAGE_STATISTICS: "true"
+  #     QUICKAPP_LOG_LEVEL: "DEBUG"


### PR DESCRIPTION
### Applicable issues

- fixes #148 

### Description of changes

- Renamed the quick_apps service to quick-apps to have a correct internal hostname.
- Clarified how to run the quick-apps service locally, docker service vs local server
- Fixed E2E & Integration tests section formating
- Added DOCKER_DEFAULT_PLATFORM  to .env template

### Screenshots
docker setup:
<img width="2672" height="1521" alt="Screenshot 2026-03-16 at 13 08 47" src="https://github.com/user-attachments/assets/cc788f4f-888c-4995-89bb-9d88cfa7b62d" />
<img width="2672" height="1521" alt="Screenshot 2026-03-16 at 13 04 19" src="https://github.com/user-attachments/assets/a752332c-ed4d-4e7b-ab6d-21e2a6860819" />

Create test app:
<img width="2032" height="1281" alt="Screenshot 2026-03-16 at 13 07 08" src="https://github.com/user-attachments/assets/590fb9f1-c4fa-41db-9446-cfd099307977" />
<img width="2032" height="1281" alt="Screenshot 2026-03-16 at 13 07 47" src="https://github.com/user-attachments/assets/12f22871-f372-4c7a-a88e-1f7c7b7b4f4d" />


### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
