### PR TITLE
feat: support interactive login to DIAL toolset #191

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -65,6 +65,13 @@ Completion initializers are invoked to prepare the request for orchestration. Th
   After this step, messages are fully expanded and ready for the orchestrator.
 - **Tool construction**: Each tool module's initializer constructs tool instances based on the application
   configuration. Each tool type (REST API, DIAL deployment, MCP, internal) has its own initializer.
+- **Interactive login (MCP)**: When a `DialMCPToolSet` returns HTTP 401 during initialization,
+  `_MCPToolInitializer` collects all unauthorized toolsets and sends a single batched sign-in request
+  to DIAL Core via `InteractiveLoginService`. Toolsets that succeed are retried; failures are recorded
+  as `ToolInitializationException`. The same mechanism applies during tool execution: `_MCPTool` catches
+  401 from `_MCPConnectionManager`, requests sign-in, and retries the call once. The
+  `X-DIAL-CLIENT-CHANNEL-ID` request header enables this flow; without it, 401 errors fall through to
+  the standard error path. See `docs/designs/interactive_login.md` for the full design.
 
 ### 5. Error Handling
 
@@ -324,7 +331,7 @@ The application is composed of 12 specialized DI modules:
 6. **Internal Tool Module**: Python interpreter, content downloader
 7. **Starters Module**: UI starter button configuration
 8. **Configuration Support API Module**: Configuration validation endpoints
-9. **DIAL Core Services Module**: DIAL Core integration
+9. **DIAL Core Services Module**: DIAL Core integration (`InteractiveLoginService`, `InteractiveLoginSettings`)
 10. **File Transfer Module**: `ToolArgumentTransformer` for `file:` prefix resolution, file transfer instruction injection
 11. **Attachment Processing Module**: Context notification tool, attachment change detection injector
 12. **Skills Module**: Skill reader tool, agent skills provider

--- a/docs/designs/interactive_login.md
+++ b/docs/designs/interactive_login.md
@@ -1,6 +1,6 @@
 # Design: Interactive Login into DIAL Toolset
 
-**Status:** Draft
+**Status:** Implemented
 
 ## Problem Statement
 

--- a/docs/designs/interactive_login.md
+++ b/docs/designs/interactive_login.md
@@ -1,0 +1,470 @@
+# Design: Interactive Login into DIAL Toolset
+
+**Status:** Draft
+
+## Problem Statement
+
+When a DIAL MCP toolset requires authentication, the MCP server returns `401 Unauthorized` — either during
+toolset initialization (connecting and listing tools) or during tool execution (calling a tool mid-request).
+QuickApp currently has no way to recover from this: both paths surface the 401 as an unrecoverable error,
+and the user must navigate to a separate login page and retry the entire conversation.
+
+DIAL Core PR #1412 introduces a **client channel** mechanism that enables QuickApp to request interactive
+sign-in from the user mid-request: it calls a dedicated DIAL Core API, which notifies the already-connected
+client via a persistent SSE channel, waits for the user to complete login, and streams the result back to
+QuickApp. This design describes how QuickApp integrates with that mechanism.
+
+## Design Goals
+
+- When a `DialMCPToolSet` returns 401 (during initialization **or** tool execution), QuickApp requests
+  interactive login via DIAL Core instead of failing immediately.
+- The login flow is transparent to the orchestrator: after a successful login, the failing operation
+  (tool list fetch or tool call) is retried exactly once.
+- If no client channel ID is present in the request (e.g. programmatic clients), the 401 falls through
+  to the existing error handling unchanged.
+- The timeout for waiting on user sign-in is configurable via an environment variable.
+- Only `DialMCPToolSet` toolsets participate in interactive login; plain `MCPToolSet` toolsets are unaffected.
+
+---
+
+## Use Cases
+
+### UC-1: 401 during toolset initialization (single or multiple toolsets)
+
+**Trigger:** A chat completion request arrives for an app that includes one or more `DialMCPToolSet`s.
+The client has subscribed to a client channel and passed `X-DIAL-CLIENT-CHANNEL-ID` in the request.
+When QuickApp connects to the MCP servers concurrently and lists tools, one or more servers return 401.
+
+**Behavior:** QuickApp collects all failing toolsets and sends a single batched
+`POST /v1/ops/client-channel/interact` request to DIAL Core containing one sign-in RPC entry per
+failing toolset. DIAL Core notifies the client; the user logs in to each toolset; DIAL Core streams
+back one result per entry. QuickApp retries the tool list fetch for each toolset whose entry returned
+`success`.
+
+**Outcome:** All successfully-authed toolsets initialize; any that were denied or timed out surface
+as individual errors. From the user's perspective, one sign-in prompt covers all toolsets at once.
+
+### UC-2: 401 during tool execution
+
+**Trigger:** Same setup as UC-1, but the toolset initialized successfully (e.g. a cached session was
+used), and the 401 occurs when a tool is called mid-request during the orchestrator loop.
+
+**Behavior:** Same interact call as UC-1. After success, the specific tool call is retried once.
+
+**Outcome:** The tool call succeeds. The orchestrator loop continues.
+
+### UC-3: Login timeout or denial
+
+**Trigger:** QuickApp sends the interact request but the user does not complete login within the configured
+timeout, or the client returns a `denied` result.
+
+**Behavior:** `InteractiveLoginService` returns a failure signal. The retry does not happen.
+
+**Outcome:** The failing operation (tool list fetch or tool call) raises an error, which surfaces to the
+user the same way other tool errors do today.
+
+### UC-4: No client channel ID
+
+**Trigger:** A chat completion request arrives without `X-DIAL-CLIENT-CHANNEL-ID` (e.g. a programmatic
+API call).
+
+**Behavior:** `InteractiveLoginService` detects that `CLIENT_CHANNEL_ID` is `None` and skips the interact
+call immediately.
+
+**Outcome:** The 401 falls through to the existing `ToolInitializationException` / tool error path, as today.
+
+---
+
+## Proposed Design
+
+### `CLIENT_CHANNEL_ID` — new DI-injectable value
+
+**What:** A new annotated DI type alias `CLIENT_CHANNEL_ID = Annotated[str | None, "CLIENT_CHANNEL_ID"]`
+added to `common/_di_types.py`, following the same convention as `DIAL_API_KEY`, `DIAL_BEARER`, and
+`ForwardedHeaders`.
+
+**Owner:** `common/_di_types.py`, `application/app_module.py`.
+
+**Semantics:** Holds the value of the `X-DIAL-CLIENT-CHANNEL-ID` request header, or `None` if the header
+was absent. Injected wherever interactive login is needed.
+
+**Rationale for a dedicated DI type:** The header is already captured in `ForwardedHeaders`, but
+`CLIENT_CHANNEL_ID` represents a protocol-level channel identifier — not just another forwarded header.
+A dedicated type makes the dependency explicit at injection sites, prevents accidental loss if
+`ForwardedHeaders` is filtered or manipulated, and provides `str | None` ergonomics without a dict
+lookup.
+
+**Change:**
+
+- `_RequestContext` gains an explicit `client_channel_id: str | None` field using a set-once property
+  with a `_client_channel_id_set: bool` flag — same pattern as `bearer`, because `None` is a valid
+  assigned value ("no channel") and must be distinguishable from "not yet set."
+- `_RequestContextSetup.setup()` extracts the header by iterating `forwarded_headers.items()` and
+  comparing `key.lower() == "x-dial-client-channel-id"` (not a direct dict `.get()`, since
+  `extract_x_headers_from_request` preserves original header casing).
+- `AppModule` gains a `@provider` method `__provide_client_channel_id` that reads from `_RequestContext`
+  and binds it to `CLIENT_CHANNEL_ID`, keeping it request-scoped.
+
+### `InteractiveLoginService` — dedicated sign-in coordinator
+
+**What:** A new request-scoped service in `dial_core_services/` responsible for calling the
+`POST /v1/ops/client-channel/interact` DIAL Core endpoint and returning per-toolset sign-in outcomes.
+
+**Owner:** `dial_core_services/interactive_login_service.py`
+
+**Semantics:**
+
+**`LoginResult` enum:**
+
+The service returns per-toolset outcomes using a `LoginResult` enum rather than a plain `bool`,
+so callers can produce meaningful error messages:
+
+| Value        | Meaning                                                            |
+|--------------|--------------------------------------------------------------------|
+| `SUCCESS`    | `"result": "success"` in the JSON-RPC response                     |
+| `DENIED`     | `"result": "denied"` or other non-success result                   |
+| `TIMEOUT`    | Wall-clock deadline elapsed before response                        |
+| `ERROR`      | HTTP error, connection drop, malformed JSON, JSON-RPC error object |
+| `NO_CHANNEL` | `client_channel_id` is `None` — interactive login unavailable      |
+
+**Public methods:**
+
+```
+async def request_signin_batch(self, toolset_dial_ids: list[str]) -> dict[str, LoginResult]
+async def request_signin(self, toolset_dial_id: str) -> LoginResult  # calls batch with one entry
+```
+
+**Execution flow:**
+
+```mermaid
+flowchart TD
+    A[request_signin_batch called] --> B{client_channel_id is None?}
+    B -->|Yes| C[return all NO_CHANNEL]
+    B -->|No| D[POST /v1/ops/client-channel/interact\nwith RPC batch]
+    D --> E{HTTP error?}
+    E -->|Yes| F[log error, return all ERROR]
+    E -->|No| G[Read SSE stream with wall-clock timeout]
+    G --> H{data line received?}
+    H -->|timeout| I[log timeout, return all TIMEOUT]
+    H -->|connection drop| F
+    H -->|Yes| J{valid JSON?}
+    J -->|No| F
+    J -->|Yes| K[Map each entry to LoginResult]
+    K --> L[return dict: dial_id to LoginResult]
+```
+
+- Each `dial_id` is assigned a sequential JSON-RPC request ID (`"1"`, `"2"`, …). The service maintains
+  the mapping internally to correlate results back to `dial_id`s.
+- The JSON-RPC request body is a batch array, one entry per toolset:
+  `[{"jsonrpc":"2.0","method":"toolset/signin","params":{"toolsetId":"<dial_id>"},"id":"<n>"}, ...]`.
+- The `X-DIAL-CLIENT-CHANNEL-ID` header carries the channel ID.
+- The SSE stream contains heartbeat comments (`: heartbeat`) followed by one `data:` line with the
+  full batch response.
+- **HTTP client:** `request_signin_batch()` creates an `httpx.AsyncClient` inline
+  (`async with httpx.AsyncClient(base_url=..., headers={"Api-Key": ...}) as client:`), same pattern
+  as `DialCoreClient.__aenter__` but without the wrapper — `aconnect_sse` requires a raw
+  `AsyncClient`.
+- **SSE reading:** Uses `httpx-sse` (already a project dependency via the MCP SDK). The service calls
+  `aconnect_sse(client, "POST", url, json=batch)` and iterates with `event_source.aiter_sse()`.
+  Heartbeat comments (`: heartbeat`) are automatically filtered by `httpx-sse` — only `data:` events
+  are yielded. The service takes the first yielded event and parses it. The DIAL Core contract is
+  exactly one `data:` event per interact call containing the full batch response.
+- **Wall-clock timeout:** The entire SSE reading loop is wrapped in `asyncio.timeout()` (not
+  `httpx.Timeout(read=...)`, which resets on each received byte including heartbeats and would not
+  enforce a wall-clock deadline). The timeout applies to the **entire batch** — the user has the
+  configured duration (default 120s) to complete all sign-ins, not 120s per toolset.
+- Response entry mapping: `"result": "success"` → `SUCCESS`; `"result": "denied"` (or any other
+  non-success value) → `DENIED`; entry with `"error"` key (JSON-RPC error object) or missing
+  `"result"` key → `ERROR`.
+
+**Error handling:** The service **never raises exceptions**. All failure modes (DIAL Core returns
+404/401/5xx, connection drops, malformed JSON) are logged and mapped to `ERROR` for all entries
+in the batch. This is intentional — the interact call is best-effort recovery, and propagating
+exceptions would complicate the caller's already-complex retry logic.
+
+**Logging:** Key log points at `INFO` level:
+
+- When the interact call is initiated (with toolset IDs and channel ID).
+- When the response arrives (per-toolset outcomes).
+- On timeout (elapsed time and toolset IDs).
+- On error (HTTP status, connection error, or parse failure details).
+
+**Injected dependencies:**
+
+- `DIAL_API_KEY` — for the `Api-Key` header on the DIAL Core request.
+- `DialSettings` — for the DIAL Core base URL.
+- `CLIENT_CHANNEL_ID` — the channel ID header value.
+- `InteractiveLoginSettings` — for the configurable timeout.
+
+**Registration:** Request-scoped in `dial_core_services_module.py`.
+
+### `InteractiveLoginSettings` — timeout configuration
+
+**What:** A new `BaseSettings` class in `dial_core_services/` holding the sign-in timeout.
+
+**Semantics:**
+
+- Single field: `interactive_login_timeout_seconds: float`, default `120.0`.
+- Environment variable: `DIAL_INTERACTIVE_LOGIN_TIMEOUT_SECONDS` (using `SettingsConfigDict(env_prefix='dial_')`).
+- The timeout is a **wall-clock absolute deadline** measured from the start of the `POST /interact`
+  request. It is not reset by heartbeats. This prevents indefinitely hanging on slow multi-toolset logins.
+
+**Registration:** Singleton in `dial_core_services_module.py`.
+
+### `MCPUnauthorizedException` — typed 401 signal
+
+**What:** A new exception class in `mcp_tooling/`, raised when an MCP connection attempt or tool call
+returns HTTP 401.
+
+**Owner:** `mcp_tooling/`
+
+**Semantics:** Wraps the underlying `httpx.HTTPStatusError` and carries the `toolset_name` for logging.
+Should include a user-friendly message (e.g. "Authentication required for toolset '{name}'") since
+it may propagate to `StagedBaseTool.arun()` and surface to the user when interactive login fails.
+Raised by `_MCPConnectionManager` in both `get_tools_list()` and `call_mcp_tool()` when an
+`httpx.HTTPStatusError` with `status_code == 401` is detected. This replaces the current behavior
+where 401s in `call_mcp_tool()` are silently wrapped in a generic `RuntimeError` and 401s in
+`get_tools_list()` propagate as raw `httpx.HTTPStatusError`.
+
+### `_MCPConnectionManager` — surface 401 as typed exception
+
+**What:** Both `get_tools_list()` and `call_mcp_tool()` gain explicit handling for HTTP 401: they
+raise `MCPUnauthorizedException` instead of propagating the raw error or wrapping it in `RuntimeError`.
+
+**Where 401 manifests:** Verified against MCP SDK 1.26.0. A 401 from the MCP server surfaces as
+`httpx.HTTPStatusError` during the HTTP connection phase — the MCP SDK does **not** wrap it in any
+SDK-specific exception type or `ExceptionGroup`.
+
+- **SSE transport:** `sse_client()` calls `event_source.response.raise_for_status()` (sse.py line 74)
+  immediately after connecting, before any MCP protocol messages. A 401 raises
+  `httpx.HTTPStatusError` directly.
+- **Streamable HTTP transport:** `streamablehttp_client()` calls `response.raise_for_status()`
+  (streamable_http.py line 358) in the POST stream handler. Same exception type.
+- **`ClientSession.initialize()`** does not independently produce HTTP errors — it operates on the
+  already-established transport. The 401 always surfaces at the transport level before `initialize()`
+  runs.
+
+**Change:**
+
+- The catch is placed inside `__session_context()`. It catches `httpx.HTTPStatusError` with
+  `status_code == 401` and raises `MCPUnauthorizedException`. All other HTTP errors propagate
+  unchanged.
+- `call_mcp_tool()` adds `except MCPUnauthorizedException: raise` before the existing generic
+  `except Exception` handler (same pattern as `_process_toolset()`). This allows
+  `MCPUnauthorizedException` from `__session_context()` to propagate to `_MCPTool` for the
+  catch-interact-retry flow, while preserving the `RuntimeError` wrapping for non-401 errors
+  (which provides tool name context in error messages).
+
+### Response stream keepalive during interactive login wait
+
+**What:** While QuickApp is blocked waiting for the `interact` SSE response (up to 120 seconds), it
+must emit heartbeat chunks on its own response stream back to DIAL Core. Without this, the upstream
+HTTP connection chain (Client → DIAL Core → QuickApp) will time out.
+
+**Solution:** Enable the `aidial_sdk`'s built-in heartbeat mechanism. `DIALApp.add_chat_completion()`
+accepts an optional `heartbeat_interval` parameter. When set, the SDK wraps the response SSE stream
+with `add_heartbeat()` (from `aidial_sdk.utils.streaming`), which emits `: heartbeat\n\n` SSE
+comment lines at the configured interval whenever the stream is idle — i.e. whenever
+`chat_completion()` is blocked and not producing chunks.
+
+This covers the interactive login wait automatically: when the initializer or tool execution is
+blocked on `request_signin_batch()`, no chunks are pushed to the response queue, so the
+`add_heartbeat` wrapper detects the idle timeout and emits heartbeats on behalf of QuickApp.
+
+**Change:** `_QuickAppApplication.__init__()` passes `heartbeat_interval=1.0` (seconds) to
+`self.add_chat_completion()`. No changes needed in `_MCPToolInitializer`, `_MCPTool`, or
+`InteractiveLoginService` — keepalive is handled transparently at the SDK/transport level.
+
+**Trade-off:** This is a global change affecting all requests, not just those with interactive login.
+SSE comment lines (`: heartbeat\n\n`) are standard and ignored by compliant clients, so there is no
+observable impact on existing behavior.
+
+**Note on forwarded headers:** `_MCPConnectionManager.__build_headers()` forwards all X-headers
+(including `X-DIAL-CLIENT-CHANNEL-ID`) to MCP servers. This is acceptable — MCP servers ignore
+unknown headers, and the channel ID carries no security-sensitive information beyond what the
+Api-Key already provides.
+
+### `_MCPToolInitializer` — multi-phase batch initialization
+
+**What:** `initialize()` is restructured into three phases. Phase 1 runs all toolsets concurrently
+as today; phase 2 collects all `MCPUnauthorizedException` failures from `DialMCPToolSet`s, sends a
+single batched interact request; phase 3 retries the ones that succeeded.
+
+**Owner:** `mcp_tooling/_mcp_tool_initializer.py`
+
+**Semantics:**
+
+```mermaid
+sequenceDiagram
+    participant Init as _MCPToolInitializer
+    participant CM1 as ConnectionManager (TS1)
+    participant CM2 as ConnectionManager (TS2)
+    participant ILS as InteractiveLoginService
+
+    par Phase 1 - concurrent
+        Init ->> CM1: get_tools_list()
+        CM1 -->> Init: MCPUnauthorizedException
+    and
+        Init ->> CM2: get_tools_list()
+        CM2 -->> Init: MCPUnauthorizedException
+    end
+
+    Init ->> ILS: request_signin_batch([ts1.dial_id, ts2.dial_id])
+    ILS -->> Init: {ts1: SUCCESS, ts2: DENIED}
+    Init ->> CM1: get_tools_list() [retry]
+    CM1 -->> Init: tools
+    Note over Init: ts2 records ToolInitializationException
+```
+
+**Control flow restructuring:**
+
+`_process_toolset()` adds `except MCPUnauthorizedException: raise` before the existing generic
+`except Exception` handler, so the 401 propagates to `initialize()` instead of being swallowed.
+
+**Phase 1 — concurrent initialization (existing logic).** `initialize()` runs all
+`_process_toolset()` tasks via `asyncio.gather(return_exceptions=True)`. It then classifies the
+results: `MCPUnauthorizedException` from a `DialMCPToolSet` is collected for batch interaction;
+a 401 from a plain `MCPToolSet` falls through to the existing exception handler; all other
+exceptions are handled as today.
+
+**Phase 2 — batch interactive login.** The collected `dial_id`s are passed to
+`InteractiveLoginService.request_signin_batch()`. If no toolsets are unauthorized, this phase is
+skipped. The `NO_CHANNEL` case (no client channel ID) is handled by the service itself — it
+returns `NO_CHANNEL` for all entries, and `initialize()` maps that to `ToolInitializationException`
+with an appropriate message (see error templates below).
+
+**Phase 3 — retry and error reporting.** Toolsets whose `LoginResult` is not `SUCCESS` have a
+`ToolInitializationException` appended to `_MCPToolingContext` with a message derived from the
+result (see error templates below). Toolsets that succeeded are retried concurrently via a
+`_retry_process_toolset()` wrapper. This wrapper calls `_process_toolset()` but catches
+`MCPUnauthorizedException` and converts it to `ToolInitializationException` (since interactive
+login was already attempted). Any other exception from the retry is also converted to
+`ToolInitializationException` and appended to `_MCPToolingContext`.
+
+**Error message templates** (user-facing, for `ToolInitializationException`):
+
+- `NO_CHANNEL`: "Toolset '{name}' requires sign-in, but no client channel is available"
+- `DENIED`: "Sign-in was denied for toolset '{name}'"
+- `TIMEOUT`: "Sign-in timed out for toolset '{name}'"
+- `ERROR`: "Sign-in failed for toolset '{name}'"
+- Retry failure: "Sign-in succeeded but toolset '{name}' initialization still failed"
+
+**New injected dependency:** `InteractiveLoginService`.
+
+### `_MCPTool` — catch, interact, retry during tool execution
+
+**What:** `_run_in_stage_async()` intercepts `MCPUnauthorizedException` from
+`connection_manager.call_mcp_tool()`, calls `InteractiveLoginService.request_signin()`, and retries
+the tool call once on success.
+
+**Owner:** `mcp_tooling/_mcp_tool.py`
+
+**Semantics:** Interactive login is only attempted when `self.__dial_toolset_id` is not `None`.
+The `CLIENT_CHANNEL_ID` guard is not duplicated here — `InteractiveLoginService.request_signin()`
+already returns non-`SUCCESS` when no channel is present. When `dial_toolset_id` is `None` or login
+fails, the exception propagates through the `StagedBaseTool` error handling path as today.
+Keepalive is handled by the SDK-level heartbeat. Note: the stage wrapper is already tracking
+wall-clock time when the interactive login wait occurs, so the tool will appear as taking up to
+120s in the UI stage display. This is intentional — the user knows they were logging in.
+
+**New injected dependency:** `InteractiveLoginService`.
+
+---
+
+## Out of Scope
+
+- **Batching during tool execution.** Tools execute in parallel within an orchestrator step, so multiple
+  tools from different toolsets could return 401 simultaneously. Batching those would require coordination
+  across concurrent tool calls, adding significant complexity for a rare case. Single-call `request_signin()`
+  is sufficient for tool execution. Note: if two tools from the **same** toolset both fail with 401
+  simultaneously, two concurrent `request_signin()` calls are made with the same `dial_id`. This is safe —
+  DIAL Core's RPC batch processing deduplicates by checking pending messages: the second call finds the
+  existing entry and subscribes as a recipient on the same response rather than creating a duplicate prompt.
+- **Retry count > 1.** A single retry after sign-in is sufficient for the current use case. If the retry
+  also fails with 401, it is treated as a hard error.
+
+---
+
+## Configuration / Usage Examples
+
+### Environment variables
+
+| Variable                                 | Default | Description                                      |
+|------------------------------------------|---------|--------------------------------------------------|
+| `DIAL_INTERACTIVE_LOGIN_TIMEOUT_SECONDS` | `120.0` | Max seconds to wait for user to complete sign-in |
+
+### Typical request flow — multiple toolsets requiring login
+
+1. DIAL Chat subscribes: `POST /v1/ops/client-channel/subscribe` → receives `X-DIAL-CLIENT-CHANNEL-ID: abc-123`.
+2. Chat sends a completion request with header `X-DIAL-CLIENT-CHANNEL-ID: abc-123`.
+3. QuickApp stores `abc-123` in `_RequestContext.client_channel_id` and exposes it as `CLIENT_CHANNEL_ID`.
+4. `_MCPToolInitializer` runs all toolsets concurrently; two `DialMCPToolSet`s return 401 →
+   `MCPUnauthorizedException` for each.
+5. `InteractiveLoginService.request_signin_batch(["toolsets/public/ts1", "toolsets/public/ts2"])` calls:
+   ```
+   POST /v1/ops/client-channel/interact
+   Api-Key: <key>
+   X-DIAL-CLIENT-CHANNEL-ID: abc-123
+
+   [
+     {"jsonrpc":"2.0","method":"toolset/signin","params":{"toolsetId":"toolsets/public/ts1"},"id":"1"},
+     {"jsonrpc":"2.0","method":"toolset/signin","params":{"toolsetId":"toolsets/public/ts2"},"id":"2"}
+   ]
+   ```
+6. DIAL Core notifies the client; user logs in to both; DIAL Core streams:
+   ```
+   : heartbeat
+   data: [{"jsonrpc":"2.0","result":"success","id":"1"},{"jsonrpc":"2.0","result":"success","id":"2"}]
+   ```
+7. Service returns `{"toolsets/public/ts1": SUCCESS, "toolsets/public/ts2": SUCCESS}`; initializer
+   retries both concurrently and they succeed.
+
+---
+
+## Migration
+
+### Non-breaking changes
+
+- `X-DIAL-CLIENT-CHANNEL-ID` header is optional; existing clients that do not send it see no change in behavior.
+- `DIAL_INTERACTIVE_LOGIN_TIMEOUT_SECONDS` has a safe default.
+- All new components are additive; no existing public interfaces change.
+
+---
+
+## Testing Strategy
+
+- **`InteractiveLoginService`:** Unit tests with mocked `httpx.AsyncClient` and SSE responses
+  covering: successful batch, partial success/denial, timeout, HTTP errors, malformed JSON, and
+  `NO_CHANNEL`.
+- **`_MCPToolInitializer` multi-phase flow:** Unit tests with mocked `_MCPConnectionManager` and
+  `InteractiveLoginService`, covering: no 401s (unchanged path), batch login + retry, retry failure,
+  mixed success/failure.
+- **`_MCPConnectionManager`:** Unit test verifying `MCPUnauthorizedException` is raised on 401 and
+  other HTTP errors propagate unchanged.
+- **Integration tests:** Require a DIAL Core instance with client channel support. Test the full
+  flow: subscribe → send request with channel ID → 401 → interact → retry → success.
+- **Observability (future work):** A counter metric for login attempts by outcome (`SUCCESS`,
+  `DENIED`, `TIMEOUT`, `ERROR`, `NO_CHANNEL`) and a tracing span wrapping the interact call would
+  aid production debugging. Deferred to a follow-up — the `INFO`-level logging specified in
+  `InteractiveLoginService` is sufficient for initial rollout.
+
+---
+
+## Summary of Changes
+
+| Component                                          | Change                                                                                                                        |
+|----------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| `common/_di_types.py`                              | Add `CLIENT_CHANNEL_ID` type alias                                                                                            |
+| `application/_request_context.py`                  | Add `client_channel_id: str \| None` field                                                                                    |
+| `application/_request_context_setup.py`            | Extract `X-DIAL-CLIENT-CHANNEL-ID` from forwarded headers into context                                                        |
+| `application/app_module.py`                        | Add `@provider` for `CLIENT_CHANNEL_ID`                                                                                       |
+| `dial_core_services/interactive_login_service.py`  | **New** — `InteractiveLoginService` with `LoginResult` enum, `request_signin_batch()`, `request_signin()`                     |
+| `dial_core_services/interactive_login_settings.py` | **New** — `InteractiveLoginSettings` with wall-clock timeout                                                                  |
+| `dial_core_services/dial_core_services_module.py`  | Register new service and settings                                                                                             |
+| `mcp_tooling/_mcp_unauthorized_exception.py`       | **New** — `MCPUnauthorizedException`                                                                                          |
+| `mcp_tooling/_mcp_connection_manager.py`           | Raise `MCPUnauthorizedException` on 401 in `__session_context()`; re-raise before `RuntimeError` wrapper in `call_mcp_tool()` |
+| `application/_quick_app_application.py`            | Enable `heartbeat_interval` on `add_chat_completion()`                                                                        |
+| `mcp_tooling/_mcp_tool_initializer.py`             | Multi-phase batch init; inject `InteractiveLoginService`                                                                      |
+| `mcp_tooling/_mcp_tool.py`                         | Catch `MCPUnauthorizedException`, call `request_signin()`, retry                                                              |
+| `mcp_tooling/mcp_tooling_module.py`                | Update DI wiring for new `InteractiveLoginService` dependency on `_MCPTool` and `_MCPToolInitializer`                         |
+| `docs/agent.md`                                    | Document interactive login flow, new DI types, `InteractiveLoginService`, heartbeat setting                                   |

--- a/src/quickapp/application/_quick_app_application.py
+++ b/src/quickapp/application/_quick_app_application.py
@@ -44,4 +44,4 @@ class _QuickAppApplication(DIALApp):
         # noinspection PyTypeChecker
         self.add_middleware(InjectorMiddleware, injector=injector)
         attach_injector(self, injector, RequestScopeOptions())
-        self.add_chat_completion("quick_apps2", completion)
+        self.add_chat_completion("quick_apps2", completion, heartbeat_interval=1.0)

--- a/src/quickapp/application/_request_context.py
+++ b/src/quickapp/application/_request_context.py
@@ -32,7 +32,6 @@ class _RequestContext(MessagesMixin):
     _bearer: DIAL_BEARER = None
     _response_format: ResponseFormat | None = None
     _forwarded_headers: ForwardedHeaders | None = None
-    _client_channel_id_set: bool = False
     _client_channel_id: CLIENT_CHANNEL_ID = None
 
     @property
@@ -107,13 +106,10 @@ class _RequestContext(MessagesMixin):
 
     @property
     def client_channel_id(self) -> CLIENT_CHANNEL_ID:
-        if not self._client_channel_id_set:
-            raise RuntimeError("Client channel ID is not set")
         return self._client_channel_id
 
     @client_channel_id.setter
     def client_channel_id(self, value: CLIENT_CHANNEL_ID) -> None:
-        if self._client_channel_id_set:
+        if self._client_channel_id is not None:
             raise RuntimeError("Client channel ID is already set")
-        self._client_channel_id_set = True
         self._client_channel_id = value

--- a/src/quickapp/application/_request_context.py
+++ b/src/quickapp/application/_request_context.py
@@ -1,7 +1,7 @@
 from aidial_sdk.chat_completion import Choice, ResponseFormat
 from aidial_sdk.exceptions import InvalidRequestError
 
-from quickapp.common import DIAL_API_KEY, DIAL_BEARER, ForwardedHeaders
+from quickapp.common import CLIENT_CHANNEL_ID, DIAL_API_KEY, DIAL_BEARER, ForwardedHeaders
 from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.config.application import ApplicationConfig
 
@@ -32,6 +32,8 @@ class _RequestContext(MessagesMixin):
     _bearer: DIAL_BEARER = None
     _response_format: ResponseFormat | None = None
     _forwarded_headers: ForwardedHeaders | None = None
+    _client_channel_id_set: bool = False
+    _client_channel_id: CLIENT_CHANNEL_ID = None
 
     @property
     def bearer(self) -> DIAL_BEARER:
@@ -102,3 +104,16 @@ class _RequestContext(MessagesMixin):
         if self._forwarded_headers is not None:
             raise RuntimeError("Forwarded headers are already set")
         self._forwarded_headers = value
+
+    @property
+    def client_channel_id(self) -> CLIENT_CHANNEL_ID:
+        if not self._client_channel_id_set:
+            raise RuntimeError("Client channel ID is not set")
+        return self._client_channel_id
+
+    @client_channel_id.setter
+    def client_channel_id(self, value: CLIENT_CHANNEL_ID) -> None:
+        if self._client_channel_id_set:
+            raise RuntimeError("Client channel ID is already set")
+        self._client_channel_id_set = True
+        self._client_channel_id = value

--- a/src/quickapp/application/_request_context_setup.py
+++ b/src/quickapp/application/_request_context_setup.py
@@ -6,9 +6,20 @@ from aidial_sdk.deployment.configuration import ConfigurationRequest
 from injector import ProviderOf, inject
 from pydantic import SecretStr
 
+from quickapp.common._di_types import CLIENT_CHANNEL_HEADER, CLIENT_CHANNEL_ID, ForwardedHeaders
 from quickapp.common.forwarded_headers import extract_x_headers_from_request
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.config_template_resolver import ConfigResolver
+
+
+def _extract_client_channel_id(forwarded_headers: ForwardedHeaders) -> CLIENT_CHANNEL_ID:
+    """Extract the client channel ID from forwarded headers (case-insensitive)."""
+    if forwarded_headers:
+        for key, value in forwarded_headers.items():
+            if key.lower() == CLIENT_CHANNEL_HEADER.lower():
+                return value
+    return None
+
 
 from ._messages_setup import _MessagesSetup
 from ._request_context import _RequestContext
@@ -45,6 +56,9 @@ class _RequestContextSetup:
         if isinstance(request, Request):
             context.messages = self.__messages_setup.setup(request.messages)
             context.forwarded_headers = extract_x_headers_from_request(request)
+            context.client_channel_id = _extract_client_channel_id(context.forwarded_headers)
+        else:
+            context.client_channel_id = None
         if choice:
             context.choice = choice
 

--- a/src/quickapp/application/_request_context_setup.py
+++ b/src/quickapp/application/_request_context_setup.py
@@ -57,8 +57,6 @@ class _RequestContextSetup:
             context.messages = self.__messages_setup.setup(request.messages)
             context.forwarded_headers = extract_x_headers_from_request(request)
             context.client_channel_id = _extract_client_channel_id(context.forwarded_headers)
-        else:
-            context.client_channel_id = None
         if choice:
             context.choice = choice
 

--- a/src/quickapp/application/app_module.py
+++ b/src/quickapp/application/app_module.py
@@ -4,8 +4,13 @@ from fastapi import FastAPI
 from fastapi_injector import request_scope
 from injector import Binder, Module, multiprovider, provider, singleton
 
-from quickapp.common import DIAL_API_KEY, DIAL_BEARER, RESPONSE_FORMAT
-from quickapp.common._di_types import ForwardedHeaders
+from quickapp.common import (
+    CLIENT_CHANNEL_ID,
+    DIAL_API_KEY,
+    DIAL_BEARER,
+    RESPONSE_FORMAT,
+    ForwardedHeaders,
+)
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
@@ -77,6 +82,10 @@ class AppModule(Module):
     @provider
     def __provide_forwarded_headers(self, context: _RequestContext) -> ForwardedHeaders:
         return context.forwarded_headers
+
+    @provider
+    def __provide_client_channel_id(self, context: _RequestContext) -> CLIENT_CHANNEL_ID:
+        return context.client_channel_id
 
     @provider
     def __provide_stage(self, choice: Choice) -> Stage:

--- a/src/quickapp/common/__init__.py
+++ b/src/quickapp/common/__init__.py
@@ -1,4 +1,11 @@
-from ._di_types import DIAL_API_KEY, DIAL_BEARER, ForwardedHeaders, RESPONSE_FORMAT
+from ._di_types import (
+    DIAL_API_KEY,
+    DIAL_BEARER,
+    CLIENT_CHANNEL_HEADER,
+    CLIENT_CHANNEL_ID,
+    ForwardedHeaders,
+    RESPONSE_FORMAT,
+)
 from quickapp.common.base_initializer import BaseInitializer, InitializerType
 from .completion_result import CompletionResult
 from .staged_base_tool import StagedBaseTool

--- a/src/quickapp/common/_di_types.py
+++ b/src/quickapp/common/_di_types.py
@@ -7,3 +7,5 @@ DIAL_API_KEY = Annotated[SecretStr, "DIAL_API_KEY"]
 DIAL_BEARER = Annotated[SecretStr | None, "DIAL_BEARER"]
 RESPONSE_FORMAT = Annotated[ResponseFormat | None, "RESPONSE_FORMAT"]
 ForwardedHeaders = Annotated[dict[str, str] | None, "ForwardedHeaders"]
+CLIENT_CHANNEL_ID = Annotated[str | None, "CLIENT_CHANNEL_ID"]
+CLIENT_CHANNEL_HEADER = "X-DIAL-CLIENT-CHANNEL-ID"

--- a/src/quickapp/dial_core_services/_interactive_login_service.py
+++ b/src/quickapp/dial_core_services/_interactive_login_service.py
@@ -1,0 +1,156 @@
+import asyncio
+import json
+import logging
+
+import httpx
+from httpx_sse import aconnect_sse
+from injector import inject
+
+from quickapp.common import CLIENT_CHANNEL_ID, DIAL_API_KEY
+from quickapp.common._di_types import CLIENT_CHANNEL_HEADER
+from quickapp.common.dial_settings import DialSettings
+from quickapp.dial_core_services._interactive_login_settings import InteractiveLoginSettings
+from quickapp.dial_core_services._login_result import LoginResult
+
+logger = logging.getLogger(__name__)
+
+_INTERACT_PATH = "/v1/ops/client-channel/interact"
+
+
+@inject
+class InteractiveLoginService:
+    """Coordinates interactive sign-in via DIAL Core's client channel mechanism."""
+
+    def __init__(
+        self,
+        api_key: DIAL_API_KEY,
+        dial_settings: DialSettings,
+        client_channel_id: CLIENT_CHANNEL_ID,
+        settings: InteractiveLoginSettings,
+    ):
+        self.__api_key = api_key
+        self.__dial_settings = dial_settings
+        self.__client_channel_id = client_channel_id
+        self.__settings = settings
+
+    async def request_signin_batch(self, toolset_dial_ids: list[str]) -> dict[str, LoginResult]:
+        """Request interactive sign-in for multiple toolsets in a single batch.
+
+        Returns a dict mapping each dial_id to its LoginResult.
+        This method never raises exceptions — all failures are mapped to LoginResult values.
+        """
+        if self.__client_channel_id is None:
+            logger.info(
+                "Interactive login skipped: no client channel ID. Toolsets: %s",
+                toolset_dial_ids,
+            )
+            return {tid: LoginResult.NO_CHANNEL for tid in toolset_dial_ids}
+
+        id_to_dial_id: dict[str, str] = {}
+        rpc_batch: list[dict] = []
+        for idx, dial_id in enumerate(toolset_dial_ids, start=1):
+            rpc_id = str(idx)
+            id_to_dial_id[rpc_id] = dial_id
+            rpc_batch.append(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "toolset/signin",
+                    "params": {"toolsetId": dial_id},
+                    "id": rpc_id,
+                }
+            )
+
+        logger.info(
+            "Requesting interactive login for toolsets %s (channel: %s)",
+            toolset_dial_ids,
+            self.__client_channel_id,
+        )
+
+        try:
+            return await asyncio.wait_for(
+                self._do_interact(rpc_batch, id_to_dial_id, toolset_dial_ids),
+                timeout=self.__settings.interactive_login_timeout_seconds,
+            )
+        except TimeoutError:
+            logger.info(
+                "Interactive login timed out after %ss for toolsets %s",
+                self.__settings.interactive_login_timeout_seconds,
+                toolset_dial_ids,
+            )
+            return {tid: LoginResult.TIMEOUT for tid in toolset_dial_ids}
+        except Exception:
+            logger.exception("Interactive login failed for toolsets %s", toolset_dial_ids)
+            return {tid: LoginResult.ERROR for tid in toolset_dial_ids}
+
+    async def _do_interact(
+        self,
+        rpc_batch: list[dict],
+        id_to_dial_id: dict[str, str],
+        toolset_dial_ids: list[str],
+    ) -> dict[str, LoginResult]:
+        """Execute the interact call and parse the SSE response."""
+        assert self.__client_channel_id is not None  # guaranteed by caller
+        async with httpx.AsyncClient(
+            base_url=self.__dial_settings.url,
+            headers={
+                "Api-Key": self.__api_key.get_secret_value(),
+                CLIENT_CHANNEL_HEADER: self.__client_channel_id,
+            },
+        ) as client:
+            async with aconnect_sse(client, "POST", _INTERACT_PATH, json=rpc_batch) as event_source:
+                event_source.response.raise_for_status()
+
+                async for sse_event in event_source.aiter_sse():
+                    if sse_event.data:
+                        return self._parse_batch_response(
+                            sse_event.data, id_to_dial_id, toolset_dial_ids
+                        )
+
+        # Stream ended without a data event
+        logger.warning(
+            "Interactive login SSE stream ended without data for toolsets %s", toolset_dial_ids
+        )
+        return {tid: LoginResult.ERROR for tid in toolset_dial_ids}
+
+    @staticmethod
+    def _parse_batch_response(
+        data: str,
+        id_to_dial_id: dict[str, str],
+        toolset_dial_ids: list[str],
+    ) -> dict[str, LoginResult]:
+        """Parse a JSON-RPC batch response and map to LoginResult per dial_id."""
+        try:
+            entries = json.loads(data)
+        except (json.JSONDecodeError, TypeError):
+            logger.exception("Failed to parse interactive login response: %s", data)
+            return {tid: LoginResult.ERROR for tid in toolset_dial_ids}
+
+        if not isinstance(entries, list):
+            entries = [entries]
+
+        result_map: dict[str, LoginResult] = {}
+        for entry in entries:
+            rpc_id = entry.get("id")
+            dial_id = id_to_dial_id.get(str(rpc_id)) if rpc_id is not None else None
+            if dial_id is None:
+                continue
+
+            if "error" in entry:
+                result_map[dial_id] = LoginResult.ERROR
+            elif entry.get("result") == "success":
+                result_map[dial_id] = LoginResult.SUCCESS
+            else:
+                result_map[dial_id] = LoginResult.DENIED
+
+        # Fill in any missing entries as ERROR
+        for tid in toolset_dial_ids:
+            if tid not in result_map:
+                result_map[tid] = LoginResult.ERROR
+
+        logger.info("Interactive login results: %s", result_map)
+        return result_map
+
+    async def request_signin(self, toolset_dial_id: str) -> LoginResult:
+        """Request interactive sign-in for a single toolset. Convenience wrapper."""
+        results = await self.request_signin_batch([toolset_dial_id])
+        return results[toolset_dial_id]

--- a/src/quickapp/dial_core_services/_interactive_login_settings.py
+++ b/src/quickapp/dial_core_services/_interactive_login_settings.py
@@ -1,0 +1,11 @@
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class InteractiveLoginSettings(BaseSettings):
+    model_config = SettingsConfigDict(env_prefix='dial_')
+
+    interactive_login_timeout_seconds: float = Field(
+        default=120.0,
+        description="Wall-clock timeout in seconds for waiting on user sign-in via interactive login.",
+    )

--- a/src/quickapp/dial_core_services/_login_result.py
+++ b/src/quickapp/dial_core_services/_login_result.py
@@ -1,0 +1,11 @@
+from enum import Enum
+
+
+class LoginResult(Enum):
+    """Outcome of an interactive login request for a single toolset."""
+
+    SUCCESS = "success"
+    DENIED = "denied"
+    TIMEOUT = "timeout"
+    ERROR = "error"
+    NO_CHANNEL = "no_channel"

--- a/src/quickapp/dial_core_services/dial_core_services_module.py
+++ b/src/quickapp/dial_core_services/dial_core_services_module.py
@@ -3,6 +3,8 @@ import logging
 from fastapi_injector import request_scope
 from injector import Binder, Module, singleton
 
+from quickapp.dial_core_services._interactive_login_service import InteractiveLoginService
+from quickapp.dial_core_services._interactive_login_settings import InteractiveLoginSettings
 from quickapp.dial_core_services.attachment_service import AttachmentService
 from quickapp.dial_core_services.dial_file_service import DialFileService
 from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
@@ -15,3 +17,5 @@ class DialCoreServicesModule(Module):
         binder.bind(ToolConfigCoreService, ToolConfigCoreService, scope=singleton)
         binder.bind(AttachmentService, AttachmentService, scope=request_scope)
         binder.bind(DialFileService, DialFileService, scope=request_scope)
+        binder.bind(InteractiveLoginSettings, InteractiveLoginSettings, scope=singleton)
+        binder.bind(InteractiveLoginService, InteractiveLoginService, scope=request_scope)

--- a/src/quickapp/mcp_tooling/_mcp_connection_manager.py
+++ b/src/quickapp/mcp_tooling/_mcp_connection_manager.py
@@ -1,6 +1,7 @@
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager
 
+import httpx
 from injector import inject
 from mcp import ClientSession, Tool
 from mcp.client.sse import sse_client
@@ -17,6 +18,7 @@ from quickapp.config.toolsets.authorization import (
     MCPApiKeyAuthorization,
 )
 from quickapp.config.toolsets.mcp import MCPProtocol, MCPServerInfo, MCPToolSet
+from quickapp.mcp_tooling._mcp_unauthorized_exception import MCPUnauthorizedException
 
 MAX_ITERATIONS = 1000
 
@@ -74,28 +76,35 @@ class _MCPConnectionManager:
         Async context manager that yields an initialized ClientSession for the given server_info.
         Automatically builds headers, opens the underlying connection (SSE or streamable HTTP),
         initializes the session, and ensures clean teardown.
-        """
-        headers = await self.__build_headers(self.__toolset_info.mcp_server_info)
 
-        if self.__toolset_info.mcp_server_info.protocol == MCPProtocol.streamable_http:
-            async with streamablehttp_client(
-                self.__toolset_info.mcp_server_info.url, headers=headers
-            ) as (read_stream, write_stream, _):
-                async with ClientSession(read_stream, write_stream) as session:
-                    await session.initialize()
-                    yield session
-        elif self.__toolset_info.mcp_server_info.protocol == MCPProtocol.sse:
-            async with sse_client(self.__toolset_info.mcp_server_info.url, headers=headers) as (
-                read_stream,
-                write_stream,
-            ):
-                async with ClientSession(read_stream, write_stream) as session:
-                    await session.initialize()
-                    yield session
-        else:
-            raise ValueError(
-                f"Unsupported protocol: {self.__toolset_info.mcp_server_info.protocol}"
-            )
+        Raises MCPUnauthorizedException if the MCP server returns HTTP 401.
+        """
+        try:
+            headers = await self.__build_headers(self.__toolset_info.mcp_server_info)
+
+            if self.__toolset_info.mcp_server_info.protocol == MCPProtocol.streamable_http:
+                async with streamablehttp_client(
+                    self.__toolset_info.mcp_server_info.url, headers=headers
+                ) as (read_stream, write_stream, _):
+                    async with ClientSession(read_stream, write_stream) as session:
+                        await session.initialize()
+                        yield session
+            elif self.__toolset_info.mcp_server_info.protocol == MCPProtocol.sse:
+                async with sse_client(self.__toolset_info.mcp_server_info.url, headers=headers) as (
+                    read_stream,
+                    write_stream,
+                ):
+                    async with ClientSession(read_stream, write_stream) as session:
+                        await session.initialize()
+                        yield session
+            else:
+                raise ValueError(
+                    f"Unsupported protocol: {self.__toolset_info.mcp_server_info.protocol}"
+                )
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 401:
+                raise MCPUnauthorizedException(toolset_name=self.__toolset_info.name) from e
+            raise
 
     async def get_tools_list(self) -> list[Tool]:
         """Return the tool list from the MCP server."""
@@ -130,5 +139,7 @@ class _MCPConnectionManager:
                 if kwargs is None:
                     return await session.call_tool(tool_name)
                 return await session.call_tool(tool_name, kwargs)
+        except MCPUnauthorizedException:
+            raise
         except Exception as e:
             raise RuntimeError(f"Error calling MCP tool '{tool_name}': {e}") from e

--- a/src/quickapp/mcp_tooling/_mcp_tool.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool.py
@@ -13,10 +13,13 @@ from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.state_holder import StateHolder
 from quickapp.common.utils import generate_attachment_filename, matches_type
 from quickapp.config.tools.mcp import MCPTool
+from quickapp.dial_core_services._interactive_login_service import InteractiveLoginService
+from quickapp.dial_core_services._login_result import LoginResult
 from quickapp.dial_core_services.attachment_service import AttachmentService
 from quickapp.dial_core_services.dial_file_service import DialFileService
 from quickapp.mcp_tooling._mcp_connection_manager import _MCPConnectionManager
 from quickapp.mcp_tooling._mcp_stage_wrapper import _MCPStageWrapper
+from quickapp.mcp_tooling._mcp_unauthorized_exception import MCPUnauthorizedException
 
 logger = logging.getLogger(__name__)
 
@@ -35,6 +38,7 @@ class _MCPTool(StagedBaseTool):
         perf_timer: PerformanceTimer,
         file_service: DialFileService,  # todo combine DialFileService and AttachmentService.
         dial_toolset_id: str | None,
+        login_service: InteractiveLoginService,
         argument_transformers: list[ToolArgumentTransformer] | None = None,
     ):
         super().__init__(
@@ -53,6 +57,7 @@ class _MCPTool(StagedBaseTool):
         self.__connection_manager: _MCPConnectionManager = connection_manager
         self.__file_service: DialFileService = file_service
         self.__dial_toolset_id = dial_toolset_id
+        self.__login_service: InteractiveLoginService = login_service
 
     async def _pre_process_params(self, **kwargs: Any) -> dict[str, Any]:
         kwargs = await super()._pre_process_params(**kwargs)
@@ -129,7 +134,19 @@ class _MCPTool(StagedBaseTool):
 
         logger.debug(f"MCP tool called with {kwargs}")
 
-        tool_call_result = await self.__connection_manager.call_mcp_tool(self.__tool.name, **kwargs)
+        try:
+            tool_call_result = await self.__connection_manager.call_mcp_tool(
+                self.__tool.name, **kwargs
+            )
+        except MCPUnauthorizedException:
+            if self.__dial_toolset_id is None:
+                raise
+            login_result = await self.__login_service.request_signin(self.__dial_toolset_id)
+            if login_result != LoginResult.SUCCESS:
+                raise
+            tool_call_result = await self.__connection_manager.call_mcp_tool(
+                self.__tool.name, **kwargs
+            )
         # Handle error flag if present
         if getattr(tool_call_result, "isError", False):
             logger.error(

--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -22,12 +22,15 @@ from quickapp.config.tools.mcp import MCPTool
 from quickapp.config.toolsets.authorization import MCPApiKeyAuthorization
 from quickapp.config.toolsets.dial_mcp import DialMCPToolSet
 from quickapp.config.toolsets.mcp import MCPProtocol, MCPServerInfo, MCPToolSet
+from quickapp.dial_core_services._interactive_login_service import InteractiveLoginService
+from quickapp.dial_core_services._login_result import LoginResult
 from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
 
 from ._di_types import DialToolsetCacheService
 from ._mcp_connection_manager import _MCPConnectionManager
 from ._mcp_tool import _MCPTool
 from ._mcp_tooling_context import _MCPToolingContext
+from ._mcp_unauthorized_exception import MCPUnauthorizedException
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +45,19 @@ def _human_readable_dial_id(dial_id: str) -> str:
     """
     last_part = dial_id.split("/")[-1] if "/" in dial_id else dial_id
     return unquote(last_part)
+
+
+_LOGIN_RESULT_MESSAGES: dict[LoginResult, str] = {
+    LoginResult.NO_CHANNEL: "Toolset '{name}' requires sign-in, but no client channel is available",
+    LoginResult.DENIED: "Sign-in was denied for toolset '{name}'",
+    LoginResult.TIMEOUT: "Sign-in timed out for toolset '{name}'",
+    LoginResult.ERROR: "Sign-in failed for toolset '{name}'",
+}
+
+
+def _login_result_message(result: LoginResult, toolset_label: str) -> str:
+    template = _LOGIN_RESULT_MESSAGES.get(result, "Sign-in failed for toolset '{name}'")
+    return template.format(name=toolset_label)
 
 
 def _toolset_label_for_error(toolset_info: MCPToolSet | DialMCPToolSet) -> str:
@@ -65,6 +81,7 @@ class _MCPToolInitializer(CompletionInitializer):
         connection_manager_builder: AssistedBuilder[_MCPConnectionManager],
         dial_mcp_cache: DialToolsetCacheService,
         tool_config_service: ToolConfigCoreService,
+        login_service: InteractiveLoginService,
     ):
         self.__toolset_list: list[MCPToolSet | DialMCPToolSet] = toolset_list
         self.__mcp_context: _MCPToolingContext = mcp_context
@@ -76,6 +93,7 @@ class _MCPToolInitializer(CompletionInitializer):
         )
         self.__mcp_cache: DialToolsetCacheService = dial_mcp_cache
         self.__tool_config_service: ToolConfigCoreService = tool_config_service
+        self.__login_service: InteractiveLoginService = login_service
 
     @staticmethod
     # todo add Title to config so that we could use it in stage name
@@ -98,14 +116,77 @@ class _MCPToolInitializer(CompletionInitializer):
         if not self.__toolset_list:
             return
 
-        # Create worker tasks for all configured toolsets and run them concurrently.
+        # Phase 1: Try all toolsets concurrently.
+        # MCPUnauthorizedException propagates out of _process_toolset() for DialMCPToolSets.
         tasks = [asyncio.create_task(self._process_toolset(ts)) for ts in self.__toolset_list]
-        # Await all tasks; errors are handled inside each task. Use return_exceptions=True to be robust.
         results = await asyncio.gather(*tasks, return_exceptions=True)
-        # Log any unexpected exceptions propagated (should be rare because we catch inside worker)
-        for r in results:
-            if isinstance(r, Exception):
-                logger.error("Unexpected error during MCP toolset initialization", exc_info=r)
+
+        # Classify results: collect unauthorized DialMCPToolSets for batch interaction.
+        unauthorized: list[DialMCPToolSet] = []
+        for ts, result in zip(self.__toolset_list, results):
+            if isinstance(result, MCPUnauthorizedException) and isinstance(ts, DialMCPToolSet):
+                unauthorized.append(ts)
+            elif isinstance(result, MCPUnauthorizedException):
+                # Plain MCPToolSet 401 — not eligible for interactive login, record as error
+                label = _toolset_label_for_error(ts)
+                logger.error(
+                    "MCP toolset '%s' returned 401 (not eligible for interactive login)", label
+                )
+                self.__mcp_context.append_exception(
+                    ToolInitializationException(
+                        message=f"Authentication required for toolset '{label}'",
+                        toolset_name=label,
+                    )
+                )
+            elif isinstance(result, Exception):
+                logger.error("Unexpected error during MCP toolset initialization", exc_info=result)
+
+        if not unauthorized:
+            return
+
+        # Phase 2: Batch interactive login for all unauthorized DialMCPToolSets.
+        dial_ids = [ts.dial_id for ts in unauthorized]
+        signin_results = await self.__login_service.request_signin_batch(dial_ids)
+
+        # Phase 3: Retry successful logins, record failures.
+        retry_toolsets: list[DialMCPToolSet] = []
+        for ts in unauthorized:
+            login_result = signin_results.get(ts.dial_id, LoginResult.ERROR)
+            if login_result == LoginResult.SUCCESS:
+                retry_toolsets.append(ts)
+            else:
+                label = _toolset_label_for_error(ts)
+                self.__mcp_context.append_exception(
+                    ToolInitializationException(
+                        message=_login_result_message(login_result, label),
+                        toolset_name=label,
+                    )
+                )
+
+        if retry_toolsets:
+            retry_tasks = [
+                asyncio.create_task(self._retry_process_toolset(ts)) for ts in retry_toolsets
+            ]
+            await asyncio.gather(*retry_tasks)
+
+    async def _retry_process_toolset(self, toolset_info: DialMCPToolSet) -> None:
+        """Retry _process_toolset after successful interactive login.
+
+        Catches all exceptions (including MCPUnauthorizedException) and converts them to
+        ToolInitializationException, since interactive login was already attempted.
+        """
+        label = _toolset_label_for_error(toolset_info)
+        try:
+            await self._process_toolset(toolset_info)
+        except Exception as e:
+            logger.error("Toolset '%s' failed after interactive login: %s", label, e, exc_info=True)
+            self.__mcp_context.append_exception(
+                ToolInitializationException(
+                    message=f"Sign-in succeeded but toolset '{label}' initialization still failed",
+                    toolset_name=label,
+                    details=str(e),
+                )
+            )
 
     async def _process_toolset(self, toolset_info: MCPToolSet | DialMCPToolSet) -> None:
         if not toolset_info.enabled:
@@ -173,6 +254,8 @@ class _MCPToolInitializer(CompletionInitializer):
             if created_tools:
                 self.__mcp_context.extend_tools(created_tools)
 
+        except MCPUnauthorizedException:
+            raise
         except ToolInitializationException as e:
             logger.error(e, exc_info=True)
             self.__mcp_context.append_exception(e)

--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -116,18 +116,24 @@ class _MCPToolInitializer(CompletionInitializer):
         if not self.__toolset_list:
             return
 
-        # Phase 1: Try all toolsets concurrently.
-        # MCPUnauthorizedException propagates out of _process_toolset() for DialMCPToolSets.
         tasks = [asyncio.create_task(self._process_toolset(ts)) for ts in self.__toolset_list]
         results = await asyncio.gather(*tasks, return_exceptions=True)
 
-        # Classify results: collect unauthorized DialMCPToolSets for batch interaction.
+        unauthorized = self._classify_initialization_results(results)
+        if not unauthorized:
+            return
+
+        await self._interactive_login_and_retry(unauthorized)
+
+    def _classify_initialization_results(
+        self, results: list[BaseException | None]
+    ) -> list[DialMCPToolSet]:
+        """Collect unauthorized DialMCPToolSets for interactive login, record other errors."""
         unauthorized: list[DialMCPToolSet] = []
         for ts, result in zip(self.__toolset_list, results):
             if isinstance(result, MCPUnauthorizedException) and isinstance(ts, DialMCPToolSet):
                 unauthorized.append(ts)
             elif isinstance(result, MCPUnauthorizedException):
-                # Plain MCPToolSet 401 — not eligible for interactive login, record as error
                 label = _toolset_label_for_error(ts)
                 logger.error(
                     "MCP toolset '%s' returned 401 (not eligible for interactive login)", label
@@ -140,15 +146,13 @@ class _MCPToolInitializer(CompletionInitializer):
                 )
             elif isinstance(result, Exception):
                 logger.error("Unexpected error during MCP toolset initialization", exc_info=result)
+        return unauthorized
 
-        if not unauthorized:
-            return
-
-        # Phase 2: Batch interactive login for all unauthorized DialMCPToolSets.
+    async def _interactive_login_and_retry(self, unauthorized: list[DialMCPToolSet]) -> None:
+        """Batch interactive login for unauthorized toolsets, then retry successful ones."""
         dial_ids = [ts.dial_id for ts in unauthorized]
         signin_results = await self.__login_service.request_signin_batch(dial_ids)
 
-        # Phase 3: Retry successful logins, record failures.
         retry_toolsets: list[DialMCPToolSet] = []
         for ts in unauthorized:
             login_result = signin_results.get(ts.dial_id, LoginResult.ERROR)

--- a/src/quickapp/mcp_tooling/_mcp_unauthorized_exception.py
+++ b/src/quickapp/mcp_tooling/_mcp_unauthorized_exception.py
@@ -1,0 +1,6 @@
+class MCPUnauthorizedException(Exception):
+    """Raised when an MCP connection or tool call returns HTTP 401 Unauthorized."""
+
+    def __init__(self, toolset_name: str):
+        super().__init__(f"Authentication required for toolset '{toolset_name}'")
+        self.toolset_name = toolset_name

--- a/src/tests/unit_tests/application_tests/test_request_context_setup.py
+++ b/src/tests/unit_tests/application_tests/test_request_context_setup.py
@@ -1,0 +1,77 @@
+"""Tests for _RequestContextSetup — verifying context fields are set on all request paths."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from aidial_sdk.chat_completion import Request
+from aidial_sdk.deployment.configuration import ConfigurationRequest
+
+from quickapp.application._request_context import _RequestContext
+from quickapp.application._request_context_setup import _RequestContextSetup
+
+_PATCH_MODEL_VALIDATE = patch(
+    "quickapp.application._request_context_setup.ApplicationConfig.model_validate",
+    return_value=MagicMock(),
+)
+
+
+def _make_setup() -> tuple[_RequestContextSetup, _RequestContext]:
+    context = _RequestContext()
+    context_provider = MagicMock()
+    context_provider.get.return_value = context
+    config_resolver = MagicMock()
+    config_resolver.resolve_config.return_value = MagicMock()
+    messages_setup = MagicMock()
+    messages_setup.setup.return_value = []
+    setup = _RequestContextSetup(
+        context_provider=context_provider,
+        config_resolver=config_resolver,
+        messages_setup=messages_setup,
+    )
+    return setup, context
+
+
+def _make_chat_request(headers: dict | None = None) -> MagicMock:
+    request = MagicMock(spec=Request)
+    request.api_key = "test-key"
+    request.bearer_token = "test-bearer"
+    request.messages = []
+    request.response_format = None
+    request.headers = headers or {}
+    request.request_dial_application_properties = AsyncMock(return_value={})
+    return request
+
+
+def _make_config_request() -> MagicMock:
+    request = MagicMock(spec=ConfigurationRequest)
+    request.api_key = "test-key"
+    request.bearer_token = None
+    request.request_dial_application_properties = AsyncMock(return_value={})
+    return request
+
+
+@pytest.mark.asyncio
+async def test_chat_request_sets_client_channel_id_from_header():
+    setup, context = _make_setup()
+    request = _make_chat_request(headers={"X-DIAL-CLIENT-CHANNEL-ID": "ch-123"})
+    with _PATCH_MODEL_VALIDATE:
+        await setup.setup(request)
+    assert context.client_channel_id == "ch-123"
+
+
+@pytest.mark.asyncio
+async def test_chat_request_sets_client_channel_id_none_when_no_header():
+    setup, context = _make_setup()
+    request = _make_chat_request(headers={})
+    with _PATCH_MODEL_VALIDATE:
+        await setup.setup(request)
+    assert context.client_channel_id is None
+
+
+@pytest.mark.asyncio
+async def test_configuration_request_sets_client_channel_id_none():
+    setup, context = _make_setup()
+    request = _make_config_request()
+    with _PATCH_MODEL_VALIDATE:
+        await setup.setup(request)
+    assert context.client_channel_id is None

--- a/src/tests/unit_tests/dial_core_services_tests/test_interactive_login_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_interactive_login_service.py
@@ -1,0 +1,216 @@
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+from pydantic import SecretStr
+
+from quickapp.common.dial_settings import DialSettings
+from quickapp.dial_core_services._interactive_login_service import InteractiveLoginService
+from quickapp.dial_core_services._interactive_login_settings import InteractiveLoginSettings
+from quickapp.dial_core_services._login_result import LoginResult
+
+
+def _make_service(
+    client_channel_id: str | None = "test-channel",
+    timeout: float = 120.0,
+) -> InteractiveLoginService:
+    return InteractiveLoginService(
+        api_key=SecretStr("test-key"),
+        dial_settings=DialSettings(url="http://dial-core", api_version="2025-01-01-preview"),
+        client_channel_id=client_channel_id,
+        settings=InteractiveLoginSettings(interactive_login_timeout_seconds=timeout),
+    )
+
+
+class _FakeSSEEvent:
+    def __init__(self, data: str | None = None):
+        self.data = data
+
+
+class _FakeEventSource:
+    """Simulates an httpx-sse event source context manager."""
+
+    def __init__(self, events: list[_FakeSSEEvent], status_code: int = 200):
+        self.events = events
+        self.response = MagicMock()
+        self.response.status_code = status_code
+        if status_code >= 400:
+            self.response.raise_for_status.side_effect = httpx.HTTPStatusError(
+                "error", request=MagicMock(), response=self.response
+            )
+        else:
+            self.response.raise_for_status = MagicMock()
+
+    async def aiter_sse(self):
+        for event in self.events:
+            yield event
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        pass
+
+
+def _patch_sse(event_source: _FakeEventSource):
+    """Patch aconnect_sse to return a fake event source."""
+    mock_client = AsyncMock()
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    return patch(
+        "quickapp.dial_core_services._interactive_login_service.aconnect_sse",
+        return_value=event_source,
+    ), patch(
+        "quickapp.dial_core_services._interactive_login_service.httpx.AsyncClient",
+        return_value=mock_client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_no_channel_returns_no_channel():
+    service = _make_service(client_channel_id=None)
+    result = await service.request_signin_batch(["toolset/a", "toolset/b"])
+    assert result == {"toolset/a": LoginResult.NO_CHANNEL, "toolset/b": LoginResult.NO_CHANNEL}
+
+
+@pytest.mark.asyncio
+async def test_single_success():
+    data = json.dumps([{"jsonrpc": "2.0", "result": "success", "id": "1"}])
+    event_source = _FakeEventSource([_FakeSSEEvent(data)])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.SUCCESS}
+
+
+@pytest.mark.asyncio
+async def test_batch_mixed_results():
+    data = json.dumps(
+        [
+            {"jsonrpc": "2.0", "result": "success", "id": "1"},
+            {"jsonrpc": "2.0", "result": "denied", "id": "2"},
+        ]
+    )
+    event_source = _FakeEventSource([_FakeSSEEvent(data)])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a", "toolset/b"])
+
+    assert result == {"toolset/a": LoginResult.SUCCESS, "toolset/b": LoginResult.DENIED}
+
+
+@pytest.mark.asyncio
+async def test_jsonrpc_error_object():
+    data = json.dumps(
+        [
+            {"jsonrpc": "2.0", "error": {"code": -32600, "message": "Invalid"}, "id": "1"},
+        ]
+    )
+    event_source = _FakeEventSource([_FakeSSEEvent(data)])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.ERROR}
+
+
+@pytest.mark.asyncio
+async def test_missing_entry_returns_error():
+    """If DIAL Core response is missing an entry for a requested toolset, it maps to ERROR."""
+    data = json.dumps([{"jsonrpc": "2.0", "result": "success", "id": "1"}])
+    event_source = _FakeEventSource([_FakeSSEEvent(data)])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a", "toolset/b"])
+
+    assert result["toolset/a"] == LoginResult.SUCCESS
+    assert result["toolset/b"] == LoginResult.ERROR
+
+
+@pytest.mark.asyncio
+async def test_malformed_json_returns_error():
+    event_source = _FakeEventSource([_FakeSSEEvent("not json")])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.ERROR}
+
+
+@pytest.mark.asyncio
+async def test_http_error_returns_error():
+    event_source = _FakeEventSource([], status_code=404)
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.ERROR}
+
+
+@pytest.mark.asyncio
+async def test_timeout_returns_timeout():
+    service = _make_service(timeout=0.01)
+
+    async def slow_interact(*args, **kwargs):
+        import asyncio
+
+        await asyncio.sleep(10)
+
+    with patch.object(service, "_do_interact", side_effect=slow_interact):
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.TIMEOUT}
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_returns_error():
+    """Stream ends without any data events."""
+    event_source = _FakeEventSource([])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.ERROR}
+
+
+@pytest.mark.asyncio
+async def test_request_signin_convenience():
+    """request_signin() delegates to request_signin_batch() and returns scalar."""
+    service = _make_service()
+    mock_result = {"toolset/a": LoginResult.SUCCESS}
+    with patch.object(service, "request_signin_batch", return_value=mock_result) as mock_batch:
+        result = await service.request_signin("toolset/a")
+
+    assert result == LoginResult.SUCCESS
+    mock_batch.assert_awaited_once_with(["toolset/a"])
+
+
+@pytest.mark.asyncio
+async def test_single_result_not_list():
+    """DIAL Core returns a single RPC response object (not a list)."""
+    data = json.dumps({"jsonrpc": "2.0", "result": "success", "id": "1"})
+    event_source = _FakeEventSource([_FakeSSEEvent(data)])
+    service = _make_service()
+
+    sse_patch, client_patch = _patch_sse(event_source)
+    with sse_patch, client_patch:
+        result = await service.request_signin_batch(["toolset/a"])
+
+    assert result == {"toolset/a": LoginResult.SUCCESS}

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_initializer_interactive_login.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_initializer_interactive_login.py
@@ -1,0 +1,291 @@
+"""Tests for multi-phase interactive login in _MCPToolInitializer.initialize()."""
+
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+import pytest
+from aidial_client.types.deployment import Features
+from pydantic import SecretStr
+
+from quickapp.common.dial_core_client import ToolsetInfo
+from quickapp.common.tool_initialization_exception import ToolInitializationException
+from quickapp.config.toolsets.dial_mcp import DialMCPToolSet
+from quickapp.config.toolsets.mcp import MCPProtocol, MCPServerInfo, MCPToolSet
+from quickapp.dial_core_services._login_result import LoginResult
+from quickapp.mcp_tooling._mcp_tool import _MCPTool
+from quickapp.mcp_tooling._mcp_tool_initializer import _MCPToolInitializer
+from quickapp.mcp_tooling._mcp_unauthorized_exception import MCPUnauthorizedException
+
+
+def _make_dial_toolset(dial_id: str = "toolsets/public/ts1", name: str = "ts1") -> DialMCPToolSet:
+    return DialMCPToolSet(
+        dial_id=dial_id,
+        name=name,
+        enabled=True,
+    )
+
+
+def _make_mcp_toolset(name: str = "ext-toolset") -> MCPToolSet:
+    return MCPToolSet(
+        mcp_server_info=MCPServerInfo(
+            url="https://ext-mcp", authorization=None, protocol=MCPProtocol.sse
+        ),
+        name=name,
+    )
+
+
+def _build_tool_side_effect(tool, tool_config, connection_manager=None, **kwargs):
+    return _MCPTool(
+        tool=tool,
+        tool_config=tool_config,
+        connection_manager=connection_manager,
+        stage_wrapper_builder=MagicMock(),
+        dial_attachment_service=MagicMock(),
+        state_holder=MagicMock(),
+        perf_timer=Mock(),
+        file_service=MagicMock(),
+        dial_toolset_id=None,
+        login_service=MagicMock(),
+    )
+
+
+def _make_toolset_info() -> ToolsetInfo:
+    """Create a minimal ToolsetInfo for DialMCPToolSet resolution."""
+    return ToolsetInfo(
+        id="ts1",
+        toolset="toolsets/public/ts1",
+        display_name="ts1",
+        description="test",
+        features=Features(),
+        transport="HTTP",
+    )
+
+
+def _make_initializer(
+    toolset_list,
+    login_service=None,
+    connection_manager_builder=None,
+):
+    mcp_context = MagicMock()
+
+    if connection_manager_builder is None:
+        conn = MagicMock()
+        conn.get_tools_list = AsyncMock(return_value=[])
+        connection_manager_builder = MagicMock()
+        connection_manager_builder.build.return_value = conn
+
+    tool_builder = MagicMock()
+    tool_builder.build.side_effect = _build_tool_side_effect
+
+    if login_service is None:
+        login_service = AsyncMock()
+        login_service.request_signin_batch = AsyncMock(return_value={})
+
+    # api_key_provider must return a SecretStr for DialMCPToolSet resolution
+    api_key_provider = MagicMock()
+    api_key_provider.get.return_value = SecretStr("test-key")
+
+    # dial_mcp_cache must be an AsyncMock since .get() is awaited
+    dial_mcp_cache = AsyncMock()
+    dial_mcp_cache.get = AsyncMock(return_value=_make_toolset_info())
+
+    dial_setting = MagicMock()
+    dial_setting.url = "http://dial-core"
+
+    initializer = _MCPToolInitializer(
+        toolset_list=toolset_list,
+        mcp_context=mcp_context,
+        dial_setting=dial_setting,
+        api_key_provider=api_key_provider,
+        tool_builder=tool_builder,
+        connection_manager_builder=connection_manager_builder,
+        dial_mcp_cache=dial_mcp_cache,
+        tool_config_service=MagicMock(),
+        login_service=login_service,
+    )
+    return initializer, mcp_context, login_service
+
+
+@pytest.mark.asyncio
+async def test_no_401_no_login_called():
+    """When no toolsets return 401, interactive login is never called."""
+    ts = _make_mcp_toolset()
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(return_value=[])
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    initializer, mcp_context, login_service = _make_initializer(
+        [ts], connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    login_service.request_signin_batch.assert_not_awaited()
+    mcp_context.append_exception.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dial_toolset_401_triggers_batch_login():
+    """DialMCPToolSet returning 401 triggers batch interactive login."""
+    ts = _make_dial_toolset(dial_id="toolsets/public/ts1")
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts1"))
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    login_service = AsyncMock()
+    login_service.request_signin_batch = AsyncMock(
+        return_value={"toolsets/public/ts1": LoginResult.DENIED}
+    )
+
+    initializer, mcp_context, _ = _make_initializer(
+        [ts], login_service=login_service, connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    login_service.request_signin_batch.assert_awaited_once_with(["toolsets/public/ts1"])
+    assert mcp_context.append_exception.call_count == 1
+    exc = mcp_context.append_exception.call_args[0][0]
+    assert isinstance(exc, ToolInitializationException)
+    assert "denied" in exc.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_dial_toolset_401_success_retries():
+    """DialMCPToolSet 401 → login SUCCESS → retry succeeds."""
+    ts = _make_dial_toolset(dial_id="toolsets/public/ts1")
+
+    call_count = 0
+
+    async def get_tools_side_effect():
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise MCPUnauthorizedException("ts1")
+        return []  # success on retry
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=get_tools_side_effect)
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    login_service = AsyncMock()
+    login_service.request_signin_batch = AsyncMock(
+        return_value={"toolsets/public/ts1": LoginResult.SUCCESS}
+    )
+
+    initializer, mcp_context, _ = _make_initializer(
+        [ts], login_service=login_service, connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    login_service.request_signin_batch.assert_awaited_once()
+    # No exceptions appended — retry succeeded
+    mcp_context.append_exception.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_retry_failure_appends_exception():
+    """Login SUCCESS but retry still fails → ToolInitializationException appended."""
+    ts = _make_dial_toolset(dial_id="toolsets/public/ts1", name="ts1")
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts1"))
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    login_service = AsyncMock()
+    login_service.request_signin_batch = AsyncMock(
+        return_value={"toolsets/public/ts1": LoginResult.SUCCESS}
+    )
+
+    initializer, mcp_context, _ = _make_initializer(
+        [ts], login_service=login_service, connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    # Retry also throws 401, which _retry_process_toolset catches
+    assert mcp_context.append_exception.call_count == 1
+    exc = mcp_context.append_exception.call_args[0][0]
+    assert isinstance(exc, ToolInitializationException)
+    assert "still failed" in exc.message.lower()
+
+
+@pytest.mark.asyncio
+async def test_plain_mcp_toolset_401_not_eligible():
+    """A plain MCPToolSet returning 401 is NOT eligible for interactive login."""
+    ts = _make_mcp_toolset()
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ext"))
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    initializer, mcp_context, login_service = _make_initializer(
+        [ts], connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    # MCPUnauthorizedException from plain MCPToolSet → logged, not sent to interactive login
+    login_service.request_signin_batch.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_batch_multiple_toolsets():
+    """Multiple DialMCPToolSets fail with 401 → single batch login call."""
+    ts1 = _make_dial_toolset(dial_id="toolsets/public/ts1", name="ts1")
+    ts2 = _make_dial_toolset(dial_id="toolsets/public/ts2", name="ts2")
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts"))
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    login_service = AsyncMock()
+    login_service.request_signin_batch = AsyncMock(
+        return_value={
+            "toolsets/public/ts1": LoginResult.SUCCESS,
+            "toolsets/public/ts2": LoginResult.TIMEOUT,
+        }
+    )
+
+    initializer, mcp_context, _ = _make_initializer(
+        [ts1, ts2], login_service=login_service, connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    # Single batch call with both dial_ids
+    login_service.request_signin_batch.assert_awaited_once()
+    call_args = login_service.request_signin_batch.await_args[0][0]
+    assert set(call_args) == {"toolsets/public/ts1", "toolsets/public/ts2"}
+
+    # ts2 timed out → exception appended
+    exceptions = [c[0][0] for c in mcp_context.append_exception.call_args_list]
+    timeout_excs = [e for e in exceptions if "timed out" in e.message.lower()]
+    assert len(timeout_excs) == 1
+
+
+@pytest.mark.asyncio
+async def test_no_channel_appends_exception():
+    """Login returns NO_CHANNEL → ToolInitializationException with appropriate message."""
+    ts = _make_dial_toolset(dial_id="toolsets/public/ts1", name="ts1")
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts1"))
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    login_service = AsyncMock()
+    login_service.request_signin_batch = AsyncMock(
+        return_value={"toolsets/public/ts1": LoginResult.NO_CHANNEL}
+    )
+
+    initializer, mcp_context, _ = _make_initializer(
+        [ts], login_service=login_service, connection_manager_builder=conn_builder
+    )
+    await initializer.initialize()
+
+    assert mcp_context.append_exception.call_count == 1
+    exc = mcp_context.append_exception.call_args[0][0]
+    assert isinstance(exc, ToolInitializationException)
+    assert "no client channel" in exc.message.lower()

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_pre_process_params.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_pre_process_params.py
@@ -54,6 +54,7 @@ def _make_tool(
         perf_timer=perf_timer,
         file_service=file_service,
         dial_toolset_id=dial_toolset_id,
+        login_service=MagicMock(),
         argument_transformers=[file_transformer],
     )
     return mcp_tool, file_service

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool.py
@@ -11,6 +11,7 @@ from pydantic import AnyUrl, SecretStr
 from starlette.testclient import TestClient
 
 from quickapp.common import (
+    CLIENT_CHANNEL_ID,
     DIAL_API_KEY,
     DIAL_BEARER,
     CompletionResult,
@@ -24,6 +25,7 @@ from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.tools.base import AttachmentConfig
 from quickapp.config.toolsets.mcp import MCPProtocol, MCPServerInfo, MCPToolSet
+from quickapp.dial_core_services._interactive_login_settings import InteractiveLoginSettings
 from quickapp.dial_core_services.attachment_service import AttachmentService
 from quickapp.mcp_tooling import MCPToolingModule
 from tests.unit_tests.common import create_test_app
@@ -123,6 +125,8 @@ async def test_mcp_tool(mock_get_tools_list, mock_call_mcp_tool):
         )
         binder.bind(PerformanceTimer, to=PerformanceTimer)
         binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.bind(CLIENT_CHANNEL_ID, to=InstanceProvider(None))
+        binder.bind(InteractiveLoginSettings, to=InteractiveLoginSettings())
         binder.multibind(list[ToolArgumentTransformer], to=[])
 
     app = create_test_app([MCPToolingModule, configure])
@@ -288,6 +292,8 @@ async def test_mcp_tool_narrow_supported_types_skips_non_matching(
         )
         binder.bind(PerformanceTimer, to=PerformanceTimer)
         binder.bind(ForwardedHeaders, to=InstanceProvider(None))
+        binder.bind(CLIENT_CHANNEL_ID, to=InstanceProvider(None))
+        binder.bind(InteractiveLoginSettings, to=InteractiveLoginSettings())
         binder.multibind(list[ToolArgumentTransformer], to=[])
 
     app = create_test_app([MCPToolingModule, configure])

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
@@ -87,6 +87,7 @@ def mcp_tool1(
         perf_timer=Mock(),
         file_service=MagicMock(),
         dial_toolset_id=None,
+        login_service=MagicMock(),
     )
 
 
@@ -111,6 +112,7 @@ def mcp_tool2(
         perf_timer=Mock(),
         file_service=MagicMock(),
         dial_toolset_id=None,
+        login_service=MagicMock(),
     )
 
 
@@ -142,6 +144,7 @@ def builder_mock():
             perf_timer=Mock(),
             file_service=MagicMock(),
             dial_toolset_id=None,
+            login_service=MagicMock(),
         )
 
     m = MagicMock()
@@ -169,6 +172,7 @@ def initializer_factory(builder_mock, connection_manager_builder):
             connection_manager_builder,
             MagicMock(),  # dial_mcp_cache
             MagicMock(),  # tool_config_service
+            MagicMock(),  # login_service
         )
         return initializer, mcp_context
 
@@ -252,6 +256,7 @@ async def test_initialize_multiple_toolsets(tool1, tool2, builder_mock):
         connection_manager_builder,
         MagicMock(),  # dial_mcp_cache
         MagicMock(),  # tool_config_service
+        MagicMock(),  # login_service
     )
 
     await initializer.initialize()
@@ -333,6 +338,7 @@ async def test_no_exception_if_toolset_list_is_empty():
         MagicMock(),  # connection_manager_builder
         MagicMock(),  # dial_mcp_cache
         MagicMock(),  # tool_config_service
+        MagicMock(),  # login_service
     )
     await initializer.initialize()
     mcp_context.append_tool.assert_not_called()

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_interactive_login.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_interactive_login.py
@@ -1,0 +1,126 @@
+"""Tests for interactive login retry in _MCPTool._run_in_stage_async."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from quickapp.common import CompletionResult
+from quickapp.dial_core_services._login_result import LoginResult
+from quickapp.mcp_tooling._mcp_tool import _MCPTool
+from quickapp.mcp_tooling._mcp_unauthorized_exception import MCPUnauthorizedException
+
+
+def _make_mcp_tool(
+    *,
+    dial_toolset_id: str | None = "toolsets/public/ts1",
+    login_result: LoginResult = LoginResult.SUCCESS,
+) -> tuple[_MCPTool, AsyncMock, AsyncMock]:
+    """Create an _MCPTool with mocked dependencies. Returns (tool, connection_manager, login_service)."""
+    tool_meta = SimpleNamespace(
+        name="test_tool",
+        description="test",
+        inputSchema={"type": "object", "properties": {}},
+    )
+    tool_config = MagicMock()
+    tool_config.attachment.supported_types = []
+
+    connection_manager = AsyncMock()
+    login_service = AsyncMock()
+    login_service.request_signin = AsyncMock(return_value=login_result)
+
+    mcp_tool = _MCPTool(
+        tool=tool_meta,
+        tool_config=tool_config,
+        connection_manager=connection_manager,
+        stage_wrapper_builder=MagicMock(),
+        state_holder=MagicMock(),
+        dial_attachment_service=MagicMock(),
+        perf_timer=MagicMock(),
+        file_service=MagicMock(),
+        dial_toolset_id=dial_toolset_id,
+        login_service=login_service,
+    )
+    return mcp_tool, connection_manager, login_service
+
+
+def _ok_result():
+    return SimpleNamespace(content=[SimpleNamespace(type="text", text="ok")], isError=False)
+
+
+@pytest.mark.asyncio
+async def test_successful_call_no_login():
+    """Normal tool call — no 401, no interactive login."""
+    tool, conn, login = _make_mcp_tool()
+    conn.call_mcp_tool.return_value = _ok_result()
+
+    result = await tool._run_in_stage_async(None)
+
+    assert isinstance(result, CompletionResult)
+    assert result.content == "ok"
+    login.request_signin.assert_not_awaited()
+    conn.call_mcp_tool.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_401_triggers_login_and_retry():
+    """401 on first call → login → retry succeeds."""
+    tool, conn, login = _make_mcp_tool(login_result=LoginResult.SUCCESS)
+    conn.call_mcp_tool.side_effect = [MCPUnauthorizedException("ts1"), _ok_result()]
+
+    result = await tool._run_in_stage_async(None)
+
+    assert result.content == "ok"
+    login.request_signin.assert_awaited_once_with("toolsets/public/ts1")
+    assert conn.call_mcp_tool.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_401_login_denied_raises():
+    """401 → login returns DENIED → exception propagates."""
+    tool, conn, login = _make_mcp_tool(login_result=LoginResult.DENIED)
+    conn.call_mcp_tool.side_effect = MCPUnauthorizedException("ts1")
+
+    with pytest.raises(MCPUnauthorizedException):
+        await tool._run_in_stage_async(None)
+
+    login.request_signin.assert_awaited_once()
+    conn.call_mcp_tool.assert_awaited_once()  # no retry
+
+
+@pytest.mark.asyncio
+async def test_401_no_dial_toolset_id_raises():
+    """401 with no dial_toolset_id → exception propagates without login attempt."""
+    tool, conn, login = _make_mcp_tool(dial_toolset_id=None)
+    conn.call_mcp_tool.side_effect = MCPUnauthorizedException("ts1")
+
+    with pytest.raises(MCPUnauthorizedException):
+        await tool._run_in_stage_async(None)
+
+    login.request_signin.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_401_on_retry_propagates():
+    """401 on first call → login succeeds → 401 on retry → propagates."""
+    tool, conn, login = _make_mcp_tool(login_result=LoginResult.SUCCESS)
+    conn.call_mcp_tool.side_effect = [
+        MCPUnauthorizedException("ts1"),
+        MCPUnauthorizedException("ts1"),
+    ]
+
+    with pytest.raises(MCPUnauthorizedException):
+        await tool._run_in_stage_async(None)
+
+    assert conn.call_mcp_tool.await_count == 2
+    login.request_signin.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_401_no_channel_raises():
+    """401 → login returns NO_CHANNEL → exception propagates."""
+    tool, conn, login = _make_mcp_tool(login_result=LoginResult.NO_CHANNEL)
+    conn.call_mcp_tool.side_effect = MCPUnauthorizedException("ts1")
+
+    with pytest.raises(MCPUnauthorizedException):
+        await tool._run_in_stage_async(None)


### PR DESCRIPTION
### Applicable issues

- fixes #191

### Description of changes

When a DIAL MCP toolset requires authentication, QuickApp now requests interactive sign-in from the user mid-request instead of failing with an error.

**How it works:** If an MCP server returns 401 during initialization or tool execution, QuickApp calls DIAL Core's `/v1/ops/client-channel/interact` endpoint — which notifies the client (via a pre-established SSE channel) to complete login. On success, the failing operation is retried once.

**Key design decisions:**
- During initialization, all 401 failures are collected and sent as a **single batched** interact request — so the user sees one prompt even if multiple toolsets need login.
- During tool execution, each tool handles its own 401 independently (DIAL Core deduplicates server-side).
- The SDK's built-in `heartbeat_interval` keeps the response stream alive during the wait.
- Only `DialMCPToolSet` participates; plain `MCPToolSet` and requests without `X-DIAL-CLIENT-CHANNEL-ID` are unaffected.

Full design: `docs/designs/interactive_login.md`

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Design documented is updated/created and approved by the team (if applicable)
- [X] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
