### PR TITLE
fix: PyInterpreter close session integration test

### DIFF
--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/session_manager.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/session_manager.py
@@ -86,6 +86,7 @@ class SessionManager:
 
     async def close_session(self, session_id: str):
         await self.__client.close_session(PyInterpreterSession(sessionId=session_id))
+        self.__validated_session_id = None
 
     def _persist_state(self, interpreter_state: PyInterpreterState) -> None:
         self.__state_holder.add_state(

--- a/src/tests/integration_tests/test_simple_tool.py
+++ b/src/tests/integration_tests/test_simple_tool.py
@@ -6,6 +6,7 @@ import pytest
 from starlette.testclient import TestClient
 
 from quickapp.common.messages_mixin import MessagesMixin
+from quickapp.common.state_holder import StateHolder
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_client import (
     _PyInterpreterClient,
 )
@@ -378,11 +379,14 @@ async def test_pyinterpreter_close_session():
     ) as client:
         messages_mixin = MessagesMixin()
         messages_mixin.messages = []
-        session_manager = SessionManager(client=client, messages_mixin=messages_mixin)
-        session_id = await session_manager.ensure_valid_session(None, True)
+        state_holder = StateHolder()
+        session_manager = SessionManager(
+            client=client, messages_mixin=messages_mixin, state_holder=state_holder
+        )
+        session_id = await session_manager.ensure_valid_session(None)
         logger.info("Closing session, and try call py_interpreter again")
         await session_manager.close_session(session_id)
-        new_session_id = await session_manager.ensure_valid_session(session_id, True)
+        new_session_id = await session_manager.ensure_valid_session(session_id)
         assert new_session_id != session_id
 
 


### PR DESCRIPTION
### Applicable issues

--

### Description of changes

- Fix test_pyinterpreter_close_session integration test according to changes in https://github.com/epam/ai-dial-quickapps-backend/pull/209
- Nullify `__validated_session_id` after session is closed

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
