### PR TITLE
feat: added `auto_submit` parameter to conversation starters config #145

### DIFF
--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -541,6 +541,12 @@
           "title": "Chat Message Input Disabled",
           "type": "boolean"
         },
+        "auto_submit": {
+          "default": true,
+          "description": "Whether to automatically submit the conversation starter text when a button is clicked. If false, the text will be populated in the chat input but not submitted, allowing users to edit it before sending.",
+          "title": "Auto Submit",
+          "type": "boolean"
+        },
         "starters": {
           "description": "The list of conversation starters.",
           "items": {

--- a/src/quickapp/config/starters.py
+++ b/src/quickapp/config/starters.py
@@ -17,6 +17,10 @@ class ConversationStartersConfig(BaseModel):
         default=False,
         description="Whether to disable the chat message input when using conversation starters. If true, users can only interact with the agent through the conversation starter buttons.",
     )
+    auto_submit: bool = Field(
+        default=True,
+        description="Whether to automatically submit the conversation starter text when a button is clicked. If false, the text will be populated in the chat input but not submitted, allowing users to edit it before sending.",
+    )
     starters: list[ConversationStarter] = Field(
         description="The list of conversation starters.", min_length=1
     )

--- a/src/quickapp/starters/_utils.py
+++ b/src/quickapp/starters/_utils.py
@@ -8,20 +8,25 @@ from pydantic import BaseModel
 from quickapp.config.starters import ConversationStarter, ConversationStartersConfig
 
 
-def _create_dial_buttons(starter_configs: list[ConversationStarter]) -> list[Button]:
+def _create_dial_buttons(
+    starter_configs: list[ConversationStarter], auto_submit: bool
+) -> list[Button]:
     return [
         Button(
             const=const,
             title=starter_config.title,
             populateText=starter_config.text,
-            submit=True,
+            submit=auto_submit,
         )
         for const, starter_config in enumerate(starter_configs, start=1)
     ]
 
 
 def create_starters_configuration(config: ConversationStartersConfig) -> dict[str, Any]:
-    buttons = _create_dial_buttons(config.starters)
+    buttons = _create_dial_buttons(
+        starter_configs=config.starters,
+        auto_submit=config.auto_submit,
+    )
 
     class _QuickAppStartersConfig(BaseModel, metaclass=FormMetaclass):
         model_config = DialConfigDict(

--- a/src/tests/unit_tests/starters_tests/test_starters.py
+++ b/src/tests/unit_tests/starters_tests/test_starters.py
@@ -29,15 +29,18 @@ class TestConversationStarterConfig:
         )
         assert config.intro_text == "Select an action"
         assert config.chat_message_input_disabled is False
+        assert config.auto_submit is True
 
     def test_valid_config_custom_fields(self):
         config = ConversationStartersConfig(
             intro_text="Pick one",
             chat_message_input_disabled=True,
+            auto_submit=False,
             starters=[ConversationStarter(title="A", text="B")],
         )
         assert config.intro_text == "Pick one"
         assert config.chat_message_input_disabled is True
+        assert config.auto_submit is False
 
     def test_empty_starters_list_rejected(self):
         with pytest.raises(ValidationError, match="starters"):
@@ -100,7 +103,7 @@ class TestCreateDialButtons:
             ConversationStarter(title="Hello", text="Say hello"),
             ConversationStarter(title="Help", text="I need help"),
         ]
-        buttons = _create_dial_buttons(starters)
+        buttons = _create_dial_buttons(starters, auto_submit=True)
 
         assert len(buttons) == 2
         assert buttons[0].const == 1
@@ -111,11 +114,24 @@ class TestCreateDialButtons:
         assert buttons[1].const == 2
         assert buttons[1].title == "Help"
         assert buttons[1].populateText == "I need help"
+        assert buttons[1].submit is True
 
     def test_single_starter(self):
-        buttons = _create_dial_buttons([ConversationStarter(title="Go", text="go")])
+        buttons = _create_dial_buttons(
+            [ConversationStarter(title="Go", text="go")], auto_submit=True
+        )
         assert len(buttons) == 1
         assert buttons[0].const == 1
+
+    def test_auto_submit_false(self):
+        starters = [
+            ConversationStarter(title="Hello", text="Say hello"),
+        ]
+        buttons = _create_dial_buttons(starters, auto_submit=False)
+
+        assert len(buttons) == 1
+        assert buttons[0].submit is False
+        assert buttons[0].populateText == "Say hello"
 
 
 class TestCreateStartersConfiguration:
@@ -157,6 +173,26 @@ class TestCreateStartersConfiguration:
         )
         schema = create_starters_configuration(config)
         assert schema["dial:chatMessageInputDisabled"] is True
+
+    def test_auto_submit_default(self):
+        config = ConversationStartersConfig(
+            starters=[ConversationStarter(title="A", text="a")],
+        )
+        schema = create_starters_configuration(config)
+        opts = schema["properties"]["starter"]["oneOf"][0]["dial:widgetOptions"]
+        assert opts["submit"] is True
+
+    def test_auto_submit_false(self):
+        config = ConversationStartersConfig(
+            auto_submit=False,
+            starters=[
+                ConversationStarter(title="A", text="a"),
+                ConversationStarter(title="B", text="b"),
+            ],
+        )
+        schema = create_starters_configuration(config)
+        for entry in schema["properties"]["starter"]["oneOf"]:
+            assert entry["dial:widgetOptions"]["submit"] is False
 
 
 def _make_app_config(


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #145

### Description of changes

<!-- Please explain the changes you made right below this line. -->

- Added `auto_submit` property to starters config
- Added unit tests

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
