### PR TITLE
chore: make transformer and prompt provider pipelines async

### DIFF
--- a/src/quickapp/agent/_messages_transformers.py
+++ b/src/quickapp/agent/_messages_transformers.py
@@ -15,11 +15,11 @@ class _AddSystemPromptTransformer(MessagesTransformer):
         self.__prompt_providers = prompt_providers
         logger.debug(f"Prompt part providers: {prompt_providers}")
 
-    def transform(self, messages: list[Message]) -> list[Message]:
+    async def transform(self, messages: list[Message]) -> list[Message]:
         # Construct system prompt from all providers
         prompt_parts = []
         for provider in self.__prompt_providers:
-            part = provider.get_prompt_part()
+            part = await provider.get_prompt_part()
             if part:  # Only add non-empty parts
                 prompt_parts.append(part)
 

--- a/src/quickapp/agent/_prompt_providers.py
+++ b/src/quickapp/agent/_prompt_providers.py
@@ -15,7 +15,7 @@ class ConfigBasedPromptProvider(PromptPartProvider):
     def __init__(self, config_provider: ProviderOf[ApplicationConfig]):
         self.__config_provider = config_provider
 
-    def get_prompt_part(self) -> str:
+    async def get_prompt_part(self) -> str:
         """Return the system prompt from config.
 
         Returns:

--- a/src/quickapp/application/_messages_setup.py
+++ b/src/quickapp/application/_messages_setup.py
@@ -27,10 +27,10 @@ class _MessagesSetup:
         self.__transformers = transformers
         logger.debug(f"Messages transformers: {transformers}")
 
-    def setup(self, messages: list[Message]) -> list[Message]:
+    async def setup(self, messages: list[Message]) -> list[Message]:
         messages = self.extract_tool_calls(messages)
         for transformer in self.__transformers:
-            messages = transformer.transform(messages)
+            messages = await transformer.transform(messages)
         return messages
 
     @staticmethod

--- a/src/quickapp/application/_request_context_setup.py
+++ b/src/quickapp/application/_request_context_setup.py
@@ -56,7 +56,7 @@ class _RequestContextSetup:
         )
         log_customised_catch_all_strategies(context.application_config)
         if isinstance(request, Request):
-            context.messages = self.__messages_setup.setup(request.messages)
+            context.messages = await self.__messages_setup.setup(request.messages)
             context.forwarded_headers = extract_x_headers_from_request(request)
             context.client_channel_id = _extract_client_channel_id(context.forwarded_headers)
         if choice:

--- a/src/quickapp/attachment_processing/_attachment_notification_injector.py
+++ b/src/quickapp/attachment_processing/_attachment_notification_injector.py
@@ -28,7 +28,7 @@ class _AttachmentNotificationInjector(MessagesTransformer):
     def __init__(self, config_provider: ProviderOf[ApplicationConfig]):
         self.__config_provider: ProviderOf[ApplicationConfig] = config_provider
 
-    def transform(self, messages: list[Message]) -> list[Message]:
+    async def transform(self, messages: list[Message]) -> list[Message]:
         contexts = list(self.__config_provider.get().contexts)
 
         if not should_activate_context_tool(contexts, messages):

--- a/src/quickapp/common/abstract/base_prompt_provider.py
+++ b/src/quickapp/common/abstract/base_prompt_provider.py
@@ -9,7 +9,7 @@ class PromptPartProvider(ABC):
     """
 
     @abstractmethod
-    def get_prompt_part(self) -> str:
+    async def get_prompt_part(self) -> str:
         """Return the prompt part provided by this provider.
 
         Returns:

--- a/src/quickapp/common/abstract/base_transformer.py
+++ b/src/quickapp/common/abstract/base_transformer.py
@@ -10,7 +10,7 @@ class MessagesTransformer(ABC):
     """
 
     @abstractmethod
-    def transform(self, messages: list[Message]) -> list[Message]: ...
+    async def transform(self, messages: list[Message]) -> list[Message]: ...
 
 
 class PreInvocationTransformer(ABC):

--- a/src/quickapp/skills/_inject_file_transfer_instruction_transformer.py
+++ b/src/quickapp/skills/_inject_file_transfer_instruction_transformer.py
@@ -28,7 +28,7 @@ class _InjectFileTransferInstructionTransformer(MessagesTransformer):
     def __init__(self, skills_provider: AgentSkillsProvider):
         self.__skills_provider = skills_provider
 
-    def transform(self, messages: list[Message]) -> list[Message]:
+    async def transform(self, messages: list[Message]) -> list[Message]:
         # Check if synthetic tool call already exists in history
         if self._has_synthetic_tool_call(messages):
             logger.debug("Synthetic file transfer instruction already present, skipping injection")

--- a/src/quickapp/skills/agent_skills_provider.py
+++ b/src/quickapp/skills/agent_skills_provider.py
@@ -188,7 +188,7 @@ class AgentSkillsProvider(PromptPartProvider):
         """Return XML metadata for all available skills."""
         return self._xml_metadata
 
-    def get_prompt_part(self) -> str:
+    async def get_prompt_part(self) -> str:
         """Return skills XML for inclusion in the system prompt."""
         return self.get_skills_xml()
 

--- a/src/quickapp/timestamp_tooling/_timestamp_injection_transformer.py
+++ b/src/quickapp/timestamp_tooling/_timestamp_injection_transformer.py
@@ -31,7 +31,7 @@ class _TimestampInjectionTransformer(MessagesTransformer):
         self.__time_provider = time_provider
         self.__config_provider = config_provider
 
-    def transform(self, messages: list[Message]) -> list[Message]:
+    async def transform(self, messages: list[Message]) -> list[Message]:
         features = self.__config_provider.get().features
         if features is None or features.timestamp is None or not messages:
             return messages

--- a/src/tests/unit_tests/application_tests/test_extract_tool_calls_processor.py
+++ b/src/tests/unit_tests/application_tests/test_extract_tool_calls_processor.py
@@ -1,5 +1,6 @@
 import warnings
 
+import pytest
 from aidial_sdk.chat_completion import CustomContent, FunctionCall, ToolCall
 from aidial_sdk.chat_completion.request import Message, Role
 
@@ -14,25 +15,28 @@ def make_tool_call(id: str, name: str = "test_tool", arguments: str = "{}") -> T
 class TestExtractToolCallsFromStateProcessor:
     """Tests for ExtractToolCallsFromStateProcessor."""
 
-    def test_empty_messages_returns_empty(self):
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_empty(self):
         msgs_setup = _MessagesSetup([])
-        result = msgs_setup.setup([])
+        result = await msgs_setup.setup([])
         assert result == []
 
-    def test_messages_without_state_unchanged(self):
+    @pytest.mark.asyncio
+    async def test_messages_without_state_unchanged(self):
         msgs_setup = _MessagesSetup([])
         messages = [
             Message(role=Role.USER, content="hello"),
             Message(role=Role.ASSISTANT, content="hi there"),
         ]
 
-        result = msgs_setup.setup(messages)
+        result = await msgs_setup.setup(messages)
 
         assert len(result) == 2
         assert result[0].role == Role.USER
         assert result[1].role == Role.ASSISTANT
 
-    def test_message_without_tool_history_unchanged(self):
+    @pytest.mark.asyncio
+    async def test_message_without_tool_history_unchanged(self):
         msgs_setup = _MessagesSetup([])
         messages = [
             Message(
@@ -42,12 +46,13 @@ class TestExtractToolCallsFromStateProcessor:
             )
         ]
 
-        result = msgs_setup.setup(messages)
+        result = await msgs_setup.setup(messages)
 
         assert len(result) == 1
         assert result[0].content == "response"
 
-    def test_new_format_single_tool_call(self):
+    @pytest.mark.asyncio
+    async def test_new_format_single_tool_call(self):
         """Test extraction of new message-based format with single tool call."""
         msgs_setup = _MessagesSetup([])
         tc = make_tool_call("tc-1", "my_tool")
@@ -65,7 +70,7 @@ class TestExtractToolCallsFromStateProcessor:
             )
         ]
 
-        result = msgs_setup.setup(messages)
+        result = await msgs_setup.setup(messages)
 
         # Should have: ASSISTANT (from history), TOOL (from history), ASSISTANT (final)
         assert len(result) == 3
@@ -78,7 +83,8 @@ class TestExtractToolCallsFromStateProcessor:
         assert result[2].role == Role.ASSISTANT
         assert result[2].content == "final response"
 
-    def test_new_format_parallel_tool_calls_preserved(self):
+    @pytest.mark.asyncio
+    async def test_new_format_parallel_tool_calls_preserved(self):
         """Key test: parallel tool calls should remain in ONE assistant message."""
         msgs_setup = _MessagesSetup([])
         tc1 = make_tool_call("tc-1", "tool_a")
@@ -105,7 +111,7 @@ class TestExtractToolCallsFromStateProcessor:
             )
         ]
 
-        result = msgs_setup.setup(messages)
+        result = await msgs_setup.setup(messages)
 
         # Should have: ASSISTANT (with 2 tool_calls), TOOL, TOOL, ASSISTANT (final)
         assert len(result) == 4
@@ -120,7 +126,8 @@ class TestExtractToolCallsFromStateProcessor:
         assert result[3].role == Role.ASSISTANT
         assert result[3].content == "done"
 
-    def test_new_format_multiple_iterations(self):
+    @pytest.mark.asyncio
+    async def test_new_format_multiple_iterations(self):
         """Test multiple sequential tool call iterations."""
         msgs_setup = _MessagesSetup([])
         tc1 = make_tool_call("tc-1", "tool_a")
@@ -141,7 +148,7 @@ class TestExtractToolCallsFromStateProcessor:
             )
         ]
 
-        result = msgs_setup.setup(messages)
+        result = await msgs_setup.setup(messages)
 
         # 4 from history + 1 final = 5 messages
         assert len(result) == 5
@@ -154,7 +161,8 @@ class TestExtractToolCallsFromStateProcessor:
         assert result[4].role == Role.ASSISTANT
         assert result[4].content == "final"
 
-    def test_legacy_format_backward_compatibility(self):
+    @pytest.mark.asyncio
+    async def test_legacy_format_backward_compatibility(self):
         """Test that legacy ExecutedToolCallDTO format still works with deprecation warning."""
         msgs_setup = _MessagesSetup([])
         tc = make_tool_call("tc-1", "my_tool")
@@ -181,7 +189,7 @@ class TestExtractToolCallsFromStateProcessor:
 
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            result = msgs_setup.setup(messages)
+            result = await msgs_setup.setup(messages)
 
             # Should emit deprecation warning about legacy tool_execution_history format
             deprecation_warnings = [
@@ -200,7 +208,8 @@ class TestExtractToolCallsFromStateProcessor:
         assert result[1].role == Role.TOOL
         assert result[2].role == Role.ASSISTANT
 
-    def test_tool_history_removed_from_final_message_state(self):
+    @pytest.mark.asyncio
+    async def test_tool_history_removed_from_final_message_state(self):
         """Verify that tool_execution_history is removed from the final message's state."""
         msgs_setup = _MessagesSetup([])
         tc = make_tool_call("tc-1", "my_tool")
@@ -220,7 +229,7 @@ class TestExtractToolCallsFromStateProcessor:
             )
         ]
 
-        result = msgs_setup.setup(messages)
+        result = await msgs_setup.setup(messages)
 
         # Final message should not have tool_execution_history but keep other state
         final_msg = result[-1]

--- a/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
+++ b/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
@@ -58,7 +58,7 @@ def test_context_file_notified_via_synthetic_tool_call():
     async def get_method(messages_setup: _MessagesSetup = Injected(_MessagesSetup)):
         messages = [_user_msg("hello")]
 
-        result = messages_setup.setup(messages)
+        result = await messages_setup.setup(messages)
 
         # Original + synthetic assistant tool_call + tool result
         assert len(result) == 3
@@ -92,7 +92,7 @@ def test_user_attachment_text_and_context_tool_call():
             )
         ]
 
-        result = messages_setup.setup(messages)
+        result = await messages_setup.setup(messages)
 
         # Original message + 2 synthetic messages for context
         assert len(result) == 3

--- a/src/tests/unit_tests/application_tests/test_request_context_setup.py
+++ b/src/tests/unit_tests/application_tests/test_request_context_setup.py
@@ -22,7 +22,7 @@ def _make_setup() -> tuple[_RequestContextSetup, _RequestContext]:
     config_resolver = MagicMock()
     config_resolver.resolve_config.return_value = MagicMock()
     messages_setup = MagicMock()
-    messages_setup.setup.return_value = []
+    messages_setup.setup = AsyncMock(return_value=[])
     setup = _RequestContextSetup(
         context_provider=context_provider,
         config_resolver=config_resolver,

--- a/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
+++ b/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
@@ -1,6 +1,7 @@
 import json
 from types import SimpleNamespace
 
+import pytest
 from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
 
 from quickapp.attachment_processing._attachment_notification_injector import (
@@ -42,26 +43,29 @@ def _extract_synthetic(result: list[Message], original_count: int) -> list[Messa
 
 
 class TestNoChanges:
-    def test_empty_messages_no_contexts(self):
+    @pytest.mark.asyncio
+    async def test_empty_messages_no_contexts(self):
         injector = _make_injector()
         messages: list[Message] = []
-        result = injector.transform(messages)
+        result = await injector.transform(messages)
         assert result == []
 
-    def test_no_attachments_no_contexts(self):
+    @pytest.mark.asyncio
+    async def test_no_attachments_no_contexts(self):
         injector = _make_injector()
         messages = [_user_msg("hello")]
-        result = injector.transform(messages)
+        result = await injector.transform(messages)
         assert len(result) == 1
         assert result[0].role == Role.USER
 
 
 class TestContextInjection:
-    def test_context_files_inject_synthetic_messages(self):
+    @pytest.mark.asyncio
+    async def test_context_files_inject_synthetic_messages(self):
         ctx = FileContextConfig(url="files/bucket/ref.csv", description="Reference data")
         injector = _make_injector(contexts=[ctx])
         messages = [_user_msg("hello")]
-        result = injector.transform(messages)
+        result = await injector.transform(messages)
         # Original + assistant tool_call + tool result for context
         assert len(result) == 3
         assert result[1].role == Role.ASSISTANT
@@ -73,7 +77,8 @@ class TestContextInjection:
         assert data["entries"][0]["description"] == "Reference data"
         assert data["entries"][0]["status"] == "new"
 
-    def test_second_call_same_contexts_no_injection(self):
+    @pytest.mark.asyncio
+    async def test_second_call_same_contexts_no_injection(self):
         """Fresh injector with history containing the same URLs produces no new messages."""
         ctx = FileContextConfig(url="files/bucket/ref.csv")
         contexts = [ctx]
@@ -81,22 +86,23 @@ class TestContextInjection:
         # Turn 1 — fresh injector, injects synthetic messages
         injector1 = _make_injector(contexts=contexts)
         messages = [_user_msg("hello")]
-        result1 = injector1.transform(messages)
+        result1 = await injector1.transform(messages)
         assert len(result1) == 3
 
         # Turn 2 — fresh injector, same contexts, history from turn 1
         injector2 = _make_injector(contexts=contexts)
-        result2 = injector2.transform(result1)
+        result2 = await injector2.transform(result1)
         assert len(result2) == 3  # unchanged, no new synthetic messages
 
-    def test_context_removal_injects_removed_entry(self):
+    @pytest.mark.asyncio
+    async def test_context_removal_injects_removed_entry(self):
         ctx = FileContextConfig(url="files/bucket/ref.pdf", description="Reference data")
         contexts: list[FileContextConfig] = [ctx]
         messages = [_user_msg("hello")]
 
         # Turn 1: context present
         injector1 = _make_injector(contexts=contexts)
-        result1 = injector1.transform(messages)
+        result1 = await injector1.transform(messages)
         assert len(result1) == 3
 
         # Remove the context
@@ -104,7 +110,7 @@ class TestContextInjection:
 
         # Turn 2: fresh injector, empty contexts, history from turn 1
         injector2 = _make_injector(contexts=contexts)
-        result2 = injector2.transform(result1)
+        result2 = await injector2.transform(result1)
         assert len(result2) == 5  # 3 original + 2 new synthetic
         synthetic = _extract_synthetic(result2, 3)
         data2 = json.loads(synthetic[1].content)
@@ -115,7 +121,8 @@ class TestContextInjection:
         assert data2["entries"][0]["description"] == "Reference data"
         assert data2["entries"][0]["status"] == "removed"
 
-    def test_context_lifecycle_add_remove_all(self):
+    @pytest.mark.asyncio
+    async def test_context_lifecycle_add_remove_all(self):
         file_a = FileContextConfig(url="files/bucket/a.csv", description="File A")
         file_b = FileContextConfig(url="files/bucket/b.pdf")
         contexts: list[FileContextConfig] = []
@@ -123,13 +130,13 @@ class TestContextInjection:
 
         # Step 1: no contexts — fresh injector, no injection
         injector1 = _make_injector(contexts=contexts)
-        result1 = injector1.transform(messages)
+        result1 = await injector1.transform(messages)
         assert len(result1) == 1
 
         # Step 2: add 2 files — fresh injector, both reported as new
         contexts.extend([file_a, file_b])
         injector2 = _make_injector(contexts=contexts)
-        result2 = injector2.transform(messages)
+        result2 = await injector2.transform(messages)
         assert len(result2) == 3
         data2 = json.loads(result2[2].content)
         assert len(data2["entries"]) == 2
@@ -140,13 +147,13 @@ class TestContextInjection:
 
         # Step 3: same files, with history — fresh injector, no injection
         injector3 = _make_injector(contexts=contexts)
-        result2b = injector3.transform(result2)
+        result2b = await injector3.transform(result2)
         assert len(result2b) == 3  # unchanged
 
         # Step 4: remove file_b — fresh injector, file_a still present, file_b removed
         contexts.remove(file_b)
         injector4 = _make_injector(contexts=contexts)
-        result3 = injector4.transform(result2)
+        result3 = await injector4.transform(result2)
         assert len(result3) == 5  # 3 original + 2 new synthetic
         synthetic3 = _extract_synthetic(result3, 3)
         data3 = json.loads(synthetic3[1].content)
@@ -160,7 +167,7 @@ class TestContextInjection:
         # Step 5: remove file_a — fresh injector, reported as removed
         contexts.clear()
         injector5 = _make_injector(contexts=contexts)
-        result4 = injector5.transform(result3)
+        result4 = await injector5.transform(result3)
         assert len(result4) == 7  # 5 original + 2 new synthetic
         synthetic4 = _extract_synthetic(result4, 5)
         data4 = json.loads(synthetic4[1].content)
@@ -169,14 +176,15 @@ class TestContextInjection:
         assert data4["entries"][0]["description"] == "File A"
         assert data4["entries"][0]["status"] == "removed"
 
-    def test_description_change_triggers_renotification(self):
+    @pytest.mark.asyncio
+    async def test_description_change_triggers_renotification(self):
         """When a context description changes but URL stays the same, re-notification occurs."""
         ctx = FileContextConfig(url="files/bucket/ref.csv", description="V1")
         messages = [_user_msg("hello")]
 
         # Turn 1: initial injection — status: new
         injector1 = _make_injector(contexts=[ctx])
-        result1 = injector1.transform(messages)
+        result1 = await injector1.transform(messages)
         assert len(result1) == 3
         data1 = json.loads(result1[2].content)
         assert data1["entries"][0]["status"] == "new"
@@ -185,7 +193,7 @@ class TestContextInjection:
         # Turn 2: same URL, description changed to V2 — status: updated
         ctx_v2 = FileContextConfig(url="files/bucket/ref.csv", description="V2")
         injector2 = _make_injector(contexts=[ctx_v2])
-        result2 = injector2.transform(result1)
+        result2 = await injector2.transform(result1)
         assert len(result2) == 5  # 3 original + 2 new synthetic
         synthetic2 = _extract_synthetic(result2, 3)
         data2 = json.loads(synthetic2[1].content)
@@ -194,26 +202,27 @@ class TestContextInjection:
 
         # Turn 3: same URL, same description V2 — no injection (stable)
         injector3 = _make_injector(contexts=[ctx_v2])
-        result3 = injector3.transform(result2)
+        result3 = await injector3.transform(result2)
         assert len(result3) == 5  # unchanged
 
-    def test_context_removal_then_no_change(self):
+    @pytest.mark.asyncio
+    async def test_context_removal_then_no_change(self):
         ctx = FileContextConfig(url="files/bucket/ref.csv")
         contexts: list[FileContextConfig] = [ctx]
         messages = [_user_msg("hello")]
 
         # Turn 1: context present
         injector1 = _make_injector(contexts=contexts)
-        result1 = injector1.transform(messages)
+        result1 = await injector1.transform(messages)
 
         # Remove the context
         contexts.clear()
 
         # Turn 2: removal detected
         injector2 = _make_injector(contexts=contexts)
-        result2 = injector2.transform(result1)
+        result2 = await injector2.transform(result1)
 
         # Turn 3: fresh injector, no change (still empty, last tool result has only removed)
         injector3 = _make_injector(contexts=contexts)
-        result3 = injector3.transform(result2)
+        result3 = await injector3.transform(result2)
         assert len(result3) == len(result2)  # no new synthetic messages

--- a/src/tests/unit_tests/skills_tests/test_inject_file_transfer_instruction_transformer.py
+++ b/src/tests/unit_tests/skills_tests/test_inject_file_transfer_instruction_transformer.py
@@ -1,3 +1,4 @@
+import pytest
 from aidial_sdk.chat_completion import Message, Role
 
 from quickapp.config.predefined_content_provider import (
@@ -40,37 +41,41 @@ def _assert_synthetic_pair(messages: list[Message], assistant_idx: int) -> None:
 class TestInjectFileTransferInstructionTransformer:
     """Tests for _InjectFileTransferInstructionTransformer."""
 
-    def test_skill_with_name_tool_call_file_parameter_formatting_is_present(self):
+    @pytest.mark.asyncio
+    async def test_skill_with_name_tool_call_file_parameter_formatting_is_present(self):
         """Verify the file-transfer skill is loaded and injected as a synthetic tool call."""
         transformer = _make_transformer()
-        result = transformer.transform([])
+        result = await transformer.transform([])
 
         assert len(result) == 2, "Expected assistant tool call + tool response"
         _assert_synthetic_pair(result, 0)
 
-    def test_injects_after_first_user_message_with_system(self):
+    @pytest.mark.asyncio
+    async def test_injects_after_first_user_message_with_system(self):
         """Synthetic pair is inserted after the first USER message, not after SYSTEM."""
         messages = [
             Message(role=Role.SYSTEM, content="system prompt"),
             Message(role=Role.USER, content="hello"),
         ]
-        result = _make_transformer().transform(messages)
+        result = await _make_transformer().transform(messages)
 
         assert len(result) == 4
         assert result[0].role == Role.SYSTEM
         assert result[1].role == Role.USER
         _assert_synthetic_pair(result, 2)
 
-    def test_injects_after_first_user_message_without_system(self):
+    @pytest.mark.asyncio
+    async def test_injects_after_first_user_message_without_system(self):
         """When there is no system message, inject after the first USER."""
         messages = [Message(role=Role.USER, content="hello")]
-        result = _make_transformer().transform(messages)
+        result = await _make_transformer().transform(messages)
 
         assert len(result) == 3
         assert result[0].role == Role.USER
         _assert_synthetic_pair(result, 1)
 
-    def test_injects_after_first_user_with_multiple_users(self):
+    @pytest.mark.asyncio
+    async def test_injects_after_first_user_with_multiple_users(self):
         """Synthetic pair is injected after the FIRST user message only."""
         messages = [
             Message(role=Role.SYSTEM, content="system prompt"),
@@ -78,7 +83,7 @@ class TestInjectFileTransferInstructionTransformer:
             Message(role=Role.ASSISTANT, content="reply"),
             Message(role=Role.USER, content="second"),
         ]
-        result = _make_transformer().transform(messages)
+        result = await _make_transformer().transform(messages)
 
         assert len(result) == 6
         assert result[0].role == Role.SYSTEM
@@ -90,24 +95,26 @@ class TestInjectFileTransferInstructionTransformer:
         assert result[5].role == Role.USER
         assert result[5].content == "second"
 
-    def test_no_user_message_appends_at_end(self):
+    @pytest.mark.asyncio
+    async def test_no_user_message_appends_at_end(self):
         """When there is no USER message, synthetic pair is appended at the end."""
         messages = [Message(role=Role.SYSTEM, content="system prompt")]
-        result = _make_transformer().transform(messages)
+        result = await _make_transformer().transform(messages)
 
         assert len(result) == 3
         assert result[0].role == Role.SYSTEM
         _assert_synthetic_pair(result, 1)
 
-    def test_skips_if_synthetic_already_present(self):
+    @pytest.mark.asyncio
+    async def test_skips_if_synthetic_already_present(self):
         """Transformer is idempotent — does not inject twice."""
         messages = [
             Message(role=Role.SYSTEM, content="system prompt"),
             Message(role=Role.USER, content="hello"),
         ]
         transformer = _make_transformer()
-        first_pass = transformer.transform(messages)
-        second_pass = transformer.transform(first_pass)
+        first_pass = await transformer.transform(messages)
+        second_pass = await transformer.transform(first_pass)
 
         assert len(second_pass) == len(first_pass)
         assert second_pass == first_pass

--- a/src/tests/unit_tests/timestamp_tooling/test_timestamp_injection_transformer.py
+++ b/src/tests/unit_tests/timestamp_tooling/test_timestamp_injection_transformer.py
@@ -1,6 +1,7 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
 from aidial_sdk.chat_completion import Message, Role
 
 from quickapp.common.time_provider import TimeProvider
@@ -30,20 +31,22 @@ def _make_transformer(enabled: bool = True) -> _TimestampInjectionTransformer:
 
 
 class TestTimestampInjectionTransformer:
-    def test_appends_two_synthetic_messages(self):
+    @pytest.mark.asyncio
+    async def test_appends_two_synthetic_messages(self):
         transformer = _make_transformer()
         messages = [Message(role=Role.USER, content="hello")]
 
-        result = transformer.transform(messages)
+        result = await transformer.transform(messages)
 
         assert len(result) == 3
         assert result[0] is messages[0]
         assert result[1].role == Role.ASSISTANT
         assert result[2].role == Role.TOOL
 
-    def test_synthetic_call_id_has_correct_prefix(self):
+    @pytest.mark.asyncio
+    async def test_synthetic_call_id_has_correct_prefix(self):
         transformer = _make_transformer()
-        result = transformer.transform([Message(role=Role.USER, content="hi")])
+        result = await transformer.transform([Message(role=Role.USER, content="hi")])
 
         assistant_msg = result[1]
         tool_msg = result[2]
@@ -52,16 +55,18 @@ class TestTimestampInjectionTransformer:
         assert call_id.startswith(SYNTHETIC_TIMESTAMP_CALL_PREFIX)
         assert tool_msg.tool_call_id == call_id
 
-    def test_tool_name_matches_config(self):
+    @pytest.mark.asyncio
+    async def test_tool_name_matches_config(self):
         transformer = _make_transformer()
-        result = transformer.transform([Message(role=Role.USER, content="hi")])
+        result = await transformer.transform([Message(role=Role.USER, content="hi")])
 
         assistant_msg = result[1]
         assert assistant_msg.tool_calls[0].function.name == CURRENT_TIMESTAMP_TOOL_NAME
 
-    def test_content_contains_iso_timestamp(self):
+    @pytest.mark.asyncio
+    async def test_content_contains_iso_timestamp(self):
         transformer = _make_transformer()
-        result = transformer.transform([Message(role=Role.USER, content="hi")])
+        result = await transformer.transform([Message(role=Role.USER, content="hi")])
 
         tool_msg = result[2]
         content = str(tool_msg.content)
@@ -69,24 +74,27 @@ class TestTimestampInjectionTransformer:
         assert "source=default" in content
         assert "T" in content
 
-    def test_does_not_modify_original_messages(self):
+    @pytest.mark.asyncio
+    async def test_does_not_modify_original_messages(self):
         transformer = _make_transformer()
         original = [Message(role=Role.USER, content="hi")]
-        result = transformer.transform(original)
+        result = await transformer.transform(original)
 
         assert len(original) == 1
         assert len(result) == 3
 
-    def test_empty_messages_returns_empty(self):
+    @pytest.mark.asyncio
+    async def test_empty_messages_returns_empty(self):
         transformer = _make_transformer()
         messages: list[Message] = []
-        result = transformer.transform(messages)
+        result = await transformer.transform(messages)
 
         assert result is messages
 
-    def test_noop_when_feature_disabled(self):
+    @pytest.mark.asyncio
+    async def test_noop_when_feature_disabled(self):
         transformer = _make_transformer(enabled=False)
         messages = [Message(role=Role.USER, content="hi")]
-        result = transformer.transform(messages)
+        result = await transformer.transform(messages)
 
         assert result is messages


### PR DESCRIPTION
### Applicable issues

<!-- N/A: preparatory refactor split off from the DIAL-prompts-as-skills feature PR. -->

### Description of changes

Convert `MessagesTransformer.transform` and `PromptPartProvider.get_prompt_part` from sync to async, and propagate through all implementations, callers, and tests. Mechanical refactor — no behavioral changes. Unblocks transformers/providers that need to perform async I/O.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.