### PR TITLE
fix: configuration parameter handling in deployment tools #198

### DIFF
--- a/src/quickapp/config/dial_deployment.py
+++ b/src/quickapp/config/dial_deployment.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, PrivateAttr
 
 
 class CustomFieldsConfig(BaseModel):
@@ -57,3 +57,4 @@ class DialDeploymentConfig(BaseModel):
         default_factory=DialDeploymentParameters,
         description="The predefined parameters for the DIAL deployment.",
     )
+    _configuration_param_names: set[str] = PrivateAttr(default_factory=set)

--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -132,10 +132,12 @@ class ToolConfigCoreService:
 
             required_params.append("attachment_urls")
 
+        configuration_param_names: set[str] = set()
         if config and config.get("properties"):
             config_required = set(config.get("required", []))
             for param_name, param_details in config["properties"].items():
                 logger.debug(f"Processing parameter: {param_name} with details: {param_details}")
+                configuration_param_names.add(param_name)
                 # Extract enum values from the 'anyOf' structure
                 enum_values = []
                 if "anyOf" in param_details:
@@ -155,6 +157,7 @@ class ToolConfigCoreService:
 
         output_tool.open_ai_tool.function.parameters.properties = properties
         output_tool.open_ai_tool.function.parameters.required = sorted(set(required_params))
+        output_tool.deployment._configuration_param_names = configuration_param_names
 
         return output_tool
 

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -19,7 +19,11 @@ from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import to_plain_dict
 from quickapp.config.dial_deployment import DialDeploymentParameters
 from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
-from quickapp.dial_deployment_tooling.constants import ATTACHMENT_PARAM, CONTENT_PARAM
+from quickapp.dial_deployment_tooling.constants import (
+    ATTACHMENT_PARAM,
+    CONFIGURATION,
+    CONTENT_PARAM,
+)
 from quickapp.dial_deployment_tooling.dial_completion_service import DialCompletionService
 
 from .deployment_stage_wrapper import DeploymentStageWrapper
@@ -168,12 +172,36 @@ class BaseDeploymentTool(StagedBaseTool):
 
         prepared: dict[str, Any] = {}
 
+        tool_config = cast(DialDeploymentTool, self.tool_config)
+        config_param_names = tool_config.deployment._configuration_param_names
+
         # If tool config defines defaults, normalize them first
-        params = self.tool_config.deployment.parameters
+        params = tool_config.deployment.parameters
         self._merge_to_prepared_params(params, prepared)
 
-        # Now process runtime kwargs - these should override defaults
-        prepared.update(kwargs)
+        # Split LLM kwargs: configuration params vs standard params
+        config_kwargs: dict[str, Any] = {}
+        other_kwargs: dict[str, Any] = {}
+        for k, v in kwargs.items():
+            if k in config_param_names:
+                config_kwargs[k] = v
+            else:
+                other_kwargs[k] = v
+
+        # Wrap configuration params into custom_fields.configuration, merging with defaults
+        if config_kwargs:
+            custom_fields = prepared.get("custom_fields", {})
+            if not isinstance(custom_fields, dict):
+                custom_fields = {}
+            configuration = custom_fields.get(CONFIGURATION, {})
+            if not isinstance(configuration, dict):
+                configuration = {}
+            configuration.update(config_kwargs)
+            custom_fields[CONFIGURATION] = configuration
+            prepared["custom_fields"] = custom_fields
+
+        # Standard params override defaults as flat keys
+        prepared.update(other_kwargs)
 
         logger.debug(f"Pre-processed tool parameters: {prepared}")
 

--- a/src/quickapp/dial_deployment_tooling/dial_completion_service.py
+++ b/src/quickapp/dial_deployment_tooling/dial_completion_service.py
@@ -1,5 +1,5 @@
 import logging
-from collections.abc import AsyncIterable, Iterable
+from collections.abc import AsyncIterable
 from typing import Any
 
 from aidial_client import AsyncDial
@@ -19,10 +19,8 @@ from quickapp.common import CompletionResult, ForwardedHeaders
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.deployment_usage import DeploymentUsage
 from quickapp.common.file_reference_pattern import strip_file_prefix
-from quickapp.common.utils import to_plain_dict
 from quickapp.dial_deployment_tooling.constants import (
     ATTACHMENT_PARAM,
-    CONFIGURATION,
     CONTENT_PARAM,
     EXTRA_BODY,
     EXTRA_HEADERS,
@@ -54,21 +52,6 @@ class DialCompletionService:
     def __init__(self, dial_client: AsyncDial, forwarded_headers: ForwardedHeaders) -> None:
         self.__dial_client: AsyncDial = dial_client
         self.__forwarded_headers: ForwardedHeaders = forwarded_headers
-
-    @staticmethod
-    def _prepare_custom_fields(items: Iterable[tuple[str, Any]]) -> dict[str, Any] | None:
-        # kept for backward compatibility in rare cases
-        normalized: dict[str, Any] = {}
-        for k, v in items:
-            if k == CONTENT_PARAM or k == ATTACHMENT_PARAM:
-                continue
-            n = to_plain_dict(v)
-            if n == {}:
-                continue
-            normalized[k] = n
-        if normalized:
-            return {CONFIGURATION: normalized}
-        return None
 
     async def complete_request_async(
         self,

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -54,3 +54,32 @@ def test_no_input_attachment_types_no_attachment_urls_param():
     result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
 
     assert "attachment_urls" not in result.open_ai_tool.function.parameters.properties
+
+
+def test_config_schema_populates_configuration_param_names():
+    deployment = _make_deployment()
+    config = {
+        "properties": {
+            "size": {"type": "string", "description": "Image size"},
+            "quality": {"type": "string", "description": "Image quality"},
+        },
+        "required": ["size"],
+    }
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment, config)
+
+    assert result.deployment._configuration_param_names == {"size", "quality"}
+
+
+def test_no_config_leaves_configuration_param_names_empty():
+    deployment = _make_deployment()
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+
+    assert result.deployment._configuration_param_names == set()
+
+
+def test_config_without_properties_leaves_configuration_param_names_empty():
+    deployment = _make_deployment()
+    config = {"required": ["size"]}
+    result = ToolConfigCoreService._convert_to_openai_tool_format(deployment, config)
+
+    assert result.deployment._configuration_param_names == set()

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -8,6 +8,19 @@ from aidial_sdk.chat_completion.request import Attachment as SdkAttachment
 from aidial_sdk.chat_completion.request import CustomContent, FunctionCall, ToolCall
 from pydantic import StrictStr
 
+from quickapp.config.dial_deployment import (
+    CustomFieldsConfig,
+    DialDeploymentConfig,
+    DialDeploymentParameters,
+)
+from quickapp.config.tools.base import (
+    ConfigurableSchemaSimpleType,
+    JsonTypeEnum,
+    OpenAiToolConfig,
+    OpenAiToolFunction,
+    OpenAiToolFunctionParameters,
+)
+from quickapp.config.tools.deployment import DialDeploymentTool
 from quickapp.dial_deployment_tooling.base_deployment_tool import BaseDeploymentTool
 
 
@@ -317,3 +330,110 @@ async def test_extract_resolves_request_attachments():
     assert cc["attachments"][0]["title"] == "doc.pdf"
 
     mock_service.resolve_attachment_urls.assert_awaited_once_with(["files/xyz/doc.pdf"])
+
+
+def _make_tool_config(
+    parameters: DialDeploymentParameters | None = None,
+    configuration_param_names: set[str] | None = None,
+) -> DialDeploymentTool:
+    """Build a real DialDeploymentTool for _pre_process_params tests."""
+    deployment = DialDeploymentConfig(
+        name="test-deployment",
+        parameters=parameters or DialDeploymentParameters(),
+    )
+    if configuration_param_names:
+        deployment._configuration_param_names = configuration_param_names
+    return DialDeploymentTool(
+        deployment=deployment,
+        open_ai_tool=OpenAiToolConfig(
+            function=OpenAiToolFunction(
+                name="test_tool",
+                description="A test tool",
+                parameters=OpenAiToolFunctionParameters(
+                    type=JsonTypeEnum.object,
+                    properties={
+                        "query": ConfigurableSchemaSimpleType(
+                            type=JsonTypeEnum.string, description="The query"
+                        ),
+                    },
+                    required=["query"],
+                ),
+            )
+        ),
+    )
+
+
+def _build_tool_with_config(
+    tool_config: DialDeploymentTool,
+    messages: list[Message] | None = None,
+) -> BaseDeploymentTool:
+    """Build a BaseDeploymentTool with a real tool_config for _pre_process_params tests."""
+    return BaseDeploymentTool(
+        application_id="test-app",
+        application_name="Test App",
+        tool_config=tool_config,
+        content_propagation=None,
+        dial_completion_service=MagicMock(),
+        messages=messages or [],
+        perf_timer=MagicMock(),
+        stage_wrapper_builder=MagicMock(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_pre_process_params_wraps_config_params():
+    """Configuration params are wrapped into custom_fields.configuration."""
+    tool_config = _make_tool_config(configuration_param_names={"size", "quality"})
+    tool = _build_tool_with_config(tool_config)
+
+    result = await tool._pre_process_params(query="draw a cat", size="1024x1024", quality="high")
+
+    assert result["query"] == "draw a cat"
+    assert result["custom_fields"]["configuration"]["size"] == "1024x1024"
+    assert result["custom_fields"]["configuration"]["quality"] == "high"
+    assert "size" not in {k for k in result if k != "custom_fields"}
+    assert "quality" not in {k for k in result if k != "custom_fields"}
+
+
+@pytest.mark.asyncio
+async def test_pre_process_params_merges_defaults_with_llm_config():
+    """LLM config params override defaults; unset defaults are preserved."""
+    params = DialDeploymentParameters(
+        custom_fields=CustomFieldsConfig(configuration={"size": "512x512", "style": "natural"})
+    )
+    tool_config = _make_tool_config(
+        parameters=params, configuration_param_names={"size", "quality"}
+    )
+    tool = _build_tool_with_config(tool_config)
+
+    result = await tool._pre_process_params(query="draw", size="1024x1024")
+
+    config = result["custom_fields"]["configuration"]
+    assert config["size"] == "1024x1024"  # LLM overrides default
+    assert config["style"] == "natural"  # default preserved
+
+
+@pytest.mark.asyncio
+async def test_pre_process_params_no_config_names_stays_flat():
+    """With no configuration_param_names, all kwargs remain flat (backward compat)."""
+    tool_config = _make_tool_config()
+    tool = _build_tool_with_config(tool_config)
+
+    result = await tool._pre_process_params(query="draw", custom_key="value")
+
+    assert result["query"] == "draw"
+    assert result["custom_key"] == "value"
+    assert "custom_fields" not in result
+
+
+@pytest.mark.asyncio
+async def test_pre_process_params_standard_params_stay_flat():
+    """Standard API params like temperature stay flat even when config params exist."""
+    tool_config = _make_tool_config(configuration_param_names={"size"})
+    tool = _build_tool_with_config(tool_config)
+
+    result = await tool._pre_process_params(query="draw", size="1024x1024", temperature=0.7)
+
+    assert result["temperature"] == 0.7
+    assert "temperature" not in result.get("custom_fields", {}).get("configuration", {})
+    assert result["custom_fields"]["configuration"]["size"] == "1024x1024"

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_completion_service.py
@@ -333,3 +333,28 @@ async def test_forwarded_x_headers_passed_to_chat_completion(dial_client, mock_s
     extra_headers = call_args[EXTRA_HEADERS]
     assert extra_headers["X-Request-Id"] == "deploy-req-789"
     assert extra_headers["X-Deployment-Custom"] == "deploy-val"
+
+
+@pytest.mark.asyncio
+async def test_custom_fields_configuration_routed_to_extra_body(
+    completion_service, dial_client, mock_stage_wrapper
+):
+    """Pre-wrapped custom_fields.configuration appears correctly nested in extra_body."""
+    await completion_service.complete_request_async(
+        params={
+            "query": "Test query",
+            "temperature": 0.7,
+            "custom_fields": {"configuration": {"size": "1024x1024", "quality": "high"}},
+        },
+        deployment_id="test-deployment",
+        deployment_name="Test Deployment",
+        stage_wrapper=mock_stage_wrapper,
+    )
+
+    call_args = dial_client.chat.completions.create.call_args[1]
+    extra_body = call_args[EXTRA_BODY]
+    assert extra_body["temperature"] == 0.7
+    assert extra_body["custom_fields"] == {
+        "configuration": {"size": "1024x1024", "quality": "high"}
+    }
+    assert "query" not in extra_body


### PR DESCRIPTION
### Applicable issues

- fixes #198

### Description of changes

Deployment configuration parameters (e.g. `size`, `quality` for image generation) were sent as flat keys in `extra_body` instead of being nested under `custom_fields.configuration` as required by the DIAL API spec.

The fix tracks which tool parameters originate from the deployment's configuration schema and routes them into `custom_fields.configuration` at request time, while keeping standard API params (like `temperature`) as flat keys.

Also removed the unused `_prepare_custom_fields` method from `DialCompletionService`.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes are tested on review environment
- [X] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [X] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
