### PR TITLE
fix: upgrade musl to 1.2.5-r23 to address CVE-2026-40200

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-alpine AS builder
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 zlib
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 zlib musl musl-utils
 RUN apk add --no-cache gcc alpine-sdk linux-headers musl-dev git
 RUN pip install poetry==2.3.2
 
@@ -16,7 +16,7 @@ RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
 FROM python:3.13-alpine AS runtime
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat zlib
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat zlib musl musl-utils
 
 WORKDIR /app
 

--- a/src/tests/integration_tests/Dockerfile
+++ b/src/tests/integration_tests/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-alpine AS test-builder
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 musl musl-utils
 RUN apk add --no-cache gcc alpine-sdk linux-headers musl-dev git
 RUN pip install poetry==2.3.2
 
@@ -24,7 +24,7 @@ COPY ./integration_tests ./integration_tests
 
 # Stage 2: Test runtime (reuse app runtime base for infra)
 FROM python:3.13-alpine AS test-runtime
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat musl musl-utils
 
 WORKDIR /app
 ENV PYTHONDONTWRITEBYTECODE=1 PYTHONUNBUFFERED=1


### PR DESCRIPTION
### Applicable issues

<!-- CVE-2026-40200 surfaced by Trivy on PR #225; no tracking issue filed -->
- fixes N/A (CVE-2026-40200)

### Description of changes

Trivy is flagging `musl` and `musl-utils` on the `python:3.13-alpine` base image with **CVE-2026-40200** (HIGH, stack-based memory corruption in `qsort` on very large arrays). Installed version `1.2.5-r21`; Alpine has published fixed version `1.2.5-r23`.

Scan excerpt from the `docker_build` job on PR #225:

```
Total: 2 (HIGH: 2, CRITICAL: 0)
│  Library   │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version │
│ musl       │ CVE-2026-40200 │ HIGH     │ fixed  │ 1.2.5-r21         │ 1.2.5-r23     │
│ musl-utils │                │          │        │                   │               │
```

This PR adds `musl musl-utils` to the existing `apk upgrade --no-cache …` lines so future rebuilds pull the patched package:

- `Dockerfile` — builder and runtime stages
- `src/tests/integration_tests/Dockerfile` — test-builder and test-runtime stages

The runtime stage is the one Trivy scans; the builder/test stages are updated for consistency.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

🤖 Generated with [Claude Code](https://claude.com/claude-code)