### PR TITLE
fix: revert switch from -alpine to -slim base docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,7 @@
-FROM python:3.13-slim AS builder
+FROM python:3.13-alpine AS builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc build-essential git \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 zlib
+RUN apk add --no-cache gcc alpine-sdk linux-headers musl-dev git
 RUN pip install poetry==2.2.1
 
 WORKDIR /app
@@ -15,22 +14,20 @@ COPY  ./src/quickapp /app/quickapp
 COPY  ./config/predefined /app/predefined
 RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
-FROM python:3.13-slim AS runtime
+FROM python:3.13-alpine AS runtime
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    chromium fonts-freefont-ttf wget \
-    && rm -rf /var/lib/apt/lists/*
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat zlib
+
+RUN apk add --no-cache chromium nss freetype harfbuzz ttf-freefont libstdc++
 
 WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
     PYTHONUNBUFFERED=1 \
-    PYDANTIC_V2=True \
-    BROWSER_PATH=/usr/bin/chromium \
-    CHROME_BIN=/usr/bin/chromium
+    PYDANTIC_V2=True
 
 # Copy the sources and virtual env. No poetry.
-RUN useradd -u 1001 -r -s /sbin/nologin appuser
+RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder /app .
 
 RUN echo '#!/bin/sh' > /docker_entrypoint.sh && \

--- a/src/tests/integration_tests/Dockerfile
+++ b/src/tests/integration_tests/Dockerfile
@@ -1,9 +1,8 @@
-FROM python:3.13-slim AS test-builder
+FROM python:3.13-alpine AS test-builder
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    gcc build-essential git \
-    && rm -rf /var/lib/apt/lists/*
-RUN pip install poetry==2.2.1
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
+RUN apk add --no-cache gcc alpine-sdk linux-headers musl-dev git
+RUN pip install poetry==2.1.1
 
 WORKDIR /app
 
@@ -24,13 +23,13 @@ COPY ./integration_tests ./integration_tests
 
 
 # Stage 2: Test runtime (reuse app runtime base for infra)
-FROM python:3.13-slim AS test-runtime
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+FROM python:3.13-alpine AS test-runtime
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat
 
 WORKDIR /app
-ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1 CHROME_BIN=/usr/bin/chromium
 
-RUN useradd -u 1001 -r -s /sbin/nologin appuser
+RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=test-builder /app .
 
 COPY --chown=appuser << 'EOF' /docker_test_entrypoint.sh && chmod +x /docker_test_entrypoint.sh


### PR DESCRIPTION
This reverts commit 382525ca144b664fa569ed9a24bcc8b90872cd1c.

### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
