### PR TITLE
feat: refactor JsonSchemaConverter to use dereference function from fastmcp

### DIFF
--- a/src/quickapp/common/json_schema_converter.py
+++ b/src/quickapp/common/json_schema_converter.py
@@ -1,5 +1,7 @@
 from typing import Any
 
+from fastmcp.utilities.json_schema import dereference_refs
+
 from quickapp.config.tools.base import (
     ConfigurableSchemaArray,
     ConfigurableSchemaObject,
@@ -13,94 +15,56 @@ _ConfigurableSchema = (
 
 
 class JsonSchemaConverter:
-    """Utility class for converting JSON schema dictionaries to ConfigurableSchema objects."""
+    """Utility class for converting JSON schema dictionaries to ConfigurableSchema objects.
+
+    Handles $ref resolution internally via fastmcp.utilities.json_schema.dereference_refs().
+    """
 
     @staticmethod
-    def _normalize_type(type_field: str | list[str] | None) -> tuple[str | None, bool]:
+    def _normalize_type(type_field: str | list[str] | None) -> str | None:
         """
         Normalize the 'type' field which can be a str or a list (e.g. ['string', 'null']).
-        Returns (primary_type_or_None, is_nullable).
+        Returns the primary non-null type, or None if no non-null type is present.
         """
         if isinstance(type_field, list):
-            is_nullable = 'null' in type_field
             non_null = [t for t in type_field if t != 'null']
-            primary = non_null[0] if non_null else None
-            return primary, is_nullable
-        return (type_field, False) if type_field is not None else (None, False)
+            return non_null[0] if non_null else None
+        return type_field
 
     @staticmethod
-    def _resolve_ref(ref: str, root_schema: dict[str, Any]) -> dict[str, Any]:
-        """
-        Resolve an internal JSON Pointer ref like '#/$defs/Name' or '#/definitions/Name'
-        by traversing the root_schema. Returns the referenced dictionary.
-        """
-        if not ref.startswith('#/'):
-            raise ValueError(f"Only local refs are supported in this converter: {ref!r}")
-        pointer = ref[2:].split('/')  # remove leading '#/'
-        node: Any = root_schema
-        for token in pointer:
-            # JSON Pointer uses ~1 for '/' and ~0 for '~' (not expected here but handle minimally)
-            token = token.replace('~1', '/').replace('~0', '~')
-            if isinstance(node, dict) and token in node:
-                node = node[token]
-            else:
-                raise KeyError(f"Could not resolve ref {ref!r} at token {token!r}")
-        if not isinstance(node, dict):
-            raise ValueError(f"Referenced ref {ref!r} does not point to an object")
-        return node
-
-    @staticmethod
-    def _pick_variant_from_anyof(
-        variants: list[dict[str, Any]], root_schema: dict[str, Any]
-    ) -> dict[str, Any]:
+    def _pick_variant_from_anyof(variants: list[dict[str, Any]]) -> dict[str, Any]:
         """
         Pick the most relevant variant from anyOf/oneOf:
         - prefer a non-null typed variant
-        - resolve $ref variants
         - fallback to the first variant
         """
         for v in variants:
             if v.get("type") == "null":
                 continue
-            # if it's a ref, try to resolve and return resolved (prefer resolved non-null)
-            if "$ref" in v:
-                try:
-                    resolved = JsonSchemaConverter._resolve_ref(v["$ref"], root_schema)
-                    # if resolved is not null, return it
-                    if resolved.get("type") != "null":
-                        return {**resolved, **{k: vv for k, vv in v.items() if k != "$ref"}}
-                except Exception:
-                    # fall through to treat v as-is
-                    return v
-            # otherwise return the first non-null typed variant
-            if v.get("type") and v.get("type") != "null":
+            if v.get("type"):
                 return v
-        # fallback: return first variant (could be null)
         return variants[0]
 
     @staticmethod
     def _build_schema_from_definition(
-        def_dict: dict[str, Any], name: str | None = None, root_schema: dict[str, Any] | None = None
+        def_dict: dict[str, Any], name: str | None = None
     ) -> _ConfigurableSchema:
         """
         Build and return a ConfigurableSchema* instance from a single property/items definition.
         This centralizes the handling for simple types, objects and arrays (including nested arrays).
         """
-        # If there's a $ref, resolve it against root_schema (if provided).
         if "$ref" in def_dict:
-            if root_schema is None:
-                raise ValueError("Root schema is required to resolve $ref")
-            resolved = JsonSchemaConverter._resolve_ref(def_dict["$ref"], root_schema)
-            # Merge resolved with local overrides (local keys take precedence)
-            merged = {**resolved, **{k: v for k, v in def_dict.items() if k != "$ref"}}
-            def_dict = merged
+            raise ValueError(
+                f"Unresolved $ref '{def_dict['$ref']}' in property {name!r}. "
+                "Schema must be dereferenced before conversion."
+            )
 
         # Handle anyOf / oneOf by selecting a representative variant
         if "anyOf" in def_dict or "oneOf" in def_dict:
             variants = def_dict.get("anyOf") or def_dict.get("oneOf")
             if not isinstance(variants, list) or not variants:
                 raise ValueError("anyOf/oneOf must be a non-empty list")
-            picked = JsonSchemaConverter._pick_variant_from_anyof(variants, root_schema or {})
+            picked = JsonSchemaConverter._pick_variant_from_anyof(variants)
             # Merge picked with def_dict to preserve top-level default/description etc.
             merged = {
                 **picked,
@@ -109,7 +73,7 @@ class JsonSchemaConverter:
             def_dict = merged
 
         raw_type = def_dict.get("type")
-        prop_type, is_nullable = JsonSchemaConverter._normalize_type(raw_type)
+        prop_type = JsonSchemaConverter._normalize_type(raw_type)
 
         description = def_dict.get("description")
         default_value = def_dict.get("default")
@@ -123,8 +87,6 @@ class JsonSchemaConverter:
             prop_type = "string"
 
         if prop_type in ["string", "number", "integer", "boolean"]:
-            # ConfigurableSchemaSimpleType doesn't track nullable explicitly;
-            # default_value may already be None when schema allowed null.
             return ConfigurableSchemaSimpleType(
                 type=getattr(JsonTypeEnum, prop_type),
                 description=description,
@@ -132,10 +94,7 @@ class JsonSchemaConverter:
                 default=default_value,
             )
         elif prop_type == "object":
-            # For nested objects, pass the original root_schema so nested refs can be resolved
-            nested_properties = JsonSchemaConverter.convert_schema_to_properties(
-                def_dict, root_schema=root_schema or def_dict
-            )
+            nested_properties = JsonSchemaConverter.convert_schema_to_properties(def_dict)
             return ConfigurableSchemaObject(
                 type=JsonTypeEnum.object,
                 properties=nested_properties,
@@ -145,10 +104,7 @@ class JsonSchemaConverter:
             )
         elif prop_type == "array":
             items_def = def_dict.get("items", {})
-            # recursively build items schema (handles array of arrays, objects, simple types)
-            items_schema = JsonSchemaConverter._build_schema_from_definition(
-                items_def, name=name, root_schema=root_schema
-            )
+            items_schema = JsonSchemaConverter._build_schema_from_definition(items_def, name=name)
             return ConfigurableSchemaArray(
                 type=JsonTypeEnum.array,
                 items=items_schema,
@@ -160,36 +116,27 @@ class JsonSchemaConverter:
 
     @staticmethod
     def convert_schema_to_properties(
-        schema_dict: dict[str, Any], root_schema: dict[str, Any] | None = None
+        schema_dict: dict[str, Any],
     ) -> dict[str, _ConfigurableSchema]:
         """
         Convert a JSON schema dictionary to ConfigurableSchema* properties.
 
+        Resolves any $ref pointers via dereference_refs() before conversion.
+
         Args:
             schema_dict: The JSON schema dictionary containing properties definition
-            root_schema: optional root schema used to resolve internal $ref pointers.
-                         If not provided, schema_dict is used as root.
 
         Returns:
             Dictionary of converted properties compatible with OpenAiToolFunctionParameters
         """
-        properties: dict[str, _ConfigurableSchema] = {}
-
-        # Preserve the original root for resolving internal refs
-        original_root = root_schema or schema_dict
-
-        # Resolve top-level $ref if present
-        if "$ref" in schema_dict:
-            resolved = JsonSchemaConverter._resolve_ref(schema_dict["$ref"], original_root)
-            # Merge resolved with local overrides (local keys take precedence)
-            schema_dict = {**resolved, **{k: v for k, v in schema_dict.items() if k != "$ref"}}
+        schema_dict = dereference_refs(schema_dict)
 
         # Handle top-level anyOf/oneOf
         if "anyOf" in schema_dict or "oneOf" in schema_dict:
             variants = schema_dict.get("anyOf") or schema_dict.get("oneOf")
             if not isinstance(variants, list) or not variants:
                 raise ValueError("anyOf/oneOf must be a non-empty list")
-            picked = JsonSchemaConverter._pick_variant_from_anyof(variants, original_root)
+            picked = JsonSchemaConverter._pick_variant_from_anyof(variants)
             schema_dict = {
                 **picked,
                 **{k: v for k, v in schema_dict.items() if k not in ("anyOf", "oneOf")},
@@ -197,9 +144,10 @@ class JsonSchemaConverter:
 
         schema_properties = schema_dict.get("properties", {})
 
+        properties: dict[str, _ConfigurableSchema] = {}
         for prop_name, prop_def in schema_properties.items():
             properties[prop_name] = JsonSchemaConverter._build_schema_from_definition(
-                prop_def, name=prop_name, root_schema=original_root
+                prop_def, name=prop_name
             )
 
         return properties

--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -79,7 +79,9 @@ class _MCPToolInitializer(CompletionInitializer):
 
     @staticmethod
     # todo add Title to config so that we could use it in stage name
-    def _convert_to_openai_tool(name: str, description: str | None, input_schema: dict[str, Any]):
+    def _convert_to_openai_tool(
+        name: str, description: str | None, input_schema: dict[str, Any]
+    ) -> OpenAiToolConfig:
         return OpenAiToolConfig(
             function=OpenAiToolFunction.model_construct(  # model_construct to prevent double @model_validator execution for name
                 name=name,

--- a/src/tests/unit_tests/common/test_json_schema_converter.py
+++ b/src/tests/unit_tests/common/test_json_schema_converter.py
@@ -1,0 +1,401 @@
+import pytest
+
+from quickapp.common.json_schema_converter import JsonSchemaConverter
+from quickapp.config.tools.base import (
+    ConfigurableSchemaArray,
+    ConfigurableSchemaObject,
+    ConfigurableSchemaSimpleType,
+    JsonTypeEnum,
+)
+
+
+class TestSimpleTypes:
+    def test_string_property(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string", "description": "A name"}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert "name" in result
+        prop = result["name"]
+        assert isinstance(prop, ConfigurableSchemaSimpleType)
+        assert prop.type == JsonTypeEnum.string
+        assert prop.description == "A name"
+
+    def test_number_property(self):
+        schema = {"type": "object", "properties": {"value": {"type": "number"}}}
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert isinstance(result["value"], ConfigurableSchemaSimpleType)
+        assert result["value"].type == JsonTypeEnum.number
+
+    def test_integer_property(self):
+        schema = {"type": "object", "properties": {"count": {"type": "integer"}}}
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert isinstance(result["count"], ConfigurableSchemaSimpleType)
+        assert result["count"].type == JsonTypeEnum.integer
+
+    def test_boolean_property(self):
+        schema = {"type": "object", "properties": {"flag": {"type": "boolean"}}}
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert isinstance(result["flag"], ConfigurableSchemaSimpleType)
+        assert result["flag"].type == JsonTypeEnum.boolean
+
+    def test_enum_values(self):
+        schema = {
+            "type": "object",
+            "properties": {"color": {"type": "string", "enum": ["red", "green", "blue"]}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        prop = result["color"]
+        assert isinstance(prop, ConfigurableSchemaSimpleType)
+        assert prop.enum == ["red", "green", "blue"]
+
+    def test_default_value(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": "string", "default": "hello"}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert result["name"].default == "hello"
+
+
+class TestMissingType:
+    def test_missing_type_defaults_to_string(self):
+        schema = {"type": "object", "properties": {"unknown": {}}}
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert isinstance(result["unknown"], ConfigurableSchemaSimpleType)
+        assert result["unknown"].type == JsonTypeEnum.string
+
+    def test_missing_type_with_properties_defaults_to_object(self):
+        schema = {
+            "type": "object",
+            "properties": {"nested": {"properties": {"inner": {"type": "string"}}}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert isinstance(result["nested"], ConfigurableSchemaObject)
+        assert result["nested"].type == JsonTypeEnum.object
+
+
+class TestNullableTypes:
+    def test_nullable_type_list(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"type": ["string", "null"]}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        prop = result["name"]
+        assert isinstance(prop, ConfigurableSchemaSimpleType)
+        assert prop.type == JsonTypeEnum.string
+
+    def test_nullable_type_list_integer(self):
+        schema = {
+            "type": "object",
+            "properties": {"count": {"type": ["integer", "null"]}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert result["count"].type == JsonTypeEnum.integer
+
+
+class TestObjectType:
+    def test_nested_object(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "config": {
+                    "type": "object",
+                    "description": "Config object",
+                    "properties": {
+                        "key": {"type": "string"},
+                        "value": {"type": "integer"},
+                    },
+                    "required": ["key"],
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        config = result["config"]
+        assert isinstance(config, ConfigurableSchemaObject)
+        assert config.type == JsonTypeEnum.object
+        assert config.description == "Config object"
+        assert config.required == ["key"]
+        assert "key" in config.properties
+        assert "value" in config.properties
+        assert isinstance(config.properties["key"], ConfigurableSchemaSimpleType)
+
+
+class TestArrayType:
+    def test_array_of_strings(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "tags": {
+                    "type": "array",
+                    "description": "Tags",
+                    "items": {"type": "string"},
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        tags = result["tags"]
+        assert isinstance(tags, ConfigurableSchemaArray)
+        assert tags.type == JsonTypeEnum.array
+        assert tags.description == "Tags"
+        assert isinstance(tags.items, ConfigurableSchemaSimpleType)
+        assert tags.items.type == JsonTypeEnum.string
+
+    def test_array_of_objects(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "items": {
+                    "type": "array",
+                    "description": "Items",
+                    "items": {
+                        "type": "object",
+                        "properties": {"id": {"type": "integer"}},
+                        "description": "An item",
+                    },
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        arr = result["items"]
+        assert isinstance(arr, ConfigurableSchemaArray)
+        assert isinstance(arr.items, ConfigurableSchemaObject)
+        assert "id" in arr.items.properties
+
+    def test_nested_array(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "matrix": {
+                    "type": "array",
+                    "description": "Matrix",
+                    "items": {
+                        "type": "array",
+                        "description": "Row",
+                        "items": {"type": "number"},
+                    },
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        matrix = result["matrix"]
+        assert isinstance(matrix, ConfigurableSchemaArray)
+        assert isinstance(matrix.items, ConfigurableSchemaArray)
+        assert isinstance(matrix.items.items, ConfigurableSchemaSimpleType)
+        assert matrix.items.items.type == JsonTypeEnum.number
+
+
+class TestRefResolution:
+    """Tests that verify the converter resolves $ref pointers."""
+
+    def test_ref_in_property(self):
+        schema = {
+            "type": "object",
+            "properties": {"addr": {"$ref": "#/$defs/Address"}},
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "description": "Address",
+                    "properties": {"city": {"type": "string"}},
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        addr = result["addr"]
+        assert isinstance(addr, ConfigurableSchemaObject)
+        assert "city" in addr.properties
+
+    def test_ref_with_sibling_override(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "addr": {
+                    "$ref": "#/$defs/Address",
+                    "description": "Overridden desc",
+                }
+            },
+            "$defs": {
+                "Address": {
+                    "type": "object",
+                    "description": "Original desc",
+                    "properties": {"city": {"type": "string"}},
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        addr = result["addr"]
+        assert isinstance(addr, ConfigurableSchemaObject)
+        assert addr.description == "Overridden desc"
+
+    def test_deep_property_path_ref(self):
+        """$ref pointing into properties tree (not $defs), as seen in MS Graph API schemas."""
+        days_enum = ["sunday", "monday", "tuesday", "wednesday", "thursday", "friday", "saturday"]
+        schema = {
+            "type": "object",
+            "properties": {
+                "pattern": {
+                    "type": "object",
+                    "description": "Pattern",
+                    "properties": {
+                        "daysOfWeek": {
+                            "type": "array",
+                            "items": {
+                                "anyOf": [
+                                    {"type": "string", "enum": days_enum},
+                                    {
+                                        "type": "object",
+                                        "properties": {},
+                                        "additionalProperties": True,
+                                    },
+                                ]
+                            },
+                            "description": "Days of week",
+                        },
+                        "firstDayOfWeek": {
+                            "$ref": "#/properties/pattern/properties/daysOfWeek/items/anyOf/0"
+                        },
+                    },
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        pattern = result["pattern"]
+        assert isinstance(pattern, ConfigurableSchemaObject)
+
+        first_day = pattern.properties["firstDayOfWeek"]
+        assert isinstance(first_day, ConfigurableSchemaSimpleType)
+        assert first_day.type == JsonTypeEnum.string
+        assert first_day.enum == days_enum
+
+        days = pattern.properties["daysOfWeek"]
+        assert isinstance(days, ConfigurableSchemaArray)
+
+    def test_unresolvable_ref_raises(self):
+        """Leftover $ref after dereferencing raises ValueError."""
+        schema = {
+            "type": "object",
+            "properties": {"bad": {"$ref": "#/$defs/DoesNotExist"}},
+        }
+        with pytest.raises(ValueError, match="Unresolved \\$ref"):
+            JsonSchemaConverter.convert_schema_to_properties(schema)
+
+    def test_top_level_ref_resolved(self):
+        """Top-level $ref is resolved by the converter."""
+        schema = {
+            "$ref": "#/$defs/Root",
+            "$defs": {
+                "Root": {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert "x" in result
+        assert isinstance(result["x"], ConfigurableSchemaSimpleType)
+
+
+class TestAnyOfOneOf:
+    def test_anyof_picks_non_null(self):
+        schema = {
+            "type": "object",
+            "properties": {"name": {"anyOf": [{"type": "string"}, {"type": "null"}]}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        prop = result["name"]
+        assert isinstance(prop, ConfigurableSchemaSimpleType)
+        assert prop.type == JsonTypeEnum.string
+
+    def test_oneof_picks_non_null(self):
+        schema = {
+            "type": "object",
+            "properties": {"value": {"oneOf": [{"type": "null"}, {"type": "integer"}]}},
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        prop = result["value"]
+        assert isinstance(prop, ConfigurableSchemaSimpleType)
+        assert prop.type == JsonTypeEnum.integer
+
+    def test_anyof_with_ref(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "item": {
+                    "anyOf": [
+                        {"$ref": "#/$defs/Item"},
+                        {"type": "null"},
+                    ]
+                }
+            },
+            "$defs": {
+                "Item": {
+                    "type": "object",
+                    "description": "An item",
+                    "properties": {"id": {"type": "integer"}},
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        item = result["item"]
+        assert isinstance(item, ConfigurableSchemaObject)
+        assert "id" in item.properties
+
+    def test_anyof_preserves_description(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "anyOf": [{"type": "string"}, {"type": "null"}],
+                    "description": "A name field",
+                }
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert result["name"].description == "A name field"
+
+    def test_top_level_anyof(self):
+        schema = {
+            "anyOf": [
+                {
+                    "type": "object",
+                    "properties": {"x": {"type": "string"}},
+                },
+                {"type": "null"},
+            ]
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert "x" in result
+
+
+class TestUnsupportedType:
+    def test_unsupported_type_raises(self):
+        schema = {
+            "type": "object",
+            "properties": {"bad": {"type": "unknown_type"}},
+        }
+        with pytest.raises(ValueError, match="Unsupported property type"):
+            JsonSchemaConverter.convert_schema_to_properties(schema)
+
+
+class TestMultipleProperties:
+    def test_multiple_properties_converted(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "name": {"type": "string", "description": "Name"},
+                "age": {"type": "integer", "description": "Age"},
+                "active": {"type": "boolean"},
+            },
+        }
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert len(result) == 3
+        assert result["name"].type == JsonTypeEnum.string
+        assert result["age"].type == JsonTypeEnum.integer
+        assert result["active"].type == JsonTypeEnum.boolean
+
+    def test_empty_properties(self):
+        schema = {"type": "object", "properties": {}}
+        result = JsonSchemaConverter.convert_schema_to_properties(schema)
+        assert result == {}

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
@@ -53,7 +53,7 @@ def tool1():
     tool = MagicMock(name="tool1")
     tool.name = "tool1"
     tool.description = "desc1"
-    tool.args_schema = {}
+    tool.inputSchema = {"type": "object", "properties": {}}
     return tool
 
 
@@ -62,7 +62,7 @@ def tool2():
     tool = MagicMock(name="tool2")
     tool.name = "tool2"
     tool.description = "desc2"
-    tool.args_schema = {}
+    tool.inputSchema = {"type": "object", "properties": {}}
     return tool
 
 
@@ -336,3 +336,19 @@ async def test_no_exception_if_toolset_list_is_empty():
     )
     await initializer.initialize()
     mcp_context.append_tool.assert_not_called()
+
+
+def test_convert_to_openai_tool_dereferences_refs():
+    schema = {
+        "type": "object",
+        "properties": {"addr": {"$ref": "#/$defs/Address"}},
+        "$defs": {
+            "Address": {
+                "type": "object",
+                "description": "Address",
+                "properties": {"city": {"type": "string"}},
+            }
+        },
+    }
+    result = _MCPToolInitializer._convert_to_openai_tool("test_tool", "A test tool", schema)
+    assert "addr" in result.function.parameters.properties


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
-

### Description of changes

Replaces the hand-rolled `$ref` resolution in `JsonSchemaConverter` with `fastmcp.utilities.json_schema.dereference_refs()`. Refs are now resolved once upfront in `convert_schema_to_properties()`, which removes the `root_schema` parameter threading and the custom `_resolve_ref` helper.

Added unit tests for `JsonSchemaConverter` and updated MCP tool initializer tests.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
