### PR TITLE
fix: use default attachment config in DialDeploymentTool #160

### DIFF
--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -12,7 +12,6 @@ from quickapp.common.dial_core_client import DialCoreClient, ToolsetInfo
 from quickapp.common.dial_settings import DialSettings
 from quickapp.config.dial_deployment import DialDeploymentConfig
 from quickapp.config.tools.base import (
-    AttachmentConfig,
     ConfigurableSchemaArray,
     ConfigurableSchemaSimpleType,
     JsonTypeEnum,
@@ -96,9 +95,6 @@ class ToolConfigCoreService:
         output_tool = DialDeploymentTool(
             display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {deployment.id}: ")),
             deployment=DialDeploymentConfig(name=deployment.id),
-            attachment=AttachmentConfig(
-                propagate_types_to_choice=[],
-            ),
             fallback_configuration=ToolFallbackConfig(strategies=[ContinueStrategyModel()]),
             open_ai_tool=OpenAiToolConfig(
                 function=OpenAiToolFunction(

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -33,11 +33,13 @@ def test_supported_types_defaults_to_all_when_empty_input_attachment_types():
     assert result.attachment.supported_types == [ALL_MIME_TYPES]
 
 
-def test_propagate_types_to_choice_is_empty_for_deployment_tools():
+def test_propagate_types_to_choice_is_default_for_deployment_tools():
     deployment = _make_deployment(input_attachment_types=["image/*"])
     result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
 
-    assert result.attachment.propagate_types_to_choice == []
+    assert len(result.attachment.propagate_types_to_choice) == 2
+    assert "image/*" in result.attachment.propagate_types_to_choice
+    assert "application/vnd.plotly.v1+json" in result.attachment.propagate_types_to_choice
 
 
 def test_input_attachment_types_adds_attachment_urls_param():


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #160 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

- removed customization of attachment config for `DialDeploymentTool`

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
