### PR TITLE
fix: refactor message handling to use MessagesMixin across multiple tools #211

### DIFF
--- a/src/quickapp/attachment_processing/_available_context_tool.py
+++ b/src/quickapp/attachment_processing/_available_context_tool.py
@@ -1,7 +1,6 @@
 import json
 from typing import Any
 
-from aidial_sdk.chat_completion import Message
 from injector import AssistedBuilder, inject
 
 from quickapp.attachment_processing._available_context_stage_wrapper import (
@@ -15,6 +14,7 @@ from quickapp.attachment_processing._context_entries import (
 from quickapp.common import CompletionResult, StagedBaseTool
 from quickapp.common.abstract.base_tool_argument_transformer import ToolArgumentTransformer
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.config.context import Context
 from quickapp.config.tools.internal import InternalTool
@@ -29,7 +29,7 @@ class _AvailableContextTool(StagedBaseTool):
         contexts: list[Context],
         tool_config: InternalTool,
         perf_timer: PerformanceTimer,
-        messages: list[Message],
+        messages_mixin: MessagesMixin,
         argument_transformers: list[ToolArgumentTransformer] | None = None,
         **kwargs: Any,
     ):
@@ -41,11 +41,11 @@ class _AvailableContextTool(StagedBaseTool):
             **kwargs,
         )
         self.__contexts: list[Context] = contexts
-        self.__messages: list[Message] = messages
+        self.__messages_mixin: MessagesMixin = messages_mixin
 
     def _get_response(self) -> AvailableContextToolResponse:
         """Collect context file metadata, flagging new or changed ones."""
-        seen_entries = extract_seen_entries_from_messages(self.__messages)
+        seen_entries = extract_seen_entries_from_messages(self.__messages_mixin.messages)
         _, entries = build_context_entries(self.__contexts, seen_entries)
         return AvailableContextToolResponse(entries=entries)
 

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -8,13 +8,14 @@ from aidial_client.types.chat.request_param import (
     CustomContentParam,
     UserMessageParam,
 )
-from aidial_sdk.chat_completion import CustomContent, Message, Role
+from aidial_sdk.chat_completion import CustomContent, Role
 from aidial_sdk.chat_completion.request import Attachment as SdkAttachment
 from injector import AssistedBuilder
 
 from quickapp.common import CompletionResult, StagedBaseTool
 from quickapp.common.abstract.base_tool_argument_transformer import ToolArgumentTransformer
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import to_plain_dict
 from quickapp.config.dial_deployment import DialDeploymentParameters
@@ -40,7 +41,7 @@ class BaseDeploymentTool(StagedBaseTool):
         tool_config: DialDeploymentTool,
         content_propagation: ContentPropagation | None,
         dial_completion_service: DialCompletionService,
-        messages: list[Message],
+        messages_mixin: MessagesMixin,
         perf_timer: PerformanceTimer,
         stage_wrapper_builder: AssistedBuilder[DeploymentStageWrapper],
         argument_transformers: list[ToolArgumentTransformer] | None = None,
@@ -57,7 +58,7 @@ class BaseDeploymentTool(StagedBaseTool):
         self.__application_name: str = application_name
         self.__dial_completion_service: DialCompletionService = dial_completion_service
         self.__content_propagation: ContentPropagation | None = content_propagation
-        self.__messages: list[Message] = messages
+        self.__messages_mixin: MessagesMixin = messages_mixin
 
     async def _run_in_stage_async(
         self,
@@ -94,16 +95,18 @@ class BaseDeploymentTool(StagedBaseTool):
         if not tool_name:
             return []
 
+        messages = self.__messages_mixin.messages
+
         # Build map: tool_call_id -> (content, custom_content)
         tool_result_by_id: dict[str, tuple[str, CustomContent | None]] = {}
-        for msg in self.__messages:
+        for msg in messages:
             if msg.role == Role.TOOL and msg.tool_call_id and msg.content:
                 content = str(msg.content) if not isinstance(msg.content, str) else msg.content
                 tool_result_by_id[msg.tool_call_id] = (content, msg.custom_content)
 
         # Walk ASSISTANT messages, find completed tool_calls matching tool_name
         history: list[UserMessageParam | AssistantMessageParam] = []
-        for msg in self.__messages:
+        for msg in messages:
             if msg.role != Role.ASSISTANT or not msg.tool_calls:
                 continue
 

--- a/src/quickapp/dial_deployment_tooling/deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/deployment_tool.py
@@ -1,8 +1,8 @@
-from aidial_sdk.chat_completion import Message
 from injector import AssistedBuilder, inject
 from pydantic import BaseModel, Field
 
 from quickapp.common.abstract.base_tool_argument_transformer import ToolArgumentTransformer
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
 
@@ -26,7 +26,7 @@ class DeploymentTool(BaseDeploymentTool):
         tool_config: DialDeploymentTool,
         content_propagation: ContentPropagation | None,
         dial_completion_service: DialCompletionService,
-        messages: list[Message],
+        messages_mixin: MessagesMixin,
         stage_wrapper_builder: AssistedBuilder[DeploymentStageWrapper],
         perf_timer: PerformanceTimer,
         argument_transformers: list[ToolArgumentTransformer] | None = None,
@@ -36,7 +36,7 @@ class DeploymentTool(BaseDeploymentTool):
             application_name=application_name,
             content_propagation=content_propagation,
             dial_completion_service=dial_completion_service,
-            messages=messages,
+            messages_mixin=messages_mixin,
             tool_config=tool_config,
             stage_wrapper_builder=stage_wrapper_builder,
             description=description,

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_py_interpreter_tool.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_py_interpreter_tool.py
@@ -11,6 +11,7 @@ from quickapp.common.abstract.base_tool_argument_transformer import ToolArgument
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.media_types import MediaTypes
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.config.tools.internal import InternalTool
 from quickapp.internal_tooling.py_interpreter_tooling._exceptions import _PyInterpreterError
@@ -53,7 +54,7 @@ class _PyInterpreterTool(StagedBaseTool):
     def __init__(
         self,
         stage_wrapper_builder: AssistedBuilder[_PyInterpreterStageWrapper],
-        messages: list[Message],
+        messages_mixin: MessagesMixin,
         client: _PyInterpreterClient,
         py_interpreter_settings: _PyInterpreterSettings,
         session_manager: SessionManager,
@@ -72,7 +73,7 @@ class _PyInterpreterTool(StagedBaseTool):
             argument_transformers=argument_transformers,
             **kwargs,
         )
-        self.__messages: list[Message] = messages
+        self.__messages_mixin: MessagesMixin = messages_mixin
 
         self.__client: _PyInterpreterClient = client
         self.__py_interpreter_settings: _PyInterpreterSettings = py_interpreter_settings
@@ -163,7 +164,7 @@ class _PyInterpreterTool(StagedBaseTool):
         )
         loaded_file_names = [file.path for file in loaded_files.files]
 
-        attachments_urls_map = self._get_attachment_urls_map(self.__messages)
+        attachments_urls_map = self._get_attachment_urls_map(self.__messages_mixin.messages)
 
         errors: list[str] = []
 

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/session_manager.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/session_manager.py
@@ -1,8 +1,9 @@
 import logging
 
-from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.chat_completion import Role
 from injector import inject
 
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.state_holder import StateHolder
 from quickapp.internal_tooling.py_interpreter_tooling._constants import (
     PY_INTERPRETER_STATE_KEY,
@@ -25,10 +26,10 @@ class SessionManager:
     """Manages Python interpreter sessions"""
 
     def __init__(
-        self, client: _PyInterpreterClient, messages: list[Message], state_holder: StateHolder
+        self, client: _PyInterpreterClient, messages_mixin: MessagesMixin, state_holder: StateHolder
     ):
         self.__client: _PyInterpreterClient = client
-        self.__messages: list[Message] = messages
+        self.__messages_mixin: MessagesMixin = messages_mixin
         self.__state_holder: StateHolder = state_holder
         self.__validated_session_id: str | None = None
 
@@ -41,7 +42,7 @@ class SessionManager:
             return PyInterpreterState.model_validate(raw).session_id
 
         # Scan message history in a single pass for both new and legacy keys
-        for msg in reversed(self.__messages):
+        for msg in reversed(self.__messages_mixin.messages):
             if msg.role == Role.ASSISTANT and msg.custom_content:
                 state = msg.custom_content.state
                 if isinstance(state, dict):

--- a/src/tests/integration_tests/test_simple_tool.py
+++ b/src/tests/integration_tests/test_simple_tool.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 from starlette.testclient import TestClient
 
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_client import (
     _PyInterpreterClient,
 )
@@ -375,7 +376,9 @@ async def test_pyinterpreter_close_session():
     async with _PyInterpreterClient(
         api_key=TestConfig.PY_INTERPRETER_API_KEY, base_url=TestConfig.PY_INTERPRETER_URL
     ) as client:
-        session_manager = SessionManager(client=client, messages=[])
+        messages_mixin = MessagesMixin()
+        messages_mixin.messages = []
+        session_manager = SessionManager(client=client, messages_mixin=messages_mixin)
         session_id = await session_manager.ensure_valid_session(None, True)
         logger.info("Closing session, and try call py_interpreter again")
         await session_manager.close_session(session_id)

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -8,6 +8,7 @@ from aidial_sdk.chat_completion.request import Attachment as SdkAttachment
 from aidial_sdk.chat_completion.request import CustomContent, FunctionCall, ToolCall
 from pydantic import StrictStr
 
+from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.config.dial_deployment import (
     CustomFieldsConfig,
     DialDeploymentConfig,
@@ -22,6 +23,12 @@ from quickapp.config.tools.base import (
 )
 from quickapp.config.tools.deployment import DialDeploymentTool
 from quickapp.dial_deployment_tooling.base_deployment_tool import BaseDeploymentTool
+
+
+def _make_messages_mixin(messages: list[Message]) -> MessagesMixin:
+    mixin = MessagesMixin()
+    mixin.messages = messages
+    return mixin
 
 
 def _make_tool_call(
@@ -80,7 +87,7 @@ def _build_tool(
         tool_config=tool_config,
         content_propagation=None,
         dial_completion_service=dial_completion_service,
-        messages=messages,
+        messages_mixin=_make_messages_mixin(messages),
         perf_timer=MagicMock(),
         stage_wrapper_builder=MagicMock(),
     )
@@ -374,7 +381,7 @@ def _build_tool_with_config(
         tool_config=tool_config,
         content_propagation=None,
         dial_completion_service=MagicMock(),
-        messages=messages or [],
+        messages_mixin=_make_messages_mixin(messages or []),
         perf_timer=MagicMock(),
         stage_wrapper_builder=MagicMock(),
     )


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #211 

### Description of changes

<!-- Please explain the changes you made right below this line. -->

`@multiprovider` for `list[Message]` always copies the list, so request-scoped tools get a frozen snapshot and miss messages appended during the orchestrator loop.

Fix: inject `MessagesMixin` instead — its `.messages` property returns the live list reference. Affected: `_PyInterpreterTool`, `SessionManager`, `_AvailableContextTool`, `BaseDeploymentTool`. Updated `CLAUDE.md` accordingly.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes are tested on review environment
- [X] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
