### PR TITLE
chore(ci): add release candidate branching

### DIFF
--- a/.github/workflows/deploy-development.yml
+++ b/.github/workflows/deploy-development.yml
@@ -1,15 +1,15 @@
 name: Deploy development
 
-permissions:
-  contents: read
-
 on:
-  workflow_dispatch:
-  registry_package:
-  workflow_run:
+  workflow_dispatch: # manual run
+  registry_package: # on new package version (main path)
+  workflow_run: # HACK: redundant trigger to mitigate GitHub's huge delays in registry_package event processing
     workflows: ["Release Workflow"]
     types:
       - completed
+
+permissions:
+  contents: read
 
 jobs:
   gitlab-dev-deploy:
@@ -17,7 +17,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event.registry_package.package_version.container_metadata.tag.name == 'development' ||
       (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'development')
-    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@3.1.3
+    uses: epam/ai-dial-ci/.github/workflows/deploy-development.yml@4.0.0
     with:
       gitlab-project-id: "2985"
       gitlab-project-ref: "master"

--- a/.github/workflows/pr-title-check.yml
+++ b/.github/workflows/pr-title-check.yml
@@ -1,9 +1,5 @@
 name: "Validate PR title"
 
-permissions:
-  contents: read
-  pull-requests: read
-
 on:
   pull_request_target:
     types:
@@ -11,12 +7,14 @@ on:
       - edited
       - reopened
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   pr-title-check:
-    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@3.1.3
+    uses: epam/ai-dial-ci/.github/workflows/pr-title-check.yml@4.0.0
     secrets:
       ACTIONS_BOT_TOKEN: ${{ secrets.ACTIONS_BOT_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,13 +1,5 @@
 name: PR Workflow
 
-env:
-  POETRY: ${{ vars.POETRY }}
-  PYTHON: ${{ vars.PYTHON }}
-
-permissions:
-  contents: read
-  security-events: write
-
 on:
   pull_request:
     branches: [development, release-*]
@@ -16,9 +8,13 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  security-events: write
+
 jobs:
   run_tests:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@3.1.3
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_pr.yml@4.0.0
     secrets: inherit
     with:
       python-version: "3.13"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,29 @@
 name: Release Workflow
 
-env:
-  POETRY: ${{ vars.POETRY }}
-  PYTHON: ${{ vars.PYTHON }}
+on:
+  push:
+    branches: [development, release-*]
+  workflow_dispatch:
+    inputs:
+      promote:
+        type: boolean
+        default: false
+        description: Promote release to stable (for release-* branches only)
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 permissions:
   contents: write
   packages: write
   security-events: write
 
-on:
-  push:
-    branches: [development, release-*]
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 jobs:
   release:
-    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@3.1.3
-    secrets: inherit
+    uses: epam/ai-dial-ci/.github/workflows/python_docker_release.yml@4.0.0
     with:
+      promote: ${{ github.event_name == 'workflow_dispatch' && inputs.promote }}
       python-version: "3.13"
       poetry-version: "2.3.2"
+    secrets: inherit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "QuickApps"
-version = "0.7.0rc"
+version = "0.0.0"
 description = "Configurable agentic application for DIAL"
 readme = "README.md"
 requires-python = ">=3.13,<3.14"

--- a/trivy.yaml
+++ b/trivy.yaml
@@ -6,5 +6,9 @@ db:
     - mirror.gcr.io/aquasec/trivy-db:2
     - public.ecr.aws/aquasecurity/trivy-db:2
     - ghcr.io/aquasecurity/trivy-db:2
+  java-repository:
+    - mirror.gcr.io/aquasec/trivy-java-db:1
+    - public.ecr.aws/aquasecurity/trivy-java-db:1
+    - ghcr.io/aquasecurity/trivy-java-db:1
 misconfiguration:
   checks-bundle-repository: mirror.gcr.io/aquasec/trivy-checks:1


### PR DESCRIPTION
- bump epam/ai-dial-ci workflow version and add promote input = enable release candidates for the given repo
- drop version in pyproject.toml file to dev marker (`0.0.0`)
- align additional Trivy configuration with reference
- minor workflow-related fixes & alignments