### PR TITLE
fix: plotly conversion in code interpreter #169

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,4 +46,4 @@ ENTRYPOINT ["/docker_entrypoint.sh"]
 HEALTHCHECK --interval=10s --timeout=5s --start-period=30s --retries=6 \
   CMD wget --no-verbose --tries=1 --spider http://localhost:5000/health || exit 1
 
-CMD ["uvicorn", "quickapp.app:app", "--host", "0.0.0.0", "--port", "5000"]
+CMD ["uvicorn", "quickapp.app:app", "--host", "0.0.0.0", "--port", "5000", "--lifespan", "on"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,14 @@ FROM python:3.13-alpine AS runtime
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat zlib
 
 RUN apk add --no-cache chromium nss freetype harfbuzz ttf-freefont libstdc++
-ENV CHROME_BIN=/usr/bin/chromium
-
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
     PYDANTIC_V2=True \
-    CHROME_BIN=/home/appuser/.cache/kaleido/chrome
+    BROWSER_PATH=/usr/bin/chromium \
+    CHROME_BIN=/usr/bin/chromium
 
 # Copy the sources and virtual env. No poetry.
 RUN adduser -u 1001 --disabled-password --gecos "" appuser

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,9 +24,7 @@ WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYDANTIC_V2=True \
-    BROWSER_PATH=/usr/bin/chromium \
-    CHROME_BIN=/usr/bin/chromium
+    PYDANTIC_V2=True
 
 # Copy the sources and virtual env. No poetry.
 RUN adduser -u 1001 --disabled-password --gecos "" appuser

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,10 @@ ignore_missing_imports = false
 module = ["aidial_sdk.*", "aidial_client.*"]
 follow_untyped_imports = true
 
+[[tool.mypy.overrides]]
+module = ["kaleido", "kaleido.*"]
+follow_untyped_imports = true
+
 [tool.poetry.group.dev]
 optional = true
 

--- a/src/quickapp/application/_quick_app_application.py
+++ b/src/quickapp/application/_quick_app_application.py
@@ -43,7 +43,7 @@ class _QuickAppApplication(DIALApp):
             logger.info("All modules successfully configured")
             yield
 
-            for resource in lifecycle_resources:
+            for resource in reversed(lifecycle_resources):
                 resource_name = type(resource).__name__
                 logger.info(f"Stopping lifecycle resource: {resource_name}")
                 await resource.stop()

--- a/src/quickapp/application/_quick_app_application.py
+++ b/src/quickapp/application/_quick_app_application.py
@@ -11,6 +11,7 @@ from injector import Injector, inject
 from quickapp.application._otel_settings import _OtelSettings
 from quickapp.common.base_initializer import InitializerType, invoke_initializers
 from quickapp.common.dial_settings import DialSettings
+from quickapp.common.lifecycle_resource import LifecycleResource
 
 logger = logging.getLogger(__name__)
 
@@ -27,12 +28,20 @@ class _QuickAppApplication(DIALApp):
         completion: ChatCompletion,
         dial_settings: DialSettings,
         otel_settings: _OtelSettings,
+        lifecycle_resources: list[LifecycleResource],
     ):
         @asynccontextmanager
         async def lifespan(app: FastAPI):  # noqa: ARG001
             await invoke_initializers(injector, InitializerType.startup)
+
+            for resource in lifecycle_resources:
+                await resource.start()
+
             logger.info("All modules successfully configured")
             yield
+
+            for resource in lifecycle_resources:
+                await resource.stop()
 
         super().__init__(
             dial_url=dial_settings.url,

--- a/src/quickapp/application/_quick_app_application.py
+++ b/src/quickapp/application/_quick_app_application.py
@@ -35,13 +35,19 @@ class _QuickAppApplication(DIALApp):
             await invoke_initializers(injector, InitializerType.startup)
 
             for resource in lifecycle_resources:
+                resource_name = type(resource).__name__
+                logger.info(f"Starting lifecycle resource: {resource_name}")
                 await resource.start()
+                logger.info(f"Lifecycle resource started: {resource_name}")
 
             logger.info("All modules successfully configured")
             yield
 
             for resource in lifecycle_resources:
+                resource_name = type(resource).__name__
+                logger.info(f"Stopping lifecycle resource: {resource_name}")
                 await resource.stop()
+                logger.info(f"Lifecycle resource stopped: {resource_name}")
 
         super().__init__(
             dial_url=dial_settings.url,

--- a/src/quickapp/common/lifecycle_resource.py
+++ b/src/quickapp/common/lifecycle_resource.py
@@ -1,0 +1,12 @@
+from abc import ABC, abstractmethod
+
+
+class LifecycleResource(ABC):
+
+    @abstractmethod
+    async def start(self) -> None:  # pragma: no cover
+        ...
+
+    @abstractmethod
+    async def stop(self) -> None:  # pragma: no cover
+        ...

--- a/src/quickapp/internal_tooling/internal_tooling_module.py
+++ b/src/quickapp/internal_tooling/internal_tooling_module.py
@@ -1,13 +1,15 @@
 import logging
 
 from fastapi_injector import request_scope
-from injector import AssistedBuilder, Binder, Module, multiprovider, provider, singleton
+from injector import AssistedBuilder, Binder, Module, ProviderOf, multiprovider, provider, singleton
 
 from quickapp.common import DIAL_API_KEY, StagedBaseTool
 from quickapp.common.dial_settings import DialSettings
+from quickapp.common.lifecycle_resource import LifecycleResource
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.tools.predefined import PredefinedTool
 from quickapp.config.toolsets.internal import InternalToolSet
+from quickapp.internal_tooling.py_interpreter_tooling._kaleido_service import _KaleidoService
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_client import (
     _PyInterpreterClient,
 )
@@ -30,6 +32,7 @@ class InternalToolModule(Module):
         binder.bind(ContentSanitizer, to=ContentSanitizer)
         binder.bind(SessionManager, to=SessionManager, scope=request_scope)
         binder.bind(_PyInterpreterTool, to=_PyInterpreterTool, scope=request_scope)
+        binder.bind(_KaleidoService, to=_KaleidoService, scope=singleton)
         logger.debug("InternalTooling module configuration completed")
 
     @multiprovider
@@ -61,6 +64,12 @@ class InternalToolModule(Module):
                             )
 
         return tools
+
+    @multiprovider
+    def _provide_lifecycle_resources(
+        self, kaleido_provider: ProviderOf[_KaleidoService]
+    ) -> list[LifecycleResource]:
+        return [kaleido_provider.get()]
 
     @singleton
     @provider

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_kaleido_service.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_kaleido_service.py
@@ -1,0 +1,47 @@
+import asyncio
+import json
+import logging
+from typing import Any
+
+from kaleido import Kaleido
+
+from quickapp.common.lifecycle_resource import LifecycleResource
+
+logger = logging.getLogger(__name__)
+
+
+class _KaleidoService(LifecycleResource):
+    def __init__(self) -> None:
+        self._kaleido: Kaleido | None = None
+        self._lock = asyncio.Lock()
+
+    async def start(self) -> None:
+        pass
+
+    async def stop(self) -> None:
+        if self._kaleido is not None:
+            logger.info("Stopping Kaleido service")
+            try:
+                await self._kaleido.__aexit__(None, None, None)
+            except Exception:
+                logger.exception("Error stopping Kaleido service")
+            finally:
+                self._kaleido = None
+
+    async def _ensure_started(self) -> Kaleido:
+        if self._kaleido is None:
+            async with self._lock:
+                if self._kaleido is None:
+                    logger.info("Starting Kaleido service (lazy init)")
+                    self._kaleido = Kaleido(n=1, timeout=90)
+                    await self._kaleido.__aenter__()
+                    logger.info("Kaleido service started")
+        return self._kaleido
+
+    async def render_figure_as_png(self, figure_json: str | dict[str, Any]) -> bytes:
+        kaleido = await self._ensure_started()
+        fig_dict = json.loads(figure_json) if isinstance(figure_json, str) else figure_json
+        data = await kaleido.calc_fig(fig_dict, opts={"format": "png"})
+        if data is None:
+            raise RuntimeError("Kaleido returned no data for the figure")
+        return bytes(data)

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_kaleido_service.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_kaleido_service.py
@@ -33,8 +33,9 @@ class _KaleidoService(LifecycleResource):
             async with self._lock:
                 if self._kaleido is None:
                     logger.info("Starting Kaleido service (lazy init)")
-                    self._kaleido = Kaleido(n=1, timeout=90)
-                    await self._kaleido.__aenter__()
+                    kaleido = Kaleido(n=1, timeout=90)
+                    await kaleido.__aenter__()
+                    self._kaleido = kaleido
                     logger.info("Kaleido service started")
         return self._kaleido
 

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/display_content_processor.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/display_content_processor.py
@@ -2,10 +2,8 @@ import base64
 import json
 import logging
 import uuid
-from io import BytesIO
 from typing import Any
 
-import plotly.io as pio
 from aidial_client import AsyncDial
 from aidial_client.types.chat.request_param import (
     AttachmentParam,
@@ -26,6 +24,7 @@ from quickapp.common.utils import generate_attachment_filename
 from quickapp.internal_tooling.py_interpreter_tooling._constants import (
     SUPPORTED_DISPLAY_MEDIA_TYPES,
 )
+from quickapp.internal_tooling.py_interpreter_tooling._kaleido_service import _KaleidoService
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_settings import (
     _PyInterpreterSettings,
 )
@@ -50,17 +49,13 @@ class DisplayContentProcessor:
         api_key: DIAL_API_KEY,
         dial_client: AsyncDial,
         py_interpreter_settings: _PyInterpreterSettings,
+        kaleido_service: _KaleidoService,
     ):
         self.__dial_settings: DialSettings = dial_settings
         self.__api_key: DIAL_API_KEY = api_key
         self.__dial_client: AsyncDial = dial_client
         self.__additional_handling_model: str = py_interpreter_settings.additional_handling_model
-        pio.defaults.chromium_args = [  # type: ignore[attr-defined]
-            "--no-sandbox",
-            "--disable-gpu",
-            "--disable-dev-shm-usage",
-            "--disable-setuid-sandbox",
-        ]
+        self.__kaleido_service: _KaleidoService = kaleido_service
 
     async def process_display_content(
         self,
@@ -166,10 +161,7 @@ class DisplayContentProcessor:
         return message
 
     async def _get_plotly_as_img(self, attachment_param: AttachmentParam) -> AttachmentParam:
-        fig = pio.from_json(attachment_param["data"])
-        image_bytes = BytesIO()
-        fig.write_image(image_bytes, format="png")
-        image_bytes.seek(0)
+        image_data = await self.__kaleido_service.render_figure_as_png(attachment_param["data"])
 
         async with DialCoreClient(
             api_key=self.__api_key, base_url=self.__dial_settings.url
@@ -178,7 +170,7 @@ class DisplayContentProcessor:
             bucket_info = await dial_core.put_file(
                 name=filename,
                 mime_type=MediaTypes.PNG,
-                content=image_bytes,
+                content=image_data,
             )
 
             return AttachmentParam(url=bucket_info.get("url"), type=MediaTypes.PNG)

--- a/src/tests/unit_tests/internal_tooling_tests/test_kaleido_service.py
+++ b/src/tests/unit_tests/internal_tooling_tests/test_kaleido_service.py
@@ -1,0 +1,110 @@
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from quickapp.internal_tooling.py_interpreter_tooling._kaleido_service import _KaleidoService
+
+
+@pytest.fixture
+def service():
+    return _KaleidoService()
+
+
+@pytest.mark.asyncio
+async def test_stop_when_not_started(service):
+    await service.stop()
+    assert service._kaleido is None
+
+
+@pytest.mark.asyncio
+async def test_lazy_start_on_first_render(service):
+    mock_kaleido = MagicMock()
+    mock_kaleido.__aenter__ = AsyncMock(return_value=mock_kaleido)
+    mock_kaleido.__aexit__ = AsyncMock(return_value=None)
+    mock_kaleido.calc_fig = AsyncMock(return_value=b"\x89PNG")
+
+    with patch(
+        "quickapp.internal_tooling.py_interpreter_tooling._kaleido_service.Kaleido",
+        return_value=mock_kaleido,
+    ) as mock_cls:
+        result = await service.render_figure_as_png({"data": [{"y": [1, 2]}]})
+
+        mock_cls.assert_called_once_with(n=1, timeout=90)
+        mock_kaleido.__aenter__.assert_awaited_once()
+        mock_kaleido.calc_fig.assert_awaited_once()
+        assert result == b"\x89PNG"
+
+
+@pytest.mark.asyncio
+async def test_stop_after_lazy_start(service):
+    mock_kaleido = MagicMock()
+    mock_kaleido.__aenter__ = AsyncMock(return_value=mock_kaleido)
+    mock_kaleido.__aexit__ = AsyncMock(return_value=None)
+    mock_kaleido.calc_fig = AsyncMock(return_value=b"\x89PNG")
+
+    with patch(
+        "quickapp.internal_tooling.py_interpreter_tooling._kaleido_service.Kaleido",
+        return_value=mock_kaleido,
+    ):
+        await service.render_figure_as_png({"data": [{"y": [1]}]})
+        assert service._kaleido is not None
+
+        await service.stop()
+        mock_kaleido.__aexit__.assert_awaited_once()
+        assert service._kaleido is None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_lazy_start_creates_single_instance(service):
+    mock_kaleido = MagicMock()
+    mock_kaleido.__aenter__ = AsyncMock(return_value=mock_kaleido)
+    mock_kaleido.__aexit__ = AsyncMock(return_value=None)
+    mock_kaleido.calc_fig = AsyncMock(return_value=b"\x89PNG")
+
+    with patch(
+        "quickapp.internal_tooling.py_interpreter_tooling._kaleido_service.Kaleido",
+        return_value=mock_kaleido,
+    ) as mock_cls:
+        results = await asyncio.gather(
+            service.render_figure_as_png({"data": [{"y": [1]}]}),
+            service.render_figure_as_png({"data": [{"y": [2]}]}),
+            service.render_figure_as_png({"data": [{"y": [3]}]}),
+        )
+
+        mock_cls.assert_called_once()
+        mock_kaleido.__aenter__.assert_awaited_once()
+        assert all(r == b"\x89PNG" for r in results)
+
+
+@pytest.mark.asyncio
+async def test_render_with_json_string(service):
+    mock_kaleido = MagicMock()
+    mock_kaleido.__aenter__ = AsyncMock(return_value=mock_kaleido)
+    mock_kaleido.__aexit__ = AsyncMock(return_value=None)
+    mock_kaleido.calc_fig = AsyncMock(return_value=b"\x89PNG")
+
+    with patch(
+        "quickapp.internal_tooling.py_interpreter_tooling._kaleido_service.Kaleido",
+        return_value=mock_kaleido,
+    ):
+        result = await service.render_figure_as_png('{"data": [{"y": [1, 2]}]}')
+
+        call_args = mock_kaleido.calc_fig.call_args
+        assert call_args[0][0] == {"data": [{"y": [1, 2]}]}
+        assert result == b"\x89PNG"
+
+
+@pytest.mark.asyncio
+async def test_render_raises_on_none_result(service):
+    mock_kaleido = MagicMock()
+    mock_kaleido.__aenter__ = AsyncMock(return_value=mock_kaleido)
+    mock_kaleido.__aexit__ = AsyncMock(return_value=None)
+    mock_kaleido.calc_fig = AsyncMock(return_value=None)
+
+    with patch(
+        "quickapp.internal_tooling.py_interpreter_tooling._kaleido_service.Kaleido",
+        return_value=mock_kaleido,
+    ):
+        with pytest.raises(RuntimeError, match="Kaleido returned no data"):
+            await service.render_figure_as_png({"data": []})


### PR DESCRIPTION
### Applicable issues

- fixes #169

### Description of changes

#### Problem

Plotly-to-PNG conversion in the Python code interpreter was failing in Kubernetes with a misleading `BrowserDepsError` from kaleido/choreographer. Investigation revealed three root causes:

1. **Redundant env vars in Dockerfile** — `CHROME_BIN` was pointing to a non-existent kaleido cache path, but it isn't even required
2. **Blocking sync rendering** — `fig.write_image()` is synchronous, blocking the async event loop while Chrome renders
3. **Chrome process per render** — each `write_image()` call spawned a new Chrome process via kaleido's convenience API, making it both slow and fragile in containers

#### Solution

- **Dockerfile**: removed redundant env variables
- **`_KaleidoService`**: New singleton service that wraps kaleido's async API. Chrome is initialized lazily on first plotly render (not at app startup) and reused across all subsequent renders. Shutdown is handled via the lifecycle resource pattern.
- **`LifecycleResource` abstraction**: New ABC in `common/` with `start()`/`stop()` methods. Modules register implementations via `@multiprovider`, and the FastAPI lifespan drives the lifecycle — fully decoupled, no module-specific imports in the application layer. `_KaleidoService` is the first implementor.
- **`DisplayContentProcessor`**: Removed dead `pio.defaults.chromium_args` code (was never read by kaleido v1.x), replaced `fig.write_image()` with the async kaleido service.

### Local test

<img width="1861" height="902" alt="image" src="https://github.com/user-attachments/assets/0ff35ca9-ea76-4b1b-bb5e-a846c8b1b24c" />

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Changes are tested locally against dev code interpreter
- [X] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
