### PR TITLE
feat: validate incoming messages array shape #240

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -42,7 +42,17 @@ When a chat completion request arrives, it flows through several stages before t
 
 The chat completion endpoint receives the incoming request with messages, configuration, and authentication credentials.
 
-### 2. Context Setup
+### 2. Messages Shape Validation
+
+The raw `messages` array is validated against the QuickApps contract `(System)? (User Assistant)* User`
+before any other request processing. The check runs outside the `create_single_choice` block so an
+`InvalidRequestError` (raised from `validate_messages_shape` in `_messages_validator.py`) propagates to
+the aidial_sdk exception handler and produces an HTTP 400 response. All rule violations are collected in
+a single pass and returned together in `display_message`, so clients see every problem at once rather
+than one at a time. Tool messages and misplaced system messages are rejected here because they are
+orchestrator-internal and must never arrive from the client.
+
+### 3. Context Setup
 
 A request-scoped context is created to hold:
 
@@ -51,12 +61,12 @@ A request-scoped context is created to hold:
 - Conversation messages
 - Response choice object for streaming output
 
-### 3. Configuration Resolution
+### 4. Configuration Resolution
 
 If the request uses predefined templates (for system prompts, tools, or toolsets), these are resolved to their actual
 definitions from the predefined configuration files.
 
-### 4. Completion Initialization
+### 5. Completion Initialization
 
 Completion initializers are invoked to prepare the request for orchestration. This includes:
 
@@ -73,12 +83,12 @@ Completion initializers are invoked to prepare the request for orchestration. Th
   `X-DIAL-CLIENT-CHANNEL-ID` request header enables this flow; without it, 401 errors fall through to
   the standard error path. See `docs/designs/interactive_login.md` for the full design.
 
-### 5. Error Handling
+### 6. Error Handling
 
 Any tool initialization errors are collected and displayed to the user via a dedicated error stage, allowing partial
 functionality even when some tools fail to initialize.
 
-### 6. Orchestrator Invocation
+### 7. Orchestrator Invocation
 
 The orchestrator is retrieved from the DI container and its invoke method is called, starting the agent loop.
 

--- a/src/quickapp/application/_messages_validator.py
+++ b/src/quickapp/application/_messages_validator.py
@@ -1,0 +1,80 @@
+from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.exceptions import InvalidRequestError
+
+# Expected raw shape (pseudo-regex): (System)? (User Assistant)* User
+#
+# The orchestrator persists tool-call history in
+# custom_content.state[TOOL_EXECUTION_HISTORY] on assistant messages;
+# raw TOOL messages or inline tool_calls are not part of the client contract.
+
+
+def validate_messages_shape(messages: list[Message]) -> None:
+    """Enforce the raw-input messages contract; raise InvalidRequestError on mismatch.
+
+    Raised before the `with response.create_single_choice()` block in
+    `_QuickAppCompletion.chat_completion` so the exception reaches the
+    aidial_sdk exception handler and produces HTTP 400 with the full
+    violation list in `display_message`.
+    """
+    if not messages:
+        _raise_violations(["Messages array must not be empty."])
+
+    illegal_role_violations = _collect_illegal_role_violations(messages)
+    if illegal_role_violations:
+        _raise_violations(illegal_role_violations)
+
+    sequence_violations = _collect_sequence_violations(messages)
+    if sequence_violations:
+        _raise_violations(sequence_violations)
+
+
+def _collect_illegal_role_violations(messages: list[Message]) -> list[str]:
+    violations: list[str] = []
+    for index, message in enumerate(messages):
+        if message.role == Role.TOOL:
+            violations.append(
+                f"Message at index {index}: role '{Role.TOOL.value}' is not allowed in raw input."
+            )
+        elif message.role == Role.SYSTEM and index != 0:
+            violations.append(
+                f"Message at index {index}: role '{Role.SYSTEM.value}' is only allowed at index 0."
+            )
+    return violations
+
+
+def _collect_sequence_violations(messages: list[Message]) -> list[str]:
+    violations: list[str] = []
+    offset = 1 if messages[0].role == Role.SYSTEM else 0
+    tail_len = len(messages) - offset
+
+    if tail_len == 0:
+        violations.append("Messages array must contain at least one user message.")
+        return violations
+
+    for index in range(offset, len(messages)):
+        expected = Role.USER if (index - offset) % 2 == 0 else Role.ASSISTANT
+        actual = messages[index].role
+        if actual != expected:
+            violations.append(
+                f"Message at index {index}: "
+                f"expected role '{expected.value}', got '{actual.value}'."
+            )
+
+    # When tail length is even, alternation would expect assistant at the last
+    # position, so a non-user last message is not caught by the loop above.
+    # Fire this rule only in that slot to avoid duplicating alternation errors.
+    if tail_len % 2 == 0 and messages[-1].role != Role.USER:
+        violations.append(
+            f"Messages must end with a user message, "
+            f"but index {len(messages) - 1} has role '{messages[-1].role.value}'."
+        )
+
+    return violations
+
+
+def _raise_violations(violations: list[str]) -> None:
+    display_message = "Invalid messages array:\n" + "\n".join(f"- {v}" for v in violations)
+    raise InvalidRequestError(
+        message="Invalid messages array",
+        display_message=display_message,
+    )

--- a/src/quickapp/application/_quick_app_completion.py
+++ b/src/quickapp/application/_quick_app_completion.py
@@ -13,6 +13,7 @@ from quickapp.common.presentation_settings import PresentationSettings
 
 from ._exception_message_resolver import resolve_exception_message
 from ._initialization_error_handler import _InitializationErrorHandler
+from ._messages_validator import validate_messages_shape
 from ._request_context_setup import _RequestContextSetup
 from .configuration import Configuration
 
@@ -38,6 +39,7 @@ class _QuickAppCompletion(ChatCompletion):
         self.__timer_period_name = "chat_completion"
 
     async def chat_completion(self, request: Request, response: Response) -> None:
+        validate_messages_shape(request.messages)
         timer_service = self.__injector.get(PerformanceTimer)
         timer_service.start_period(self.__timer_period_name, level=1)
         with response.create_single_choice() as choice:

--- a/src/tests/unit_tests/application_tests/test_completion.py
+++ b/src/tests/unit_tests/application_tests/test_completion.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import fastapi
 import pytest
 from aidial_sdk.chat_completion import Message, Request, Role
+from aidial_sdk.exceptions import InvalidRequestError
 from httpx import HTTPError
 
 import quickapp.application._quick_app_completion as quick_app_completion
@@ -98,13 +99,22 @@ async def valid_app_props(*args, **kwargs):
 
 @pytest.fixture
 def make_request_completion():
-    def _make(orchestrator=None, api_key="k", has_binding=True, extra_mapping=None):
+    def _make(
+        orchestrator=None,
+        api_key="k",
+        has_binding=True,
+        extra_mapping=None,
+        messages=None,
+    ):
+        if messages is None:
+            messages = [
+                Message(content="123", role=Role.USER),
+                Message(content="456", role=Role.ASSISTANT),
+                Message(content="789", role=Role.USER),
+            ]
         request = Request(
             api_key_secret=api_key,
-            messages=[
-                Message(content="123", role=Role.USER),
-                Message(content="456", role=Role.USER),
-            ],
+            messages=messages,
             deployment_id="default-deployment",
             headers={"1": "2"},
             original_request=fastapi.Request(scope={"type": "http"}),
@@ -322,6 +332,34 @@ async def test_chat_completion_sets_context_messages_when_request_is_request(
     # Assert: inspect the request context from the injector
     msgs = list(injector.get(_RequestContext).messages)
 
-    assert len(msgs) == 2
+    assert len(msgs) == 3
     assert msgs[0].content == "123"
     assert msgs[1].content == "456"
+    assert msgs[2].content == "789"
+
+
+@pytest.mark.asyncio
+async def test_chat_completion_invalid_messages_raises_invalid_request_error(
+    make_request_completion,
+):
+    # Arrange: two consecutive user messages violate (System)? (User Assistant)* User
+    choice = FakeChoice()
+    response = FakeResponse(choice)
+
+    bad_messages = [
+        Message(content="a", role=Role.USER),
+        Message(content="b", role=Role.USER),
+    ]
+    request, completion, _ = make_request_completion(None, messages=bad_messages)
+
+    # Act + Assert: InvalidRequestError propagates past the create_single_choice
+    # block so the aidial_sdk exception handler can produce HTTP 400
+    with pytest.raises(InvalidRequestError) as exc:
+        await completion.chat_completion(request, response)
+
+    display = exc.value.display_message
+    assert display is not None
+    assert "Invalid messages array" in display
+    assert "expected role 'assistant'" in display
+    # The error must NOT be swallowed into the streamed choice content
+    assert choice.contents == []

--- a/src/tests/unit_tests/application_tests/test_messages_validator.py
+++ b/src/tests/unit_tests/application_tests/test_messages_validator.py
@@ -1,0 +1,135 @@
+"""Tests for `validate_messages_shape` — enforces `(System)? (User Assistant)* User`."""
+
+import pytest
+from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.exceptions import InvalidRequestError
+
+from quickapp.application._messages_validator import validate_messages_shape
+
+
+def _msg(role: Role, content: str = "x") -> Message:
+    return Message(role=role, content=content)
+
+
+def _display_message(exc: InvalidRequestError) -> str:
+    display = exc.display_message
+    assert display is not None
+    return display
+
+
+class TestValidShapes:
+    def test_single_user_message(self):
+        validate_messages_shape([_msg(Role.USER)])
+
+    def test_system_plus_user(self):
+        validate_messages_shape([_msg(Role.SYSTEM), _msg(Role.USER)])
+
+    def test_one_turn(self):
+        validate_messages_shape([_msg(Role.USER), _msg(Role.ASSISTANT), _msg(Role.USER)])
+
+    def test_system_plus_multi_turn(self):
+        validate_messages_shape(
+            [
+                _msg(Role.SYSTEM),
+                _msg(Role.USER),
+                _msg(Role.ASSISTANT),
+                _msg(Role.USER),
+                _msg(Role.ASSISTANT),
+                _msg(Role.USER),
+            ]
+        )
+
+
+class TestEmptyInput:
+    def test_empty_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([])
+        assert "must not be empty" in _display_message(exc.value)
+
+
+class TestIllegalRoles:
+    def test_tool_message_anywhere_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.USER), _msg(Role.TOOL), _msg(Role.USER)])
+        msg = _display_message(exc.value)
+        assert "role 'tool' is not allowed" in msg
+        assert "index 1" in msg
+
+    def test_system_after_index_zero_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.USER), _msg(Role.SYSTEM), _msg(Role.USER)])
+        assert "role 'system' is only allowed at index 0" in _display_message(exc.value)
+
+    def test_illegal_role_suppresses_sequence_violations(self):
+        """Reporting illegal-role issues alone keeps the error list focused."""
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.TOOL)])
+        msg = _display_message(exc.value)
+        assert "role 'tool' is not allowed" in msg
+        assert "expected role" not in msg
+
+
+class TestSequenceRules:
+    def test_two_consecutive_user_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.USER), _msg(Role.USER)])
+        msg = _display_message(exc.value)
+        assert "expected role 'assistant'" in msg
+        assert "index 1" in msg
+
+    def test_two_consecutive_assistant_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape(
+                [
+                    _msg(Role.USER),
+                    _msg(Role.ASSISTANT),
+                    _msg(Role.ASSISTANT),
+                    _msg(Role.USER),
+                ]
+            )
+        msg = _display_message(exc.value)
+        assert "expected role 'user'" in msg
+        assert "index 2" in msg
+
+    def test_first_message_assistant_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.ASSISTANT), _msg(Role.USER)])
+        msg = _display_message(exc.value)
+        assert "expected role 'user'" in msg
+        assert "index 0" in msg
+
+    def test_first_message_assistant_after_system_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.SYSTEM), _msg(Role.ASSISTANT), _msg(Role.USER)])
+        msg = _display_message(exc.value)
+        assert "expected role 'user'" in msg
+        assert "index 1" in msg
+
+    def test_trailing_assistant_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.USER), _msg(Role.ASSISTANT)])
+        assert "must end with a user message" in _display_message(exc.value)
+
+    def test_only_system_raises(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape([_msg(Role.SYSTEM)])
+        assert "at least one user message" in _display_message(exc.value)
+
+
+class TestMultipleViolations:
+    def test_multiple_issues_are_all_reported(self):
+        with pytest.raises(InvalidRequestError) as exc:
+            validate_messages_shape(
+                [
+                    _msg(Role.USER),
+                    _msg(Role.USER),
+                    _msg(Role.ASSISTANT),
+                    _msg(Role.ASSISTANT),
+                ]
+            )
+        msg = _display_message(exc.value)
+        assert "index 1" in msg
+        assert "index 3" in msg
+        assert "must end with a user message" in msg
+        assert msg.startswith("Invalid messages array:\n- ")
+        assert msg.count("\n- ") >= 2


### PR DESCRIPTION
### Applicable issues

- fixes #240

### Description of changes

QuickApps previously accepted any shape of `messages`. A history like
`[System, User, User]` would flow untouched into the orchestrator, which
would then append tool calls on top of the broken sequence. OpenAI
tolerates most shapes; Gemini rejects the request or silently corrupts
its response.

This PR introduces a strict shape check that rejects invalid histories
at the edge with HTTP 400 and a complete list of violations, so the
caller sees every problem at once.

**Contract enforced** — raw incoming messages must match the
pseudo-regex `(System)? (User Assistant)* User`:

- at most one system message, only at the very start;
- a non-empty conversation that alternates user/assistant and ends with
  a user turn;
- no tool messages — those are orchestrator-internal and are restored
  from persisted state, not sent by clients.

**Where it runs** — at the entry of the chat-completion handler,
*outside* the streaming-response context, so the validation error
propagates to the aidial_sdk exception handler and becomes a genuine
HTTP 400 instead of being swallowed into a streamed 200 with a generic
message.

**Error shape** — violations are collected in a single pass and
returned together in `display_message`. Illegal-role issues (tool
anywhere, system at a non-zero index) are reported alone when present,
to avoid drowning the user in alternation noise they would cause.

The `configuration` endpoint is untouched — that request type carries
no `messages`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [x] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
