### PR TITLE
fix: py interpreter session handling #208

### DIFF
--- a/config/predefined/tool/py_interpreter.json
+++ b/config/predefined/tool/py_interpreter.json
@@ -9,7 +9,7 @@
     "type": "function",
     "function": {
       "name": "python_code_interpreter",
-      "description": "**Python Code Interpreter**  \nExecutes Python 3.11 code using Jupyter Kernel with such libraries: \n- python-multipart\n- pandas[excel, plot, output-formatting]\n- plotly\n- matplotlib\n- seaborn\n- scipy\n\n**Workflow:**\n- Single persistent session throughout conversation.\n- Code state persists and is reusable within session.\n- Session expires after 15min inactivity, deleting all code/files.\n- User files must be listed in `input_file_names` to be accessible.\n- Text outputs are sampled. Control with `data_sample_config`.\n- Web access is DISABLED.\n\n**Instructions:**\n- Use ONLY listed above external libraries.\n- Prefer `plotly` library over `matplotlib` for data visualizations, unless user asked otherwise.\n- Reuse code in session.\n- Use `open_session=true` to create new session if expired (automatic, no user prompt).\n\n**Response:**\n- `status`: SUCCESS/FAILED\n- `stdout`: Console output\n- `stderr`: Error details\n- `result`: Execution result\n- `display`: Images/Plotly diagrams",
+      "description": "**Python Code Interpreter**  \nExecutes Python 3.11 code using Jupyter Kernel with such libraries: \n- python-multipart\n- pandas[excel, plot, output-formatting]\n- plotly\n- matplotlib\n- seaborn\n- scipy\n\n**Workflow:**\n- Single persistent session throughout conversation.\n- Code state persists and is reusable within session.\n- Session expires after 15min inactivity, deleting all code/files.\n- User files must be listed in `attachment_urls` to be accessible.\n- Text outputs are sampled. Control with `data_sample_config`.\n- Web access is DISABLED.\n\n**Instructions:**\n- Use ONLY listed above external libraries.\n- Prefer `plotly` library over `matplotlib` for data visualizations, unless user asked otherwise.\n- Reuse code in session.\n\n**Response:**\n- `status`: SUCCESS/FAILED\n- `stdout`: Console output\n- `stderr`: Error details\n- `result`: Execution result\n- `display`: Images/Plotly diagrams",
       "parameters": {
         "type": "object",
         "properties": {
@@ -42,23 +42,12 @@
               }
             }
           },
-          "open_session": {
-            "type": "boolean",
-            "description": "When true, creates a new Jupyter session if the previous one expired after 15 minutes of inactivity. Use this parameter to recover from expired sessions without prompting the user. Note: New sessions have no access to code or files from previous sessions.",
-            "default": false,
-            "display": {
-              "stage": {
-                "ignore_parameter_name": true,
-                "replaced_value_info": "**New session will be opened!**"
-              }
-            }
-          },
           "attachment_urls": {
             "type": "array",
             "items": {
               "type": "string"
             },
-            "description": "List of filenames that your code needs to access from user-uploaded files. Files must be explicitly listed here to be accessible in code. If a 'file not found' error occurs, verify the filename is correctly included in this parameter.",
+            "description": "List of URLs of user-uploaded files that your code needs to access. Files listed here are transferred into the working directory and become accessible by their original filename. Reference them in code using just the filename, not the full path.\n\nExample 1: attachment_urls=[\"files/abc123/uploads/2026-03/sales_data.csv\"] → in code use: pd.read_csv(\"sales_data.csv\")\nExample 2: attachment_urls=[\"files/abc123/uploads/2026-03/My%20Report.xlsx\"] → in code use: pd.read_excel(\"My Report.xlsx\")",
             "default": [],
             "display": {
               "stage": {

--- a/docker_compose_files/core/configuration/applications.json
+++ b/docker_compose_files/core/configuration/applications.json
@@ -215,6 +215,42 @@
           }
         ]
       }
+    },
+    "quickapp_with_code_interpreter": {
+      "displayName": "QuickApp with code interpreter",
+      "description": "Sample QuickApp that has access to PyInterpreter tool",
+      "applicationTypeSchemaId": "https://mydial.epam.com/custom_application_schemas/quickapps2",
+      "inputAttachmentTypes": [
+        "*/*"
+      ],
+      "applicationProperties": {
+        "orchestrator": {
+          "deployment": {
+            "name": "anthropic.claude-sonnet-4-6"
+          },
+          "system_prompt": {
+            "type": "custom",
+            "variables": {},
+            "content": "You are an AI assistant that helps people find information and execute python code using PyInterpreter tool. Always format your responses in markdown."
+          }
+        },
+        "contexts": [],
+        "tool_sets": [
+          {
+            "type": "predefined",
+            "template_name": "py_interpreter"
+          }
+        ],
+        "conversation_starters": {
+          "intro_text": "What would you like to talk about?",
+          "starters": [
+            {
+              "title": "Calculate Fibonacci sequence",
+              "text": "Calculate Fibonacci sequence up to 10 using PyInterpreter tool."
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_constants.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_constants.py
@@ -1,6 +1,7 @@
 from quickapp.common.media_types import MediaTypes
 
-SESSION_ID_KEY = "py_interpreter_session_id"
+SESSION_ID_KEY = "py_interpreter_session_id"  # legacy, kept for backward compat
+PY_INTERPRETER_STATE_KEY = "py_interpreter_state"
 
 SUPPORTED_DISPLAY_MEDIA_TYPES = frozenset(
     [

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_py_interpreter_tool.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_py_interpreter_tool.py
@@ -1,4 +1,6 @@
+import os
 from typing import Any
+from urllib.parse import unquote
 
 from aidial_sdk.chat_completion import Attachment, Message, Role
 from injector import AssistedBuilder, inject
@@ -85,9 +87,13 @@ class _PyInterpreterTool(StagedBaseTool):
     ) -> CompletionResult:
         try:
             code: str = kwargs["code"]
-            open_session: bool = kwargs.get("open_session", False)
             attachment_urls: list[str] | None = kwargs.get("attachment_urls")
-            data_sample_config: DataSampleConfig | None = kwargs.get("data_sample_config")
+            raw_data_sample_config = kwargs.get("data_sample_config")
+            data_sample_config: DataSampleConfig | None = (
+                DataSampleConfig.model_validate(raw_data_sample_config)
+                if raw_data_sample_config is not None
+                else None
+            )
             display_title: str | None = kwargs.get("display_title")
 
             async with self.__client as client:
@@ -95,9 +101,7 @@ class _PyInterpreterTool(StagedBaseTool):
                     self.__session_manager.get_session_id()
                     or self.__py_interpreter_settings.default_session_id
                 )
-                session_id = await self.__session_manager.ensure_valid_session(
-                    session_id, open_session
-                )
+                session_id = await self.__session_manager.ensure_valid_session(session_id)
 
                 await self._prepare_input_files(
                     client=client,
@@ -160,7 +164,9 @@ class _PyInterpreterTool(StagedBaseTool):
 
         # Transfer each required file that's not already loaded
         for file_name in attachment_urls:
-            if file_name in loaded_file_names:
+            target_path = unquote(os.path.basename(file_name))
+
+            if target_path in loaded_file_names:
                 continue
 
             for attachment_url, attachment in attachments_urls_map.items():
@@ -180,7 +186,7 @@ class _PyInterpreterTool(StagedBaseTool):
                         InputFileTransferDto(
                             sessionId=session_id,
                             sourceUrl=url,
-                            targetPath=file_name,
+                            targetPath=target_path,
                         )
                     )
                     break

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/session_manager.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/session_manager.py
@@ -1,52 +1,83 @@
+import logging
+
 from aidial_sdk.chat_completion import Message, Role
 from injector import inject
 
-from quickapp.internal_tooling.py_interpreter_tooling._constants import SESSION_ID_KEY
+from quickapp.common.state_holder import StateHolder
+from quickapp.internal_tooling.py_interpreter_tooling._constants import (
+    PY_INTERPRETER_STATE_KEY,
+    SESSION_ID_KEY,
+)
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_client import (
     _PyInterpreterClient,
     _PyInterpreterSessionError,
 )
-from quickapp.internal_tooling.py_interpreter_tooling.model.common import PyInterpreterSession
+from quickapp.internal_tooling.py_interpreter_tooling.model.common import (
+    PyInterpreterSession,
+    PyInterpreterState,
+)
+
+logger = logging.getLogger(__name__)
 
 
 @inject
 class SessionManager:
     """Manages Python interpreter sessions"""
 
-    def __init__(self, client: _PyInterpreterClient, messages: list[Message]):
+    def __init__(
+        self, client: _PyInterpreterClient, messages: list[Message], state_holder: StateHolder
+    ):
         self.__client: _PyInterpreterClient = client
         self.__messages: list[Message] = messages
+        self.__state_holder: StateHolder = state_holder
+        self.__validated_session_id: str | None = None
 
     def get_session_id(self) -> str | None:
-        """Retrieves the session ID from message history"""
+        """Retrieves the session ID, checking StateHolder first (within-request),
+        then falling back to message history (across-request)."""
+        # Fast path: StateHolder (already validated in this request)
+        current_state = self.__state_holder.get_state()
+        if raw := current_state.get(PY_INTERPRETER_STATE_KEY):
+            return PyInterpreterState.model_validate(raw).session_id
+
+        # Scan message history in a single pass for both new and legacy keys
         for msg in reversed(self.__messages):
             if msg.role == Role.ASSISTANT and msg.custom_content:
                 state = msg.custom_content.state
-                if isinstance(state, dict) and state.get(SESSION_ID_KEY):
-                    return state.get(SESSION_ID_KEY)
+                if isinstance(state, dict):
+                    if raw := state.get(PY_INTERPRETER_STATE_KEY):
+                        return PyInterpreterState.model_validate(raw).session_id
+                    if session_id := state.get(SESSION_ID_KEY):
+                        return session_id
 
         return None
 
-    async def ensure_valid_session(self, session_id: str | None, open_session: bool) -> str:
+    async def ensure_valid_session(self, session_id: str | None) -> str:
         """Ensures a valid session exists or creates a new one"""
         if not session_id:
             return await self._open_session()
 
+        # Skip network validation if already validated in this request
+        if session_id == self.__validated_session_id:
+            return session_id
+
         # Validate existing session
         try:
             await self.__client.check_session_opened(PyInterpreterSession(sessionId=session_id))
-        except _PyInterpreterSessionError as e:
-            if open_session:
-                return await self._open_session()
-            else:
-                raise e
+        except _PyInterpreterSessionError:
+            logger.info("Session %s is no longer valid, opening a new one", session_id)
+            return await self._open_session()
 
         # Session is opened and can be used
+        self._persist_state(PyInterpreterState(session_id=session_id))
+        self.__validated_session_id = session_id
         return session_id
 
     async def _open_session(self) -> str:
         session: PyInterpreterSession = await self.__client.open_session()
         if session.sessionId:
+            self._persist_state(PyInterpreterState(session_id=session.sessionId))
+            self.__validated_session_id = session.sessionId
             return session.sessionId
         raise ValueError(
             "After session opening in Python Code Interpreter the 'session_id' is None"
@@ -54,3 +85,8 @@ class SessionManager:
 
     async def close_session(self, session_id: str):
         await self.__client.close_session(PyInterpreterSession(sessionId=session_id))
+
+    def _persist_state(self, interpreter_state: PyInterpreterState) -> None:
+        self.__state_holder.add_state(
+            PY_INTERPRETER_STATE_KEY, interpreter_state.model_dump(exclude_none=True)
+        )

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/model/args.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/model/args.py
@@ -11,7 +11,6 @@ class InterpreterParameters(BaseModel):
     """Data class for execution inputs with Pydantic validation"""
 
     code: str
-    open_session: bool = Field(default=False)
     # FIXME: error: Argument "default_factory" to "Field" has incompatible type "type[list[_T]]"; expected "Callable[[], Never] | Callable[[dict[str, Any]], Never]"  [arg-type]
     attachment_urls: list[str] | None = Field(default=None)
     data_sample_config: DataSampleConfig | None = Field(default=None)

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/model/common.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/model/common.py
@@ -3,3 +3,7 @@ from pydantic import BaseModel, Field
 
 class PyInterpreterSession(BaseModel):
     sessionId: str | None = Field(default=None)
+
+
+class PyInterpreterState(BaseModel):
+    session_id: str | None = Field(default=None)

--- a/src/tests/unit_tests/internal_tooling_tests/test_display_content_processor.py
+++ b/src/tests/unit_tests/internal_tooling_tests/test_display_content_processor.py
@@ -1,0 +1,126 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from quickapp.common.media_types import MediaTypes
+from quickapp.internal_tooling.py_interpreter_tooling.handlers.display_content_processor import (
+    DisplayContentProcessor,
+)
+from quickapp.internal_tooling.py_interpreter_tooling.model.response import CodeExecutionResponse
+
+
+def _make_processor() -> DisplayContentProcessor:
+    dial_settings = MagicMock()
+    dial_settings.url = "http://test"
+    api_key = MagicMock()
+    return DisplayContentProcessor(dial_settings=dial_settings, api_key=api_key)
+
+
+def _mock_put_file(url: str = "http://test/bucket/file.png"):
+    mock_client = AsyncMock()
+    mock_client.put_file = AsyncMock(return_value={"url": url})
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+    return patch(
+        "quickapp.internal_tooling.py_interpreter_tooling.handlers.display_content_processor.DialCoreClient",
+        return_value=mock_client,
+    )
+
+
+@pytest.mark.asyncio
+async def test_single_attachment_with_display_title():
+    processor = _make_processor()
+    display = [{MediaTypes.PNG: "dGVzdA=="}]
+
+    with _mock_put_file("http://test/bucket/chart.png"):
+        result = await processor.process_display_content(display, display_title="Sales Chart")
+
+    assert len(result) == 1
+    assert result[0].title == "Sales Chart"
+    assert result[0].url == "http://test/bucket/chart.png"
+    assert result[0].type == MediaTypes.PNG
+
+
+@pytest.mark.asyncio
+async def test_multiple_attachments_with_display_title():
+    processor = _make_processor()
+    display = [
+        {MediaTypes.PNG: "dGVzdA==", MediaTypes.PLOTLY: {"data": [], "layout": {}}},
+    ]
+
+    with _mock_put_file("http://test/bucket/file"):
+        result = await processor.process_display_content(display, display_title="My Chart")
+
+    assert len(result) == 2
+    assert result[0].title == "My Chart (1)"
+    assert result[1].title == "My Chart (2)"
+
+
+@pytest.mark.asyncio
+async def test_no_display_title():
+    processor = _make_processor()
+    display = [{MediaTypes.PNG: "dGVzdA=="}]
+
+    with _mock_put_file("http://test/bucket/file.png"):
+        result = await processor.process_display_content(display)
+
+    assert len(result) == 1
+    assert result[0].title is None
+
+
+@pytest.mark.asyncio
+async def test_multiple_display_items_with_title():
+    processor = _make_processor()
+    display = [
+        {MediaTypes.PNG: "dGVzdA=="},
+        {MediaTypes.JPEG: "dGVzdA=="},
+    ]
+
+    with _mock_put_file("http://test/bucket/file"):
+        result = await processor.process_display_content(display, display_title="Results")
+
+    assert len(result) == 2
+    assert result[0].title == "Results (1)"
+    assert result[1].title == "Results (2)"
+
+
+@pytest.mark.asyncio
+async def test_empty_display_content():
+    processor = _make_processor()
+
+    with _mock_put_file():
+        result = await processor.process_display_content([], display_title="Title")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_unsupported_media_type_skipped():
+    processor = _make_processor()
+    display = [{"text/html": "<h1>hi</h1>"}]
+
+    with _mock_put_file():
+        result = await processor.process_display_content(display, display_title="Title")
+
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_sanitize_display_content():
+    processor = _make_processor()
+    response = CodeExecutionResponse(
+        status="SUCCESS",
+        display=[
+            {
+                MediaTypes.PLAIN_TEXT: "some text",
+                MediaTypes.PNG: "dGVzdA==",
+                MediaTypes.PLOTLY: {"data": []},
+            }
+        ],
+    )
+
+    result = processor.sanitize_display_content(response)
+
+    assert result.display[0][MediaTypes.PLAIN_TEXT] == "some text"
+    assert result.display[0][MediaTypes.PNG] == "Content will be presented as attachment"
+    assert result.display[0][MediaTypes.PLOTLY] == "Content will be presented as attachment"


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #208

### Description of changes

<!-- Please explain the changes you made right below this line. -->

File uploads to Python Code Interpreter were completely broken — uploaded files were never accessible to executed code.

**Three bugs fixed:**

1. **Session not persisted** — each tool call opened a new session because the session ID was never written to `StateHolder`. Files transferred in one iteration were lost in the next. Now `SessionManager` persists session state via `StateHolder` as a structured `PyInterpreterState` model, surviving both within-request iterations and across requests.

2. **Wrong file path** — `targetPath` used the full DIAL storage path (`files/bucket/uploads/date/file.csv`) instead of just the filename. Fixed with `unquote(os.path.basename(...))`.

3. **`data_sample_config` crash** — LLM sends a raw dict but code accessed it with attribute syntax. Fixed by parsing via `model_validate()`.

**Cleanup:** removed dead `open_session` parameter (session recovery is now automatic), updated `attachment_urls` description with examples.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] Changes are tested locally against dev code interpreter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
