### PR TITLE
feat: add preview features gating #188

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ lint: install_dev
 	$(POETRY) run isort $(SRC_DIRS) --check-only --diff
 	$(POETRY) run autoflake $(SRC_DIRS) --check
 	$(POETRY) run mypy --show-error-codes $(MYPY_DIRS)
-	$(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json --check
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json --check
 
 mypy: install_dev
 	$(POETRY) run mypy --show-error-codes $(MYPY_DIRS)
@@ -56,7 +56,7 @@ format: install_dev
 	$(POETRY) run black $(FILES)
 	$(POETRY) run isort $(FILES)
 ifeq ($(FILES), $(SRC_DIRS))
-	$(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
 endif
 
 # --- Individual tool targets (honor FILES variable) ---
@@ -105,7 +105,7 @@ test_cov: install_dev
 	$(PYTEST_UNIT) --cov=src/quickapp --cov-report=term-missing $(ARGS)
 
 dump_app_schema: install_dev
-	$(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
 
 generate_dial_config: install_dev
 	$(POETRY) run python src/scripts/generate_dial_config.py --models \

--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ your gateways or downstream services expect.
 | `PY_INTERPRETER_DEFAULT_SESSION_ID`        | —                          | No       | Default session ID for the PyInterpreter                                                                     |
 | `PY_INTERPRETER_CLIENT_TIMEOUT`            | `60.0`                     | No       | Timeout (seconds) for PyInterpreter client requests                                                          |
 | `PY_INTERPRETER_CLIENT_MAX_RETRIES`        | `3`                        | No       | Max retries for PyInterpreter client requests                                                                |
+| **Feature Gating**                         |                            |          |                                                                                                              |
+| `ENABLE_PREVIEW_FEATURES`                  | `false`                    | No       | Enable preview features across the deployment (schema visibility + runtime activation)                       |
 | **Templates**                              |                            |          |                                                                                                              |
 | `PREDEFINED_EXTRA_PATHS`                   | —                          | No       | JSON list of directories layered on top of built-in predefined content (later entries override earlier ones) |
 | `CONFIG_PROMPT_MAPPING`                    | *(built-in mapping)*       | No       | JSON mapping of predefined system prompts to DIAL Core deployments                                           |

--- a/docs/designs/preview_feature_gating.md
+++ b/docs/designs/preview_feature_gating.md
@@ -1,6 +1,6 @@
 # Design: Preview Feature Gating
 
-- **Status:** Draft
+- **Status:** Implemented
 - **Dependencies:**
   - None
 

--- a/docs/designs/preview_feature_gating.md
+++ b/docs/designs/preview_feature_gating.md
@@ -1,8 +1,8 @@
 # Design: Preview Feature Gating
 
-**Status:** Draft
-**Dependencies:**
-- None
+- **Status:** Draft
+- **Dependencies:**
+  - None
 
 ## Problem Statement
 

--- a/docs/designs/preview_feature_gating.md
+++ b/docs/designs/preview_feature_gating.md
@@ -1,0 +1,296 @@
+# Design: Preview Feature Gating
+
+**Status:** Draft
+**Dependencies:**
+- None
+
+## Problem Statement
+
+As new features are added to QuickApps (e.g. timestamp awareness), some need to be shipped in
+a "preview" state — available for early testing but not yet considered stable. Today there is no
+mechanism to:
+
+1. **Mark a config field as preview** — app creators can configure any field that appears in
+   the schema, with no indication that a feature is experimental.
+2. **Gate preview features at deployment level** — there is no way for an operator to disable
+   all preview features across a deployment without modifying individual app configs.
+3. **Hide preview fields from the schema** — preview features appear in the JSON schema
+   alongside stable features, making them indistinguishable in the configuration UI.
+
+Without gating, preview features either ship as stable (risky) or are manually guarded with
+ad-hoc checks scattered across modules (inconsistent, hard to maintain).
+
+## Design Goals
+
+- A reusable annotation (`PreviewField`) that can mark any config field as preview, anywhere in
+  the model hierarchy, with no separate registry.
+- A single environment variable (`ENABLE_PREVIEW_FEATURES`) that gates all preview features
+  deployment-wide.
+- When preview is disabled: preview fields are stripped from the JSON schema (the platform
+  rejects configs that reference them). A runtime validator nullifies any preview fields that
+  slip through (e.g., config persisted before preview was disabled) and logs a warning.
+- Zero overhead for stable features — the mechanism only activates for fields explicitly marked
+  with `PreviewField`.
+
+---
+
+## Use Cases
+
+### UC-1: Operator disables preview features for production
+
+- **Trigger:** Operator deploys QuickApps without setting `ENABLE_PREVIEW_FEATURES`.
+- **Behavior:** Preview fields do not appear in the JSON schema. The platform rejects configs
+  that reference them. If a preview field slips through anyway (e.g., config persisted before
+  preview was disabled), the runtime validator nullifies it and logs a warning.
+- **Outcome:** No preview features are active. The primary enforcement is schema-level — the
+  platform prevents misconfiguration before the app ever sees the request.
+
+### UC-2: Operator enables preview features for staging
+
+- **Trigger:** Operator sets `ENABLE_PREVIEW_FEATURES=true` in the staging environment.
+- **Behavior:** Preview fields appear in the JSON schema and configuration UI. App creators can
+  configure them normally. Runtime validation accepts them.
+- **Outcome:** Preview features are fully functional in this environment.
+
+### UC-3: Developer marks a new feature as preview
+
+- **Trigger:** Developer adds a new feature config field and uses `PreviewField(...)` instead
+  of `Field(...)`.
+- **Behavior:** The field is automatically gated by the preview mechanism — no additional
+  wiring needed.
+- **Outcome:** The feature is hidden in production, visible in staging (when preview is
+  enabled), with no changes to the gating infrastructure.
+
+### UC-4: Feature graduates from preview to stable
+
+- **Trigger:** A preview feature is deemed stable and ready for general availability.
+- **Behavior:** Developer changes `PreviewField(...)` to `Field(...)` on the config field.
+- **Outcome:** The feature is no longer gated. It appears in the schema and is accepted at
+  runtime regardless of the `ENABLE_PREVIEW_FEATURES` setting.
+
+---
+
+## Proposed Design
+
+### 1. `PreviewField` annotation
+
+- **What:** A `Field` wrapper function (in `common/base_config.py`, alongside the existing
+  `DialConfigField` / `DialFileConfigField` helpers) that tags field metadata with an
+  `x-preview` marker.
+- **Owner:** `common/base_config.py`.
+- **Semantics:** Sets `json_schema_extra[_PREVIEW_MARKER] = True` on the field. This marker
+  is read by both schema generation and runtime validation. Any config field anywhere in the
+  model hierarchy can use `PreviewField(...)` instead of `Field(...)` — no registry, no
+  base class changes.
+- **Change:** New function and constant in `base_config.py`.
+
+```python
+_PREVIEW_MARKER = "x-preview"
+
+
+def PreviewField(default=None, **kwargs) -> FieldInfo:
+    json_schema_extra = kwargs.get("json_schema_extra", {})
+    if isinstance(json_schema_extra, dict):
+        json_schema_extra[_PREVIEW_MARKER] = True
+    else:
+        original_extra = json_schema_extra
+
+        def new_extra(schema):
+            if callable(original_extra):
+                original_extra(schema)
+            schema[_PREVIEW_MARKER] = True
+
+        json_schema_extra = new_extra
+    kwargs["json_schema_extra"] = json_schema_extra
+    return Field(default, **kwargs)
+```
+
+This follows the same callable-wrapping pattern as `_dial_config_field` in `base_config.py`.
+
+**Constraint:** `PreviewField` must always be used with `default=None` and the type annotation
+must be `T | None`. The runtime validator nullifies preview fields by setting them to `None` —
+a non-nullable type would violate its own constraint after nullification. `PreviewField`
+enforces this by requiring `default=None` (raised as a `TypeError` if a non-`None` default is
+provided).
+
+### 2. `FeatureSettings`
+
+- **What:** A `BaseSettings` class that reads the `ENABLE_PREVIEW_FEATURES` env variable.
+- **Owner:** `common/feature_settings.py`.
+- **Semantics:** Follows the existing `AgentSettings` / `PresentationSettings` pattern.
+  Defaults to `False`. Instantiated directly (not via DI) where needed — both
+  `model_json_schema()` (a classmethod) and the runtime validator need it, and neither has
+  access to the injector.
+- **Change:** New settings class.
+
+```python
+class FeatureSettings(BaseSettings):
+    enable_preview_features: bool = Field(
+        default=False, alias="ENABLE_PREVIEW_FEATURES"
+    )
+```
+
+This is consistent with how `LoggingSettings` works — instantiated at call time, reading
+directly from the environment. The DI exception is acknowledged: `model_json_schema()` is a
+classmethod and cannot receive settings via injection.
+
+### 3. Schema stripping
+
+- **What:** A `strip_preview_fields(schema)` utility that recursively removes properties
+  marked with `x-preview` from a JSON schema dict.
+- **Owner:** `common/base_config.py`.
+- **Semantics:** Walks `properties` at each level of the schema (including `$defs`). For each
+  property with `x-preview: true`, removes it from `properties` and from `required` (if
+  present). After removal, prunes any `$defs` entries that are no longer referenced anywhere
+  in the **remaining** schema (using the existing `_collect_defs_references` helper, which
+  scans the full schema post-removal — shared definitions used by stable fields are preserved). Applied in
+  `BaseApplicationTypeConfig.model_json_schema()` when `ENABLE_PREVIEW_FEATURES` is not set.
+- **Change:** New utility function; modification to `model_json_schema()`.
+
+`model_json_schema()` **always** applies stripping based on `ENABLE_PREVIEW_FEATURES` — it
+does not distinguish callers. The behavior is controlled entirely by the env variable:
+
+- **`dump_app_schema` and CI** run with `ENABLE_PREVIEW_FEATURES=true` (set in the Makefile
+  for the `dump_app_schema` and `lint` targets). This produces and checks the **full** schema
+  with all preview fields included. The committed schema is always the full version.
+- **Configuration support API** in production runs **without** the env var, so preview fields
+  are stripped at runtime. Users cannot see or configure preview features.
+
+This keeps CI deterministic and eliminates the need for `model_json_schema()` to know its
+call context.
+
+### 4. Runtime validation
+
+- **What:** A `model_validator` on `ApplicationConfig` that nullifies preview fields when
+  `ENABLE_PREVIEW_FEATURES` is not set.
+- **Owner:** `config/application.py`.
+- **Semantics:** The validator recursively walks the config model tree. Algorithm:
+
+  ```
+  def gate_preview_fields(model):
+      for field_name, field_info in model.model_fields.items():
+          value = getattr(model, field_name)
+          if has_preview_marker(field_info) and value is not None:
+              setattr(model, field_name, None)
+              log warning
+          elif isinstance(value, BaseModel):
+              gate_preview_fields(value)  # recurse into nested models
+  ```
+
+  The recursion covers `BaseModel` instances at any nesting depth. Lists and dicts of models
+  are not recursed — preview fields are expected on config objects, not inside collections.
+
+  This is a **safety net**, not the primary enforcement. The primary enforcement is
+  schema-level: when preview is disabled, preview fields are stripped from the JSON schema,
+  and the platform rejects configs that reference unknown fields. The runtime validator only
+  activates in edge cases (e.g., config persisted before preview was disabled, or config
+  injected bypassing schema validation). No warning stage is emitted — a log warning suffices
+  for this defensive case.
+- **Change:** New validator on `ApplicationConfig`.
+
+---
+
+## Out of Scope
+
+### Per-feature preview opt-in
+
+An allowlist like `PREVIEW_FEATURES=timestamp,other_feature` would give operators granular
+control over which preview features to enable. Deferred because a single boolean is sufficient
+for the current scale of preview features. If the number of concurrent preview features grows,
+this can be added as an extension to `FeatureSettings`.
+
+### Preview feature documentation / changelog
+
+A mechanism to auto-generate documentation of which features are in preview, what they do, and
+when they were introduced. Deferred — the feature count is small enough that manual
+documentation suffices.
+
+---
+
+## Configuration / Usage Examples
+
+### Marking a field as preview
+
+```python
+class Features(BaseModel):
+    timestamp: TimestampConfig | None = PreviewField(
+        default=None, description="Timestamp awareness configuration."
+    )
+```
+
+### Graduating a feature to stable
+
+```python
+class Features(BaseModel):
+    timestamp: TimestampConfig | None = Field(
+        default=None, description="Timestamp awareness configuration."
+    )
+```
+
+### Environment configuration
+
+```bash
+# Staging — preview features enabled
+ENABLE_PREVIEW_FEATURES=true
+
+# Production — preview features disabled (default)
+# ENABLE_PREVIEW_FEATURES is not set or set to false
+```
+
+### Runtime log output (edge case)
+
+If an app config somehow contains `"features": {"timestamp": {}}` but preview is disabled
+(e.g., config persisted before preview was turned off), the runtime validator logs:
+
+```
+WARNING - Preview feature "timestamp" is configured but preview features are disabled
+(ENABLE_PREVIEW_FEATURES is not set). The feature has been deactivated.
+```
+
+Under normal operation this does not occur — the platform rejects such configs at the schema
+validation level.
+
+---
+
+## Migration
+
+### Breaking changes
+
+None.
+
+### Non-breaking changes
+
+- New `PreviewField` helper in `base_config.py` — no effect on existing fields.
+- New `FeatureSettings` class — only read when preview gating logic is invoked.
+- `model_json_schema()` modification — strips fields when `ENABLE_PREVIEW_FEATURES` is not
+  set. `dump_app_schema` and CI run with `ENABLE_PREVIEW_FEATURES=true`, so the committed
+  schema is always the full version.
+- New `model_validator` on `ApplicationConfig` — only activates when preview fields slip
+  through with gating off. Existing configs with no preview fields are unaffected.
+
+## Summary of Changes
+
+### `common/base_config.py`
+
+- **Add** `_PREVIEW_MARKER` constant
+- **Add** `PreviewField()` helper function
+- **Add** `strip_preview_fields()` utility
+
+### `common/`
+
+- **Add** `FeatureSettings(BaseSettings)` (`feature_settings.py`)
+
+### `common/base_config.py` (`BaseApplicationTypeConfig`)
+
+- **Modify** `model_json_schema()` — apply `strip_preview_fields()` when
+  `ENABLE_PREVIEW_FEATURES` is not set
+
+### `config/application.py`
+
+- **Add** `model_validator` on `ApplicationConfig` for runtime preview gating (nullify +
+  log warning)
+
+### `Makefile`
+
+- **Modify** `dump_app_schema` and `lint` targets — set `ENABLE_PREVIEW_FEATURES=true` so
+  the committed schema includes all preview fields

--- a/docs/designs/preview_feature_gating.md
+++ b/docs/designs/preview_feature_gating.md
@@ -16,6 +16,10 @@ mechanism to:
    all preview features across a deployment without modifying individual app configs.
 3. **Hide preview fields from the schema** — preview features appear in the JSON schema
    alongside stable features, making them indistinguishable in the configuration UI.
+4. **Gate an entire module as preview** — some features span an entire DI module (tools,
+   transformers, prompt providers, etc.). There is no way to conditionally wire a whole module
+   based on preview status — today the module is either always registered or manually
+   if-guarded in `AppFactory`.
 
 Without gating, preview features either ship as stable (risky) or are manually guarded with
 ad-hoc checks scattered across modules (inconsistent, hard to maintain).
@@ -31,6 +35,9 @@ ad-hoc checks scattered across modules (inconsistent, hard to maintain).
   slip through (e.g., config persisted before preview was disabled) and logs a warning.
 - Zero overhead for stable features — the mechanism only activates for fields explicitly marked
   with `PreviewField`.
+- A `@preview_module` decorator that marks an entire DI module as preview, allowing
+  `AppFactory` to conditionally wire it based on the preview flag — no ad-hoc `if` guards,
+  no inheritance changes.
 
 ---
 
@@ -41,16 +48,20 @@ ad-hoc checks scattered across modules (inconsistent, hard to maintain).
 - **Trigger:** Operator deploys QuickApps without setting `ENABLE_PREVIEW_FEATURES`.
 - **Behavior:** Preview fields do not appear in the JSON schema. The platform rejects configs
   that reference them. If a preview field slips through anyway (e.g., config persisted before
-  preview was disabled), the runtime validator nullifies it and logs a warning.
+  preview was disabled), the runtime validator nullifies it and logs a warning. Preview modules
+  are not wired — their tools, transformers, and providers are entirely absent at runtime.
 - **Outcome:** No preview features are active. The primary enforcement is schema-level — the
-  platform prevents misconfiguration before the app ever sees the request.
+  platform prevents misconfiguration before the app ever sees the request. Module-level
+  features are enforced at startup — the DI container never registers their bindings.
 
 ### UC-2: Operator enables preview features for staging
 
 - **Trigger:** Operator sets `ENABLE_PREVIEW_FEATURES=true` in the staging environment.
 - **Behavior:** Preview fields appear in the JSON schema and configuration UI. App creators can
-  configure them normally. Runtime validation accepts them.
-- **Outcome:** Preview features are fully functional in this environment.
+  configure them normally. Runtime validation accepts them. Preview modules are wired into the
+  DI container and function normally.
+- **Outcome:** All preview features — both field-level and module-level — are fully functional
+  in this environment.
 
 ### UC-3: Developer marks a new feature as preview
 
@@ -67,6 +78,23 @@ ad-hoc checks scattered across modules (inconsistent, hard to maintain).
 - **Behavior:** Developer changes `PreviewField(...)` to `Field(...)` on the config field.
 - **Outcome:** The feature is no longer gated. It appears in the schema and is accepted at
   runtime regardless of the `ENABLE_PREVIEW_FEATURES` setting.
+
+### UC-5: Developer marks an entire module as preview
+
+- **Trigger:** Developer builds a new feature that spans a full DI module (e.g. a new tooling
+  integration with its own tools, transformers, and providers).
+- **Behavior:** The developer decorates the module class with `@preview_module`. `AppFactory`
+  filters it out when `ENABLE_PREVIEW_FEATURES` is not set — none of its bindings (tools,
+  transformers, prompt providers) are registered.
+- **Outcome:** The entire feature is absent at runtime in production. In staging (with preview
+  enabled), the module is wired normally and fully functional. No per-binding `if` guards
+  needed.
+
+### UC-6: Preview module graduates to stable
+
+- **Trigger:** A preview module is deemed stable and ready for general availability.
+- **Behavior:** Developer removes the `@preview_module` decorator from the module class.
+- **Outcome:** The module is always wired regardless of `ENABLE_PREVIEW_FEATURES`.
 
 ---
 
@@ -188,6 +216,46 @@ call context.
   for this defensive case.
 - **Change:** New validator on `ApplicationConfig`.
 
+### 5. Module-level preview gating
+
+- **What:** A `@preview_module` decorator that marks a DI module class as preview, and
+  filtering logic in `AppFactory` that excludes decorated modules when preview is disabled.
+- **Owner:** `common/preview.py` (decorator), `app_factory.py` (filtering).
+- **Semantics:** The decorator sets a `_is_preview_module = True` attribute on the class.
+  `AppFactory.create()` reads `FeatureSettings` once at startup and filters the module list
+  before passing it to the `Injector`:
+
+  ```python
+  _PREVIEW_MODULE_ATTR = "_is_preview_module"
+
+
+  def preview_module(cls):
+      """Mark a DI module as preview — filtered out when preview features are disabled."""
+      setattr(cls, _PREVIEW_MODULE_ATTR, True)
+      return cls
+
+
+  def is_preview_module(module) -> bool:
+      return getattr(type(module), _PREVIEW_MODULE_ATTR, False)
+  ```
+
+  In `AppFactory`:
+
+  ```
+  modules = [AppModule(), AgentModule(), ..., SomePreviewModule()]
+  if not FeatureSettings().enable_preview_features:
+      modules = [m for m in modules if not is_preview_module(m)]
+  injector = Injector(modules)
+  ```
+
+  This is a pure startup-time check. When a preview module is filtered out, none of its
+  bindings are registered — tools, transformers, providers, and initializers from that module
+  are entirely absent. The decorator does not alter the module's inheritance chain or
+  behavior; it only adds a marker attribute that `AppFactory` reads.
+
+- **Change:** New decorator and helper in `common/preview.py`; modification to
+  `AppFactory.create()`.
+
 ---
 
 ## Out of Scope
@@ -225,6 +293,26 @@ class Features(BaseModel):
     timestamp: TimestampConfig | None = Field(
         default=None, description="Timestamp awareness configuration."
     )
+```
+
+### Marking a module as preview
+
+```python
+@preview_module
+class TimestampModule(Module):
+    def configure(self, binder: Binder):
+        binder.bind(TimestampProvider, to=TimestampProvider, scope=singleton)
+        ...
+```
+
+### Graduating a module to stable
+
+```python
+# Remove the decorator — module is always wired
+class TimestampModule(Module):
+    def configure(self, binder: Binder):
+        binder.bind(TimestampProvider, to=TimestampProvider, scope=singleton)
+        ...
 ```
 
 ### Environment configuration
@@ -267,6 +355,10 @@ None.
   schema is always the full version.
 - New `model_validator` on `ApplicationConfig` — only activates when preview fields slip
   through with gating off. Existing configs with no preview fields are unaffected.
+- New `@preview_module` decorator — no effect on existing modules. Only modules explicitly
+  decorated are filtered.
+- `AppFactory` filtering — existing modules are unaffected; the filter is a no-op when no
+  preview modules are registered.
 
 ## Summary of Changes
 
@@ -279,6 +371,7 @@ None.
 ### `common/`
 
 - **Add** `FeatureSettings(BaseSettings)` (`feature_settings.py`)
+- **Add** `preview_module` decorator and `is_preview_module` helper (`preview.py`)
 
 ### `common/base_config.py` (`BaseApplicationTypeConfig`)
 
@@ -289,6 +382,11 @@ None.
 
 - **Add** `model_validator` on `ApplicationConfig` for runtime preview gating (nullify +
   log warning)
+
+### `app_factory.py`
+
+- **Modify** `AppFactory.create()` — filter out `@preview_module`-decorated modules when
+  `ENABLE_PREVIEW_FEATURES` is not set
 
 ### `Makefile`
 

--- a/src/quickapp/app_factory.py
+++ b/src/quickapp/app_factory.py
@@ -4,6 +4,8 @@ from injector import Injector
 from quickapp.agent.agent_module import AgentModule
 from quickapp.application import AppModule
 from quickapp.attachment_processing.attachment_processing_module import AttachmentProcessingModule
+from quickapp.common.feature_settings import FeatureSettings
+from quickapp.common.preview import is_preview_module
 from quickapp.config.logging_config import LoggingConfig
 from quickapp.config.logging_settings import LoggingSettings
 from quickapp.configuration_support import ConfigurationSupportApiModule
@@ -31,21 +33,22 @@ class AppFactory:
             FastAPI: The configured FastAPI application instance.
         """
         LoggingConfig(settings=LoggingSettings())
-        injector = Injector(
-            [
-                AppModule(),
-                AgentModule(),
-                RestApiToolingModule(),
-                DialDeploymentToolingModule(),
-                MCPToolingModule(),
-                InternalToolModule(),
-                StartersModule(),
-                ConfigurationSupportApiModule(),
-                DialCoreServicesModule(),
-                FileTransferModule(),
-                AttachmentProcessingModule(),
-                SkillsModule(),
-            ]
-        )
+        modules = [
+            AppModule(),
+            AgentModule(),
+            RestApiToolingModule(),
+            DialDeploymentToolingModule(),
+            MCPToolingModule(),
+            InternalToolModule(),
+            StartersModule(),
+            ConfigurationSupportApiModule(),
+            DialCoreServicesModule(),
+            FileTransferModule(),
+            AttachmentProcessingModule(),
+            SkillsModule(),
+        ]
+        if not FeatureSettings().enable_preview_features:
+            modules = [m for m in modules if not is_preview_module(m)]
+        injector = Injector(modules)
         app = injector.get(FastAPI)
         return app

--- a/src/quickapp/common/base_config.py
+++ b/src/quickapp/common/base_config.py
@@ -6,9 +6,12 @@ from pydantic import BaseModel, Field
 from pydantic.fields import FieldInfo
 
 from quickapp.common.dial_schema import DialJSONSchemaExtensions
+from quickapp.common.feature_settings import FeatureSettings
 
 _DIAL_SCHEMA_URL = "https://dial.epam.com/application_type_schemas/schema#"
 _DIAL_ID_PREFIX = "https://mydial.epam.com/custom_application_schemas/"
+
+_PREVIEW_MARKER = "x-preview"
 
 
 def _collect_defs_references(schema: Any) -> set[str]:
@@ -156,6 +159,93 @@ def _dial_file_config_field(default: Any = ..., **kwargs) -> FieldInfo:
     return Field(default, **kwargs)
 
 
+def _preview_field(default=None, **kwargs) -> FieldInfo:
+    """
+    Create a Pydantic Field marked as a preview feature.
+
+    Preview fields are stripped from the JSON schema and nullified at runtime
+    when ENABLE_PREVIEW_FEATURES is not set.
+
+    Args:
+        default: Must be None (preview fields must be nullable).
+        **kwargs: Other Pydantic Field parameters.
+
+    Returns:
+        Pydantic Field with preview marker.
+    """
+    if default is not None:
+        raise TypeError(
+            "PreviewField requires default=None (preview fields must be nullable "
+            "so they can be deactivated at runtime)."
+        )
+    json_schema_extra = kwargs.get("json_schema_extra", {})
+    if isinstance(json_schema_extra, dict):
+        json_schema_extra[_PREVIEW_MARKER] = True
+    else:
+        original_extra = json_schema_extra
+
+        def new_extra(schema):
+            if callable(original_extra):
+                original_extra(schema)
+            schema[_PREVIEW_MARKER] = True
+
+        json_schema_extra = new_extra
+    kwargs["json_schema_extra"] = json_schema_extra
+    return Field(default, **kwargs)
+
+
+def _has_preview_marker(field_info: FieldInfo) -> bool:
+    """Check whether a field is marked as a preview feature."""
+    extra = field_info.json_schema_extra
+    if extra is None:
+        return False
+    if isinstance(extra, dict):
+        return bool(extra.get(_PREVIEW_MARKER, False))
+    # Callable case: invoke on a temp dict to inspect the marker.
+    tmp: dict[str, Any] = {}
+    extra(tmp)
+    return bool(tmp.get(_PREVIEW_MARKER, False))
+
+
+def _strip_preview_properties(obj: dict) -> None:
+    """Remove preview-marked properties and clean up required list in-place."""
+    properties = obj.get("properties")
+    if not properties:
+        return
+    to_remove = [name for name, prop in properties.items() if prop.get(_PREVIEW_MARKER)]
+    for name in to_remove:
+        del properties[name]
+    required = obj.get("required")
+    if required:
+        obj["required"] = [r for r in required if r not in to_remove]
+        if not obj["required"]:
+            del obj["required"]
+
+
+def _strip_preview_fields(schema: dict) -> dict:
+    """Remove preview-marked properties from a JSON schema dict."""
+    schema = deepcopy(schema)
+
+    # Strip at root level
+    _strip_preview_properties(schema)
+
+    # Strip within $defs
+    for definition in schema.get("$defs", {}).values():
+        _strip_preview_properties(definition)
+
+    # Prune unreferenced $defs
+    defs = schema.get("$defs", {})
+    if defs:
+        still_used = _collect_defs_references(schema)
+        for key in list(defs):
+            if key not in still_used:
+                defs.pop(key)
+        if not defs:
+            schema.pop("$defs", None)
+
+    return schema
+
+
 class BaseApplicationTypeConfig(BaseModel):
     """
     Base class for configuration of schema-rich applications in DIAL.
@@ -231,6 +321,9 @@ class BaseApplicationTypeConfig(BaseModel):
         schema = super().model_json_schema(*args, **kwargs)
         schema = _flatten_root_properties(schema)
 
+        if not FeatureSettings().enable_preview_features:
+            schema = _strip_preview_fields(schema)
+
         properties = schema.get("properties", {})
         model_fields = cls.model_fields
 
@@ -273,3 +366,4 @@ class BaseApplicationTypeConfig(BaseModel):
 DialConfigField = _dial_config_field
 DialFileConfigField = _dial_file_config_field
 DialResourceConfigField = _dial_resource_config_field
+PreviewField = _preview_field

--- a/src/quickapp/common/base_config.py
+++ b/src/quickapp/common/base_config.py
@@ -194,7 +194,7 @@ def _preview_field(default=None, **kwargs) -> FieldInfo:
     return Field(default, **kwargs)
 
 
-def _has_preview_marker(field_info: FieldInfo) -> bool:
+def has_preview_marker(field_info: FieldInfo) -> bool:
     """Check whether a field is marked as a preview feature."""
     extra = field_info.json_schema_extra
     if extra is None:

--- a/src/quickapp/common/feature_settings.py
+++ b/src/quickapp/common/feature_settings.py
@@ -1,0 +1,16 @@
+"""Feature gating settings. Lives in common to avoid circular imports."""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class FeatureSettings(BaseSettings):
+    """Controls preview feature availability deployment-wide."""
+
+    model_config = SettingsConfigDict()
+
+    enable_preview_features: bool = Field(
+        default=False,
+        description="Enable preview features across the deployment",
+        alias="ENABLE_PREVIEW_FEATURES",
+    )

--- a/src/quickapp/common/preview.py
+++ b/src/quickapp/common/preview.py
@@ -3,7 +3,7 @@
 _PREVIEW_MODULE_ATTR = "_is_preview_module"
 
 
-def preview_module(cls):
+def preview_module[T](cls: T) -> T:
     """Mark a DI module as preview — filtered out when preview features are disabled."""
     setattr(cls, _PREVIEW_MODULE_ATTR, True)
     return cls

--- a/src/quickapp/common/preview.py
+++ b/src/quickapp/common/preview.py
@@ -1,0 +1,14 @@
+"""Preview module decorator for conditional DI module wiring."""
+
+_PREVIEW_MODULE_ATTR = "_is_preview_module"
+
+
+def preview_module(cls):
+    """Mark a DI module as preview — filtered out when preview features are disabled."""
+    setattr(cls, _PREVIEW_MODULE_ATTR, True)
+    return cls
+
+
+def is_preview_module(module) -> bool:
+    """Check whether a module instance belongs to a preview-decorated class."""
+    return getattr(type(module), _PREVIEW_MODULE_ATTR, False)

--- a/src/quickapp/config/application.py
+++ b/src/quickapp/config/application.py
@@ -1,9 +1,10 @@
 import logging
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 from quickapp.agent.agent_settings import AgentSettings
-from quickapp.common.base_config import BaseApplicationTypeConfig
+from quickapp.common.base_config import BaseApplicationTypeConfig, _has_preview_marker
+from quickapp.common.feature_settings import FeatureSettings
 from quickapp.config.context import Context
 from quickapp.config.dial_deployment import DialDeploymentConfig
 from quickapp.config.prompt import AgentSystemPromptConfig
@@ -34,6 +35,21 @@ class OrchestratorConfig(BaseModel):
     )
 
 
+def _nullify_preview_fields(model: BaseModel) -> None:
+    """Recursively nullify preview fields on a config model tree."""
+    for field_name, field_info in type(model).model_fields.items():
+        value = getattr(model, field_name)
+        if _has_preview_marker(field_info) and value is not None:
+            setattr(model, field_name, None)
+            logger.warning(
+                'Preview feature "%s" is configured but preview features are disabled '
+                "(ENABLE_PREVIEW_FEATURES is not set). The feature has been deactivated.",
+                field_name,
+            )
+        elif isinstance(value, BaseModel):
+            _nullify_preview_fields(value)
+
+
 class ApplicationConfig(BaseApplicationTypeConfig):
     _dial_schema_id = "quickapps2"
     _dial_application_type_display_name = "Quick App 2.0"
@@ -50,3 +66,10 @@ class ApplicationConfig(BaseApplicationTypeConfig):
     conversation_starters: ConversationStartersConfig | None = Field(
         description="The configuration for conversation starters.", default=None
     )
+
+    @model_validator(mode="after")
+    def _gate_preview_fields(self) -> "ApplicationConfig":
+        if FeatureSettings().enable_preview_features:
+            return self
+        _nullify_preview_fields(self)
+        return self

--- a/src/quickapp/config/application.py
+++ b/src/quickapp/config/application.py
@@ -3,7 +3,7 @@ import logging
 from pydantic import BaseModel, Field, model_validator
 
 from quickapp.agent.agent_settings import AgentSettings
-from quickapp.common.base_config import BaseApplicationTypeConfig, _has_preview_marker
+from quickapp.common.base_config import BaseApplicationTypeConfig, has_preview_marker
 from quickapp.common.feature_settings import FeatureSettings
 from quickapp.config.context import Context
 from quickapp.config.dial_deployment import DialDeploymentConfig
@@ -35,11 +35,15 @@ class OrchestratorConfig(BaseModel):
     )
 
 
-def _nullify_preview_fields(model: BaseModel) -> None:
-    """Recursively nullify preview fields on a config model tree."""
+def nullify_preview_fields(model: BaseModel) -> None:
+    """Recursively nullify preview fields on a config model tree.
+
+    Recurses into nested BaseModel instances but not into lists or dicts —
+    preview fields are expected on config objects, not inside collections.
+    """
     for field_name, field_info in type(model).model_fields.items():
         value = getattr(model, field_name)
-        if _has_preview_marker(field_info) and value is not None:
+        if has_preview_marker(field_info) and value is not None:
             setattr(model, field_name, None)
             logger.warning(
                 'Preview feature "%s" is configured but preview features are disabled '
@@ -47,7 +51,7 @@ def _nullify_preview_fields(model: BaseModel) -> None:
                 field_name,
             )
         elif isinstance(value, BaseModel):
-            _nullify_preview_fields(value)
+            nullify_preview_fields(value)
 
 
 class ApplicationConfig(BaseApplicationTypeConfig):
@@ -71,5 +75,5 @@ class ApplicationConfig(BaseApplicationTypeConfig):
     def _gate_preview_fields(self) -> "ApplicationConfig":
         if FeatureSettings().enable_preview_features:
             return self
-        _nullify_preview_fields(self)
+        nullify_preview_fields(self)
         return self

--- a/src/tests/unit_tests/common/test_preview_field.py
+++ b/src/tests/unit_tests/common/test_preview_field.py
@@ -1,0 +1,231 @@
+import pytest
+from pydantic import BaseModel, Field
+
+from quickapp.common.base_config import (
+    _PREVIEW_MARKER,
+    BaseApplicationTypeConfig,
+    PreviewField,
+    _has_preview_marker,
+    _strip_preview_fields,
+)
+
+# ── PreviewField ──────────────────────────────────────────────────────
+
+
+class TestPreviewField:
+    def test_marker_set_in_dict_extra(self):
+        class M(BaseModel):
+            feat: str | None = PreviewField(description="test")
+
+        field_info = M.model_fields["feat"]
+        assert isinstance(field_info.json_schema_extra, dict)
+        assert field_info.json_schema_extra[_PREVIEW_MARKER] is True
+
+    def test_default_must_be_none(self):
+        with pytest.raises(TypeError, match="PreviewField requires default=None"):
+            PreviewField(default="something")
+
+    def test_default_none_accepted(self):
+        field = PreviewField(default=None)
+        assert field.default is None
+
+    def test_default_omitted_accepted(self):
+        field = PreviewField()
+        assert field.default is None
+
+    def test_wraps_callable_json_schema_extra(self):
+        def custom_extra(schema):
+            schema["custom"] = True
+
+        class M(BaseModel):
+            feat: str | None = PreviewField(json_schema_extra=custom_extra)
+
+        schema = M.model_json_schema()
+        feat_schema = schema["properties"]["feat"]
+        assert feat_schema.get(_PREVIEW_MARKER) is True
+        assert feat_schema.get("custom") is True
+
+    def test_with_description(self):
+        class M(BaseModel):
+            feat: str | None = PreviewField(description="A preview feature")
+
+        schema = M.model_json_schema()
+        assert schema["properties"]["feat"]["description"] == "A preview feature"
+
+    def test_marker_appears_in_json_schema(self):
+        class M(BaseModel):
+            feat: str | None = PreviewField()
+            stable: str = Field(default="ok")
+
+        schema = M.model_json_schema()
+        assert schema["properties"]["feat"].get(_PREVIEW_MARKER) is True
+        assert _PREVIEW_MARKER not in schema["properties"]["stable"]
+
+
+# ── _has_preview_marker ───────────────────────────────────────────────
+
+
+class TestHasPreviewMarker:
+    def test_dict_with_marker(self):
+        class M(BaseModel):
+            feat: str | None = PreviewField()
+
+        assert _has_preview_marker(M.model_fields["feat"]) is True
+
+    def test_callable_with_marker(self):
+        def custom_extra(schema):
+            schema["custom"] = True
+
+        class M(BaseModel):
+            feat: str | None = PreviewField(json_schema_extra=custom_extra)
+
+        assert _has_preview_marker(M.model_fields["feat"]) is True
+
+    def test_regular_field(self):
+        class M(BaseModel):
+            stable: str = Field(default="ok")
+
+        assert _has_preview_marker(M.model_fields["stable"]) is False
+
+    def test_none_extra(self):
+        class M(BaseModel):
+            bare: str
+
+        assert _has_preview_marker(M.model_fields["bare"]) is False
+
+
+# ── _strip_preview_fields ─────────────────────────────────────────────
+
+
+class TestStripPreviewFields:
+    def test_basic_strip(self):
+        schema = {
+            "properties": {
+                "stable": {"type": "string"},
+                "preview": {"type": "string", _PREVIEW_MARKER: True},
+            },
+            "required": ["stable", "preview"],
+        }
+        result = _strip_preview_fields(schema)
+        assert "stable" in result["properties"]
+        assert "preview" not in result["properties"]
+
+    def test_removes_from_required(self):
+        schema = {
+            "properties": {
+                "stable": {"type": "string"},
+                "preview": {"type": "string", _PREVIEW_MARKER: True},
+            },
+            "required": ["stable", "preview"],
+        }
+        result = _strip_preview_fields(schema)
+        assert result["required"] == ["stable"]
+
+    def test_empty_required_removed(self):
+        schema = {
+            "properties": {
+                "preview": {"type": "string", _PREVIEW_MARKER: True},
+            },
+            "required": ["preview"],
+        }
+        result = _strip_preview_fields(schema)
+        assert "required" not in result
+
+    def test_strips_within_defs(self):
+        schema = {
+            "properties": {
+                "nested": {"$ref": "#/$defs/Nested"},
+            },
+            "$defs": {
+                "Nested": {
+                    "properties": {
+                        "stable": {"type": "string"},
+                        "preview": {"type": "string", _PREVIEW_MARKER: True},
+                    },
+                    "required": ["stable", "preview"],
+                }
+            },
+        }
+        result = _strip_preview_fields(schema)
+        nested_def = result["$defs"]["Nested"]
+        assert "stable" in nested_def["properties"]
+        assert "preview" not in nested_def["properties"]
+        assert nested_def["required"] == ["stable"]
+
+    def test_prunes_unreferenced_defs(self):
+        schema = {
+            "properties": {
+                "preview": {"$ref": "#/$defs/PreviewModel", _PREVIEW_MARKER: True},
+            },
+            "$defs": {
+                "PreviewModel": {"type": "object", "properties": {"x": {"type": "string"}}},
+            },
+        }
+        result = _strip_preview_fields(schema)
+        assert "$defs" not in result
+
+    def test_preserves_shared_defs(self):
+        schema = {
+            "properties": {
+                "stable": {"$ref": "#/$defs/SharedModel"},
+                "preview": {"$ref": "#/$defs/SharedModel", _PREVIEW_MARKER: True},
+            },
+            "$defs": {
+                "SharedModel": {"type": "object"},
+            },
+        }
+        result = _strip_preview_fields(schema)
+        assert "SharedModel" in result["$defs"]
+        assert "stable" in result["properties"]
+        assert "preview" not in result["properties"]
+
+    def test_noop_when_no_preview_fields(self):
+        schema = {
+            "properties": {
+                "a": {"type": "string"},
+                "b": {"type": "integer"},
+            },
+            "required": ["a", "b"],
+        }
+        result = _strip_preview_fields(schema)
+        assert result == schema
+
+    def test_does_not_mutate_original(self):
+        schema = {
+            "properties": {
+                "preview": {"type": "string", _PREVIEW_MARKER: True},
+            },
+        }
+        _strip_preview_fields(schema)
+        assert "preview" in schema["properties"]
+
+
+# ── model_json_schema integration ─────────────────────────────────────
+
+
+class TestModelJsonSchemaPreviewIntegration:
+    def test_preview_field_stripped_when_disabled(self, monkeypatch):
+        monkeypatch.delenv("ENABLE_PREVIEW_FEATURES", raising=False)
+
+        class Cfg(BaseApplicationTypeConfig):
+            _dial_schema_id = "test"
+            _dial_application_type_display_name = "Test"
+            stable: str
+            preview_feat: str | None = PreviewField(description="preview")
+
+        schema = Cfg.model_json_schema()
+        assert "stable" in schema["properties"]
+        assert "preview_feat" not in schema["properties"]
+
+    def test_preview_field_present_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
+
+        class Cfg(BaseApplicationTypeConfig):
+            _dial_schema_id = "test"
+            _dial_application_type_display_name = "Test"
+            stable: str
+            preview_feat: str | None = PreviewField(description="preview")
+
+        schema = Cfg.model_json_schema()
+        assert "stable" in schema["properties"]
+        assert "preview_feat" in schema["properties"]

--- a/src/tests/unit_tests/common/test_preview_field.py
+++ b/src/tests/unit_tests/common/test_preview_field.py
@@ -5,8 +5,8 @@ from quickapp.common.base_config import (
     _PREVIEW_MARKER,
     BaseApplicationTypeConfig,
     PreviewField,
-    _has_preview_marker,
     _strip_preview_fields,
+    has_preview_marker,
 )
 
 # ── PreviewField ──────────────────────────────────────────────────────
@@ -62,7 +62,7 @@ class TestPreviewField:
         assert _PREVIEW_MARKER not in schema["properties"]["stable"]
 
 
-# ── _has_preview_marker ───────────────────────────────────────────────
+# ── has_preview_marker ───────────────────────────────────────────────
 
 
 class TestHasPreviewMarker:
@@ -70,7 +70,7 @@ class TestHasPreviewMarker:
         class M(BaseModel):
             feat: str | None = PreviewField()
 
-        assert _has_preview_marker(M.model_fields["feat"]) is True
+        assert has_preview_marker(M.model_fields["feat"]) is True
 
     def test_callable_with_marker(self):
         def custom_extra(schema):
@@ -79,19 +79,19 @@ class TestHasPreviewMarker:
         class M(BaseModel):
             feat: str | None = PreviewField(json_schema_extra=custom_extra)
 
-        assert _has_preview_marker(M.model_fields["feat"]) is True
+        assert has_preview_marker(M.model_fields["feat"]) is True
 
     def test_regular_field(self):
         class M(BaseModel):
             stable: str = Field(default="ok")
 
-        assert _has_preview_marker(M.model_fields["stable"]) is False
+        assert has_preview_marker(M.model_fields["stable"]) is False
 
     def test_none_extra(self):
         class M(BaseModel):
             bare: str
 
-        assert _has_preview_marker(M.model_fields["bare"]) is False
+        assert has_preview_marker(M.model_fields["bare"]) is False
 
 
 # ── _strip_preview_fields ─────────────────────────────────────────────

--- a/src/tests/unit_tests/common/test_preview_module.py
+++ b/src/tests/unit_tests/common/test_preview_module.py
@@ -1,0 +1,48 @@
+from injector import Module
+
+from quickapp.common.preview import is_preview_module, preview_module
+
+
+class TestPreviewModuleDecorator:
+    def test_decorator_sets_attribute(self):
+        @preview_module
+        class MyModule(Module):
+            pass
+
+        assert getattr(MyModule, "_is_preview_module", False) is True
+
+    def test_is_preview_module_true(self):
+        @preview_module
+        class MyModule(Module):
+            pass
+
+        assert is_preview_module(MyModule()) is True
+
+    def test_is_preview_module_false(self):
+        class RegularModule(Module):
+            pass
+
+        assert is_preview_module(RegularModule()) is False
+
+    def test_decorator_preserves_class(self):
+        @preview_module
+        class MyModule(Module):
+            pass
+
+        assert MyModule.__name__ == "MyModule"
+        assert issubclass(MyModule, Module)
+
+    def test_filtering_logic(self):
+        """Verify the filtering pattern used in AppFactory."""
+
+        @preview_module
+        class PreviewMod(Module):
+            pass
+
+        class StableMod(Module):
+            pass
+
+        modules = [StableMod(), PreviewMod(), StableMod()]
+        filtered = [m for m in modules if not is_preview_module(m)]
+        assert len(filtered) == 2
+        assert all(isinstance(m, StableMod) for m in filtered)

--- a/src/tests/unit_tests/config_tests/test_preview_runtime_validator.py
+++ b/src/tests/unit_tests/config_tests/test_preview_runtime_validator.py
@@ -1,0 +1,90 @@
+import logging
+
+from pydantic import BaseModel
+
+from quickapp.common.base_config import PreviewField
+from quickapp.config.application import _nullify_preview_fields
+
+
+class TestNullifyPreviewFields:
+    def test_preview_field_nullified_when_set(self):
+        class Cfg(BaseModel):
+            feat: str | None = PreviewField(description="test")
+
+        model = Cfg.model_construct(feat="value")
+        _nullify_preview_fields(model)
+        assert model.feat is None
+
+    def test_preview_field_already_none_no_warning(self, caplog):
+        class Cfg(BaseModel):
+            feat: str | None = PreviewField(description="test")
+
+        model = Cfg.model_construct(feat=None)
+        with caplog.at_level(logging.WARNING):
+            _nullify_preview_fields(model)
+        assert not caplog.records
+
+    def test_non_preview_fields_untouched(self):
+        class Cfg(BaseModel):
+            stable: str = "hello"
+            feat: str | None = PreviewField(description="test")
+
+        model = Cfg.model_construct(stable="hello", feat="value")
+        _nullify_preview_fields(model)
+        assert model.stable == "hello"
+        assert model.feat is None
+
+    def test_nested_model_preview_field_nullified(self):
+        class Inner(BaseModel):
+            preview_inner: str | None = PreviewField(description="nested")
+
+        class Outer(BaseModel):
+            inner: Inner
+            stable: str = "ok"
+
+        inner = Inner.model_construct(preview_inner="value")
+        model = Outer.model_construct(inner=inner, stable="ok")
+        _nullify_preview_fields(model)
+        assert model.inner.preview_inner is None
+        assert model.stable == "ok"
+
+    def test_warning_logged(self, caplog):
+        class Cfg(BaseModel):
+            feat: str | None = PreviewField(description="test")
+
+        model = Cfg.model_construct(feat="value")
+        with caplog.at_level(logging.WARNING):
+            _nullify_preview_fields(model)
+        assert len(caplog.records) == 1
+        assert "feat" in caplog.records[0].message
+        assert "preview features are disabled" in caplog.records[0].message
+
+
+class TestApplicationConfigPreviewValidator:
+    """Integration tests with the real ApplicationConfig model_validator."""
+
+    def test_preview_field_nullified_on_construction(self, monkeypatch):
+        """Verify model_validator fires on ApplicationConfig subclasses."""
+        monkeypatch.delenv("ENABLE_PREVIEW_FEATURES", raising=False)
+
+        from quickapp.common.base_config import BaseApplicationTypeConfig
+
+        class TestAppConfig(BaseApplicationTypeConfig):
+            _dial_schema_id = "test_preview"
+            _dial_application_type_display_name = "Test"
+            stable: str
+            preview_feat: str | None = PreviewField(description="preview")
+
+        # NOTE: model_validator must be on ApplicationConfig, not arbitrary
+        # BaseApplicationTypeConfig subclasses. Test the helper directly.
+        model = TestAppConfig.model_construct(stable="ok", preview_feat="val")
+        _nullify_preview_fields(model)
+        assert model.preview_feat is None
+        assert model.stable == "ok"
+
+    def test_preview_field_preserved_when_enabled(self, monkeypatch):
+        monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
+
+        from quickapp.common.feature_settings import FeatureSettings
+
+        assert FeatureSettings().enable_preview_features is True

--- a/src/tests/unit_tests/config_tests/test_preview_runtime_validator.py
+++ b/src/tests/unit_tests/config_tests/test_preview_runtime_validator.py
@@ -3,7 +3,7 @@ import logging
 from pydantic import BaseModel
 
 from quickapp.common.base_config import PreviewField
-from quickapp.config.application import _nullify_preview_fields
+from quickapp.config.application import nullify_preview_fields
 
 
 class TestNullifyPreviewFields:
@@ -12,7 +12,7 @@ class TestNullifyPreviewFields:
             feat: str | None = PreviewField(description="test")
 
         model = Cfg.model_construct(feat="value")
-        _nullify_preview_fields(model)
+        nullify_preview_fields(model)
         assert model.feat is None
 
     def test_preview_field_already_none_no_warning(self, caplog):
@@ -21,7 +21,7 @@ class TestNullifyPreviewFields:
 
         model = Cfg.model_construct(feat=None)
         with caplog.at_level(logging.WARNING):
-            _nullify_preview_fields(model)
+            nullify_preview_fields(model)
         assert not caplog.records
 
     def test_non_preview_fields_untouched(self):
@@ -30,7 +30,7 @@ class TestNullifyPreviewFields:
             feat: str | None = PreviewField(description="test")
 
         model = Cfg.model_construct(stable="hello", feat="value")
-        _nullify_preview_fields(model)
+        nullify_preview_fields(model)
         assert model.stable == "hello"
         assert model.feat is None
 
@@ -44,7 +44,7 @@ class TestNullifyPreviewFields:
 
         inner = Inner.model_construct(preview_inner="value")
         model = Outer.model_construct(inner=inner, stable="ok")
-        _nullify_preview_fields(model)
+        nullify_preview_fields(model)
         assert model.inner.preview_inner is None
         assert model.stable == "ok"
 
@@ -54,7 +54,7 @@ class TestNullifyPreviewFields:
 
         model = Cfg.model_construct(feat="value")
         with caplog.at_level(logging.WARNING):
-            _nullify_preview_fields(model)
+            nullify_preview_fields(model)
         assert len(caplog.records) == 1
         assert "feat" in caplog.records[0].message
         assert "preview features are disabled" in caplog.records[0].message
@@ -78,13 +78,31 @@ class TestApplicationConfigPreviewValidator:
         # NOTE: model_validator must be on ApplicationConfig, not arbitrary
         # BaseApplicationTypeConfig subclasses. Test the helper directly.
         model = TestAppConfig.model_construct(stable="ok", preview_feat="val")
-        _nullify_preview_fields(model)
+        nullify_preview_fields(model)
         assert model.preview_feat is None
         assert model.stable == "ok"
 
     def test_preview_field_preserved_when_enabled(self, monkeypatch):
+        """When ENABLE_PREVIEW_FEATURES=true, the validator early-returns
+        and preview fields are not nullified."""
         monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
 
+        from quickapp.common.base_config import BaseApplicationTypeConfig
         from quickapp.common.feature_settings import FeatureSettings
 
         assert FeatureSettings().enable_preview_features is True
+
+        class TestAppConfig(BaseApplicationTypeConfig):
+            _dial_schema_id = "test_preview_enabled"
+            _dial_application_type_display_name = "Test"
+            stable: str
+            preview_feat: str | None = PreviewField(description="preview")
+
+        # Simulate the gating logic from ApplicationConfig._gate_preview_fields:
+        # when preview is enabled, nullify_preview_fields is never called.
+        model = TestAppConfig.model_construct(stable="ok", preview_feat="val")
+        if not FeatureSettings().enable_preview_features:
+            nullify_preview_fields(model)
+
+        assert model.preview_feat == "val"
+        assert model.stable == "ok"


### PR DESCRIPTION
### Applicable issues

- fixes #188

### Description of changes

Adds a preview feature gating mechanism controlled by a single env var `ENABLE_PREVIEW_FEATURES` (default: `false`). Two gating levels:

- **Field-level** — `PreviewField(...)` marks a config field as preview. When disabled: stripped from JSON schema (platform rejects unknown fields), nullified at runtime as a safety net.
- **Module-level** — `@preview_module` decorator on a DI module. When disabled: `AppFactory` filters it out entirely — no bindings registered.

Key components:
- `FeatureSettings` reads the env var (`common/feature_settings.py`)
- `_strip_preview_fields()` removes `x-preview` properties from the schema (`common/base_config.py`)
- `model_validator` on `ApplicationConfig` nullifies any preview fields that slip through (`config/application.py`)
- `preview_module` / `is_preview_module` for module-level gating (`common/preview.py`)
- Makefile sets `ENABLE_PREVIEW_FEATURES=true` on schema dump/lint/format so the committed schema always includes all preview fields

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Design documented is updated/created and approved by the team (if applicable)
- [X] Documentation is updated/created (if applicable)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
