### PR TITLE
fix: enforce wall-clock timeout on DIAL deployment tool #237

### DIFF
--- a/docs/designs/configurable_timeouts.md
+++ b/docs/designs/configurable_timeouts.md
@@ -27,9 +27,8 @@ flow through `AsyncDial`. Three inadequacies today:
    longer processing. Issue
    [#216](https://github.com/epam/ai-dial-quickapps-backend/issues/216): a 7.2 MB
    PDF processes directly against DIAL RAG in 9.5 min, but errors out at ~5 min
-   through a Quick App 2.0 deployment tool. The cap is in our code (per bug
-   reporter), not infra, but the **exact call site** is not yet pinpointed —
-   see [Investigation for #216](#0-investigation-tracing-the-5-minute-cap-for-216).
+   through a Quick App 2.0 deployment tool — the cap lives in our HTTP-client
+   defaults, not infra.
 3. **Timeouts look like any other tool error to the LLM.** Every tool defaults to
    `ToolFallbackConfig.strategies = [ContinueStrategyModel()]` with
    `trigger_on=None` — matches all exceptions. A timed-out call today produces a
@@ -91,26 +90,6 @@ only one leaves the feature half-useful.
 ---
 
 ## Proposed Design
-
-### 0. Investigation: tracing the 5-minute cap for #216
-
-The "fixes #216" claim is gated on locating the actual cap — the unified
-mechanism below only helps for caps that live in our HTTP clients. Priority
-hypotheses:
-
-1. **`AsyncDial`** — library read default is 600s, so not the cap directly, but
-   the deployment-tool code path (and the bucket/file operations previously
-   routed through a dedicated DIAL Core HTTP client) may wrap the call in an
-   outer `asyncio.wait_for` or accumulate retries.
-2. **MCP per-call** — if an MCP tool is in the failing flow, transport
-   `sse_read_timeout=300s` is exactly 5 minutes.
-3. **Upstream (DIAL Core / ingress)** — the user reports this is not the source,
-   but cross-checked during repro.
-
-Repro captures: exception class + traceback, elapsed time from `PerformanceTimer`,
-the `httpx.AsyncClient` construction site, payload sizes, determinism (repeat
-≥2×). If the cap turns out to be outside any of the call sites the design covers,
-a follow-up design pass is needed before shipping #216.
 
 ### 1. `ToolSettings` — env default
 
@@ -186,14 +165,20 @@ All call sites consume `T = ToolTimeoutResolver.resolve()` — always a `float`,
 never `None` — and pass it explicitly to their underlying client. No
 "library-default fallback" branch is needed anywhere. Per-client specifics:
 
-- **Deployment (`AsyncDial`)** — `AppModule.__provide_async_dial` passes
-  `timeout=openai.Timeout(connect=5, read=T, write=T, pool=T)`. `connect` is held
-  at 5s to preserve fast-fail on dead deployments; the other phases track `T`.
-  `http_client=` is not used — it would replace the whole transport and bypass
-  internal openai-client config.
-  *Streaming caveat:* DIAL deployments stream, so `read=T` means "T seconds of
-  silence between SSE events," not wall-clock. Treat `tool_defaults.timeout_seconds`
-  as an **idle budget** for streaming deployment calls.
+- **Deployment (`AsyncDial` / `AsyncAzureOpenAI`)** — both the shared
+  `AsyncDial` client (`AppModule.__provide_async_dial`) and the deployment
+  tool's `DEPLOYMENT_AZURE_CLIENT`
+  (`DialDeploymentToolingModule.provide_deployment_openai_client`) pass
+  `timeout=openai.Timeout(connect=5, read=T, write=T, pool=T)`. `connect`
+  is held at 5s to preserve fast-fail on dead deployments; the other phases
+  track `T`. `http_client=` is not used — it would replace the whole
+  transport and bypass internal openai-client config.
+  *Streaming.* DIAL deployments stream, so the client-level `read=T` alone
+  is only an idle gap between SSE events, not wall-clock. Wall-clock is
+  instead guaranteed by `translate_timeout`, which wraps the call body with
+  `asyncio.timeout(T)` (see [Section 6](#6-per-tool-timeout--tooltimeouterror-translation)).
+  Treat the client-level phase timeout as a fast-fail on stuck reads, and
+  `asyncio.timeout(T)` as the authoritative total budget.
 - **REST API (`_RestApiTool._run_in_stage_async`)** — construct
   `httpx.AsyncClient(timeout=T)`. Body wrapped in `translate_timeout`.
 - **Python interpreter (`InternalToolModule._provide_py_interpreter_client`)** —
@@ -253,9 +238,12 @@ case to handle. `__str__` always contains the stable phrase `"timed out"` so
 | Python interpreter | Existing `_PyInterpreterTimeOutError` | No wrap needed — `_PyInterpreterTimeOutError` is changed to **extend** `ToolTimeoutError` (not replace), preserving existing `isinstance` callers |
 
 A shared `translate_timeout(tool_name, timeout_seconds)` async context manager in
-`common/tool_timeout_utils.py` performs the catch-and-raise, chaining the original
-cause (`from e`) so tracebacks keep the underlying library exception visible. Two
-subtleties worth naming because they're easy to get wrong:
+`common/tool_timeout_utils.py` wraps its body with `async with
+asyncio.timeout(timeout_seconds):` (hard wall-clock) and performs the
+catch-and-raise, chaining the original cause (`from e`) so tracebacks keep the
+underlying library exception visible. The `TimeoutError` raised by
+`asyncio.timeout` is handled by the same translation branch as the library
+timeouts. Two subtleties worth naming because they're easy to get wrong:
 
 - **`mcp.McpError` needs predicate matching**, not a tuple entry. Adding it to an
   `isinstance` tuple alongside `httpx.TimeoutException` et al. would misclassify
@@ -414,6 +402,12 @@ timeout, directing it to halt and inform the user. Orchestration itself continue
 | unset | 900 | 900.0 | All clients for this app capped at 900s (MCP caveat below) |
 | 600 | 900 | 900.0 | App override wins |
 
+**Wall-clock semantics.** Resolved `T` is enforced as a hard wall-clock budget
+for deployment, REST, and MCP tool calls — the `translate_timeout` helper
+wraps each tool body with `asyncio.timeout(T)`. Per-client phase timeouts
+(`httpx`, `openai.Timeout`) are retained as fast-fail on connect/read-stall
+and are subordinate to the helper's hard cap.
+
 **MCP caveat.** Resolved `T` applies to `ClientSession.call_tool(read_timeout_seconds=T)`
 (authoritative per-call budget) and `sse_read_timeout`. It does **not** bind the
 connection-setup tier (`streamablehttp_client.timeout`, `sse_client.timeout`) — those
@@ -508,6 +502,15 @@ required.
 
 - `application/app_module.__provide_async_dial` — apply resolved timeout as
   `openai.Timeout(connect=5, read=T, write=T, pool=T)`
+- `dial_deployment_tooling/dial_deployment_tooling_module.provide_deployment_openai_client`
+  — inject `ToolTimeoutResolver`, apply the same
+  `openai.Timeout(connect=5, read=T, write=T, pool=T)` shape to
+  `AsyncAzureOpenAI` so the deployment tool's client is bounded consistently
+  with `__provide_async_dial`
+- `common/tool_timeout_utils.translate_timeout` — wrap body with
+  `async with asyncio.timeout(timeout_seconds):`; the raised `TimeoutError`
+  is absorbed by the existing translation branch and surfaces as
+  `ToolTimeoutError`
 - `rest_api_tooling/_rest_api_tool._run_in_stage_async` — pass `timeout=T` to
   `httpx.AsyncClient(...)`; wrap body in `translate_timeout`
 - `mcp_tooling/_mcp_connection_manager.__session_context` — pass
@@ -564,10 +567,8 @@ pre-empts built-in (continue and stop strategies). Bare
 Pydantic error at config load.
 
 **E2E — #216 repro.** Reproduce failure on `development`; with
-`tool_defaults.timeout_seconds=900` the call succeeds (assuming
-[Investigation for #216](#0-investigation-tracing-the-5-minute-cap-for-216)
-confirms our HTTP clients are the cap). LLM-facing tool result names the tool and
-timeout value.
+`tool_defaults.timeout_seconds=900` the call succeeds. LLM-facing tool result
+names the tool and timeout value.
 
 **Stage UI.** `ToolTimeoutError.__str__` is displayed under
 `display_error_in_stage=True` and `=False` (timeouts are intentionally exempt

--- a/src/quickapp/common/tool_timeout_utils.py
+++ b/src/quickapp/common/tool_timeout_utils.py
@@ -35,9 +35,17 @@ def _is_timeout(exc: BaseException) -> bool:
 
 @asynccontextmanager
 async def translate_timeout(tool_name: str, timeout_seconds: float) -> AsyncIterator[None]:
-    """Catch recognised timeout exceptions and re-raise as `ToolTimeoutError`."""
+    """Enforce wall-clock timeout and translate recognised timeouts to `ToolTimeoutError`.
+
+    The `asyncio.timeout` wrapper is load-bearing: streaming tool calls
+    (DIAL deployment SSE) have only an *idle-read* phase timeout at the
+    client layer, so a chatty server would otherwise run unbounded. The
+    fired `TimeoutError` is absorbed by the `asyncio.TimeoutError` branch
+    below and surfaces as `ToolTimeoutError`.
+    """
     try:
-        yield
+        async with asyncio.timeout(timeout_seconds):
+            yield
     except BaseExceptionGroup as eg:
         timeout_leaves, _ = eg.split(_is_timeout)
         if timeout_leaves is not None:

--- a/src/quickapp/dial_deployment_tooling/dial_deployment_tooling_module.py
+++ b/src/quickapp/dial_deployment_tooling/dial_deployment_tooling_module.py
@@ -8,6 +8,8 @@ from quickapp.common import DEPLOYMENT_AZURE_CLIENT, DIAL_API_KEY, ForwardedHead
 from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.tool_initialization_exception import ToolInitializationException
+from quickapp.common.tool_timeout_resolver import ToolTimeoutResolver
+from quickapp.common.tool_timeout_utils import build_async_dial_timeout
 
 from ._deployment_tool_context import _DeploymentToolingContext
 from ._deployment_tool_initializer import _DeploymentToolInitializer
@@ -36,12 +38,14 @@ class DialDeploymentToolingModule(Module):
         dial_settings: DialSettings,
         api_key: DIAL_API_KEY,
         forwarded_headers: ForwardedHeaders,
+        timeout_resolver: ToolTimeoutResolver,
     ) -> DEPLOYMENT_AZURE_CLIENT:
         return AsyncAzureOpenAI(
             azure_endpoint=dial_settings.url,
             api_key=api_key.get_secret_value(),
             api_version=dial_settings.api_version,
             default_headers=forwarded_headers or None,
+            timeout=build_async_dial_timeout(timeout_resolver.resolve()),
         )
 
     @multiprovider

--- a/src/tests/unit_tests/common/test_tool_timeout_utils.py
+++ b/src/tests/unit_tests/common/test_tool_timeout_utils.py
@@ -95,3 +95,19 @@ async def test_error_carries_timeout_value():
     assert excinfo.value.timeout_seconds == 42
     assert "timed out" in str(excinfo.value)
     assert "42" in str(excinfo.value)
+
+
+@pytest.mark.asyncio
+async def test_enforces_wall_clock_timeout():
+    with pytest.raises(ToolTimeoutError) as excinfo:
+        async with translate_timeout("my_tool", 0.05):
+            await asyncio.sleep(0.2)
+    assert excinfo.value.tool_name == "my_tool"
+    assert excinfo.value.timeout_seconds == 0.05
+    assert isinstance(excinfo.value.__cause__, TimeoutError)
+
+
+@pytest.mark.asyncio
+async def test_wall_clock_does_not_fire_when_body_is_fast():
+    async with translate_timeout("my_tool", 5):
+        await asyncio.sleep(0)  # completes immediately

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
@@ -1,0 +1,27 @@
+from unittest.mock import MagicMock
+
+import openai
+from pydantic import SecretStr
+
+from quickapp.dial_deployment_tooling.dial_deployment_tooling_module import (
+    DialDeploymentToolingModule,
+)
+from tests.unit_tests.common.common import noop_timeout_resolver
+
+
+def test_provide_deployment_openai_client_applies_resolved_timeout():
+    module = DialDeploymentToolingModule()
+    dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
+    api_key = SecretStr("test-key")
+    resolver = noop_timeout_resolver(value=42.0)
+
+    client = module.provide_deployment_openai_client(
+        dial_settings=dial_settings,
+        api_key=api_key,
+        forwarded_headers=None,
+        timeout_resolver=resolver,
+    )
+
+    expected = openai.Timeout(connect=5.0, read=42.0, write=42.0, pool=42.0)
+    assert client.timeout == expected
+    resolver.resolve.assert_called_once()


### PR DESCRIPTION
### Applicable issues

- fixes #237

### Description of changes

Fixes a gap left by #224 where a DIAL deployment tool call with the default 300s
budget could still run for 8 min without surfacing a `ToolTimeoutError`.

Two compounding causes, both addressed:

1. **`DEPLOYMENT_AZURE_CLIENT` got no `timeout=` kwarg** so openai's SDK default
   (`Timeout(read=600, ...)`) applied. The resolved value at
   `dial_completion_service.py:82` was used only to label the eventual error.
   `DialDeploymentToolingModule.provide_deployment_openai_client` now injects
   `ToolTimeoutResolver` and passes
   `timeout=build_async_dial_timeout(resolver.resolve())`, mirroring
   `AppModule.__provide_async_dial`.
2. **`translate_timeout` was a pure `try/except`** — no wall-clock. For streaming
   SSE, `read=T` is idle-between-chunks, not total. The helper now wraps its
   body with `async with asyncio.timeout(timeout_seconds):`; the raised
   `TimeoutError` is absorbed by the existing `asyncio.TimeoutError`
   translation branch and surfaces as `ToolTimeoutError`. Every site already
   using `translate_timeout` (deployment, REST, MCP) inherits the hard cap.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
