### PR TITLE
chore: split agent skills provider into frontmatter, xml, and metadata helpers

### DIFF
--- a/src/quickapp/skills/_exceptions.py
+++ b/src/quickapp/skills/_exceptions.py
@@ -1,0 +1,7 @@
+class SkillValidationError(Exception):
+    """Raised by ``parse_frontmatter`` when skill content is invalid."""
+
+    def __init__(self, source_id: str, reason: str) -> None:
+        self.source_id = source_id
+        self.reason = reason
+        super().__init__(f"Skill validation failed for '{source_id}': {reason}")

--- a/src/quickapp/skills/_frontmatter.py
+++ b/src/quickapp/skills/_frontmatter.py
@@ -1,0 +1,77 @@
+import re
+
+import yaml
+
+from quickapp.skills._exceptions import SkillValidationError
+from quickapp.skills._skill_metadata import SkillMetadata
+
+_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_SKILL_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+
+
+def parse_frontmatter(content: str, source_id: str) -> SkillMetadata:
+    """Parse YAML frontmatter delimited by ``---`` and return validated SkillMetadata.
+
+    Raises:
+        SkillValidationError: If the content is missing frontmatter or
+            fails any validation rule.
+
+    Args:
+        content: The full skill content string.
+        source_id: Identifier for error messages (file path or prompt URL).
+    """
+    match = _FRONTMATTER_RE.match(content)
+
+    if not match:
+        raise SkillValidationError(source_id, "No YAML frontmatter found")
+
+    try:
+        parsed = yaml.safe_load(match.group(1))
+    except yaml.YAMLError as exc:
+        raise SkillValidationError(source_id, f"Failed to parse YAML frontmatter: {exc}")
+
+    if not isinstance(parsed, dict):
+        raise SkillValidationError(source_id, "YAML frontmatter is not a dictionary")
+
+    # Normalize 'allowed-tools' hyphenated key to 'allowed_tools'
+    if "allowed-tools" in parsed:
+        allowed_tools_value = parsed.pop("allowed-tools")
+        if isinstance(allowed_tools_value, str):
+            parsed["allowed_tools"] = allowed_tools_value.split()
+        elif isinstance(allowed_tools_value, list):
+            parsed["allowed_tools"] = allowed_tools_value
+        else:
+            raise SkillValidationError(source_id, "Invalid allowed-tools format")
+
+    name = parsed.get("name")
+    description = parsed.get("description")
+
+    if not name or not description:
+        raise SkillValidationError(source_id, "Missing required fields (name/description)")
+
+    if len(name) > 64:
+        raise SkillValidationError(source_id, f"Skill name exceeds 64 characters: {name}")
+
+    if "--" in name or not _SKILL_NAME_RE.match(name):
+        raise SkillValidationError(
+            source_id,
+            f"Invalid skill name format: {name}"
+            " (must be lowercase letters, numbers, hyphens;"
+            " no leading/trailing or consecutive hyphens)",
+        )
+
+    if len(description) > 1024:
+        raise SkillValidationError(source_id, "Description exceeds 1024 characters")
+
+    compatibility = parsed.get("compatibility")
+    if compatibility is not None and len(compatibility) > 500:
+        raise SkillValidationError(source_id, "Compatibility exceeds 500 characters")
+
+    return SkillMetadata(
+        name=name,
+        description=description,
+        license=parsed.get("license"),
+        compatibility=compatibility,
+        metadata=parsed.get("metadata") or None,
+        allowed_tools=parsed.get("allowed_tools"),
+    )

--- a/src/quickapp/skills/_skill_metadata.py
+++ b/src/quickapp/skills/_skill_metadata.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class SkillMetadata(BaseModel):
+    """Metadata extracted from a skill file's YAML frontmatter."""
+
+    name: str
+    description: str
+    license: str | None = None
+    compatibility: str | None = None
+    metadata: dict | None = None
+    allowed_tools: list[str] | None = None

--- a/src/quickapp/skills/_xml.py
+++ b/src/quickapp/skills/_xml.py
@@ -1,0 +1,46 @@
+from xml.sax.saxutils import escape as _stdlib_escape
+
+from quickapp.skills._skill_metadata import SkillMetadata
+
+_QUOTE_ENTITIES = {'"': "&quot;", "'": "&apos;"}
+
+
+def escape_xml(text: str) -> str:
+    """Escape XML special characters including quotes (for use in attributes)."""
+    return _stdlib_escape(text, _QUOTE_ENTITIES)
+
+
+def generate_skills_xml(skills: list[SkillMetadata]) -> str:
+    """Generate XML representation of available skills for the system prompt."""
+    if not skills:
+        return ""
+
+    xml_parts = ["<available_skills>"]
+
+    for skill_metadata in skills:
+        xml_parts.append("  <skill>")
+        xml_parts.append(f"    <name>{escape_xml(skill_metadata.name)}</name>")
+        xml_parts.append(f"    <description>{escape_xml(skill_metadata.description)}</description>")
+        if skill_metadata.license:
+            xml_parts.append(f"    <license>{escape_xml(skill_metadata.license)}</license>")
+        if skill_metadata.compatibility:
+            xml_parts.append(
+                f"    <compatibility>{escape_xml(skill_metadata.compatibility)}</compatibility>"
+            )
+        if skill_metadata.allowed_tools:
+            allowed_tools = " ".join(skill_metadata.allowed_tools)
+            xml_parts.append(f"    <allowed_tools>{escape_xml(allowed_tools)}</allowed_tools>")
+        if skill_metadata.metadata:
+            xml_parts.append("    <metadata>")
+            for key in sorted(skill_metadata.metadata):
+                raw_value = skill_metadata.metadata[key]
+                value = "" if raw_value is None else str(raw_value)
+                xml_parts.append(
+                    f'      <entry key="{escape_xml(str(key))}">{escape_xml(value)}</entry>'
+                )
+            xml_parts.append("    </metadata>")
+        xml_parts.append("  </skill>")
+
+    xml_parts.append("</available_skills>")
+
+    return "\n".join(xml_parts)

--- a/src/quickapp/skills/agent_skills_provider.py
+++ b/src/quickapp/skills/agent_skills_provider.py
@@ -1,25 +1,15 @@
 import logging
-import re
 
-import yaml
 from injector import inject
-from pydantic import BaseModel
 
 from quickapp.common.abstract.base_prompt_provider import PromptPartProvider
 from quickapp.config.predefined_content_provider import ContentType, PredefinedContentProvider
+from quickapp.skills._exceptions import SkillValidationError
+from quickapp.skills._frontmatter import parse_frontmatter
+from quickapp.skills._skill_metadata import SkillMetadata
+from quickapp.skills._xml import generate_skills_xml
 
 logger = logging.getLogger(__name__)
-
-
-class SkillMetadata(BaseModel):
-    """Metadata extracted from a skill file's YAML frontmatter."""
-
-    name: str
-    description: str
-    license: str | None = None
-    compatibility: str | None = None
-    metadata: dict | None = None
-    allowed_tools: list[str] | None = None
 
 
 @inject
@@ -34,127 +24,7 @@ class AgentSkillsProvider(PromptPartProvider):
         self._provider = provider
         self._load_skills()
 
-    @staticmethod
-    def _parse_frontmatter(content: str, file_name: str) -> SkillMetadata | None:
-        """Parse YAML frontmatter delimited by ``---`` and return validated SkillMetadata."""
-        frontmatter_pattern = r'^---\s*\n(.*?)\n---\s*\n'
-        match = re.match(frontmatter_pattern, content, re.DOTALL)
-
-        if not match:
-            logger.warning(f"No YAML frontmatter found in {file_name}")
-            return None
-
-        try:
-            parsed = yaml.safe_load(match.group(1))
-        except yaml.YAMLError as exc:
-            logger.error(f"Failed to parse YAML frontmatter in {file_name}: {exc}")
-            return None
-
-        if not isinstance(parsed, dict):
-            logger.warning(f"YAML frontmatter is not a dictionary in {file_name}")
-            return None
-
-        # Normalize 'allowed-tools' hyphenated key to 'allowed_tools'
-        if 'allowed-tools' in parsed:
-            allowed_tools_value = parsed.pop('allowed-tools')
-            if isinstance(allowed_tools_value, str):
-                parsed['allowed_tools'] = allowed_tools_value.split()
-            elif isinstance(allowed_tools_value, list):
-                parsed['allowed_tools'] = allowed_tools_value
-            else:
-                logger.warning(f"Invalid allowed-tools format in {file_name}")
-
-        name = parsed.get('name')
-        description = parsed.get('description')
-
-        if not name or not description:
-            logger.warning(f"Missing required fields (name/description) in {file_name}")
-            return None
-
-        if len(name) > 64:
-            logger.warning(f"Skill name exceeds 64 characters in {file_name}: {name}")
-            return None
-
-        if '--' in name or not re.match(r'^[a-z0-9]([a-z0-9-]*[a-z0-9])?$', name):
-            logger.warning(
-                f"Invalid skill name format in {file_name}: {name}"
-                " (must be lowercase letters, numbers, hyphens;"
-                " no leading/trailing or consecutive hyphens)"
-            )
-            return None
-
-        if len(description) > 1024:
-            logger.warning(f"Description exceeds 1024 characters in {file_name}")
-            return None
-
-        compatibility = parsed.get('compatibility')
-        if compatibility is not None and len(compatibility) > 500:
-            logger.warning(f"Compatibility exceeds 500 characters in {file_name}, truncating")
-            compatibility = compatibility[:500]
-
-        return SkillMetadata(
-            name=name,
-            description=description,
-            license=parsed.get('license'),
-            compatibility=compatibility,
-            metadata=parsed.get('metadata') or None,
-            allowed_tools=parsed.get('allowed_tools'),
-        )
-
-    def _generate_xml(self, skills: list[SkillMetadata]) -> str:
-        """Generate XML representation of available skills for the system prompt."""
-        if not skills:
-            return ""
-
-        xml_parts = ["<available_skills>"]
-
-        for skill_metadata in skills:
-            xml_parts.append("  <skill>")
-            xml_parts.append(f"    <name>{self._escape_xml(skill_metadata.name)}</name>")
-            xml_parts.append(
-                f"    <description>{self._escape_xml(skill_metadata.description)}</description>"
-            )
-            if skill_metadata.license:
-                xml_parts.append(
-                    f"    <license>{self._escape_xml(skill_metadata.license)}</license>"
-                )
-            if skill_metadata.compatibility:
-                xml_parts.append(
-                    f"    <compatibility>{self._escape_xml(skill_metadata.compatibility)}</compatibility>"
-                )
-            if skill_metadata.allowed_tools:
-                allowed_tools = " ".join(skill_metadata.allowed_tools)
-                xml_parts.append(
-                    f"    <allowed_tools>{self._escape_xml(allowed_tools)}</allowed_tools>"
-                )
-            if skill_metadata.metadata:
-                xml_parts.append("    <metadata>")
-                for key in sorted(skill_metadata.metadata):
-                    raw_value = skill_metadata.metadata[key]
-                    value = "" if raw_value is None else str(raw_value)
-                    xml_parts.append(
-                        f"      <entry key=\"{self._escape_xml(str(key))}\">{self._escape_xml(value)}</entry>"
-                    )
-                xml_parts.append("    </metadata>")
-            xml_parts.append("  </skill>")
-
-        xml_parts.append("</available_skills>")
-
-        return "\n".join(xml_parts)
-
-    @staticmethod
-    def _escape_xml(text: str) -> str:
-        """Escape XML special characters."""
-        return (
-            text.replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-            .replace('"', "&quot;")
-            .replace("'", "&apos;")
-        )
-
     def _load_skills(self) -> None:
-        """Load all skill files and generate XML metadata."""
         skill_names = self._provider.list_names(ContentType.SKILL)
 
         if not skill_names:
@@ -166,22 +36,25 @@ class AgentSkillsProvider(PromptPartProvider):
             try:
                 logger.debug(f"Loading skill `{file_stem}`")
                 content = self._provider.read_text(ContentType.SKILL, file_stem)
-                metadata = self._parse_frontmatter(content, file_stem)
-                if metadata is None:
-                    continue
-                if metadata.name != file_stem:
-                    logger.warning(
-                        "Skill name '%s' does not match directory name '%s'; skipping",
-                        metadata.name,
-                        file_stem,
-                    )
-                    continue
-                skills.append(metadata)
+                metadata = parse_frontmatter(content, file_stem)
+            except SkillValidationError as exc:
+                logger.warning(str(exc))
+                continue
             except Exception as exc:
                 logger.error(f"Failed to parse skill `{file_stem}`: {exc}")
+                continue
+
+            if metadata.name != file_stem:
+                logger.warning(
+                    "Skill name '%s' does not match directory name '%s'; skipping",
+                    metadata.name,
+                    file_stem,
+                )
+                continue
+            skills.append(metadata)
 
         self._skills = skills
-        self._xml_metadata = self._generate_xml(skills)
+        self._xml_metadata = generate_skills_xml(skills)
         logger.info(f"Loaded {len(skills)} skill(s)")
 
     def get_skills_xml(self) -> str:

--- a/src/tests/unit_tests/skills_tests/test_agent_skills_provider.py
+++ b/src/tests/unit_tests/skills_tests/test_agent_skills_provider.py
@@ -6,15 +6,19 @@ from quickapp.config.predefined_content_provider import (
     PredefinedContentProvider,
     PredefinedSettings,
 )
-from quickapp.skills.agent_skills_provider import AgentSkillsProvider, SkillMetadata
+from quickapp.skills._exceptions import SkillValidationError
+from quickapp.skills._frontmatter import parse_frontmatter
+from quickapp.skills._skill_metadata import SkillMetadata
+from quickapp.skills._xml import generate_skills_xml
+from quickapp.skills.agent_skills_provider import AgentSkillsProvider
 
 # ---------------------------------------------------------------------------
-# _parse_frontmatter unit tests
+# parse_frontmatter unit tests
 # ---------------------------------------------------------------------------
 
 
 class TestParseFrontmatter:
-    """Tests for AgentSkillsProvider._parse_frontmatter()."""
+    """Tests for parse_frontmatter()."""
 
     def test_valid_skill_all_fields(self):
         content = (
@@ -31,8 +35,7 @@ class TestParseFrontmatter:
             "---\n"
             "Body content\n"
         )
-        result = AgentSkillsProvider._parse_frontmatter(content, "my-skill")
-        assert result is not None
+        result = parse_frontmatter(content, "my-skill")
         assert isinstance(result, SkillMetadata)
         assert result.name == "my-skill"
         assert result.description == "A test skill"
@@ -41,43 +44,50 @@ class TestParseFrontmatter:
         assert result.metadata == {"version": "1.0"}
         assert result.allowed_tools == ["tool_a", "tool_b"]
 
-    def test_missing_name_returns_none(self):
+    def test_missing_name_raises(self):
         content = "---\ndescription: A skill without name\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_missing_description_returns_none(self):
+    def test_missing_description_raises(self):
         content = "---\nname: my-skill\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_name_exceeds_64_chars_returns_none(self):
+    def test_name_exceeds_64_chars_raises(self):
         long_name = "a" * 65
         content = f"---\nname: {long_name}\ndescription: desc\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_consecutive_hyphens_returns_none(self):
+    def test_consecutive_hyphens_raises(self):
         content = "---\nname: my--skill\ndescription: desc\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_leading_hyphen_returns_none(self):
+    def test_leading_hyphen_raises(self):
         content = "---\nname: -my-skill\ndescription: desc\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_trailing_hyphen_returns_none(self):
+    def test_trailing_hyphen_raises(self):
         content = "---\nname: my-skill-\ndescription: desc\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_invalid_yaml_returns_none(self):
+    def test_invalid_yaml_raises(self):
         content = "---\n: [invalid yaml\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_non_dict_yaml_returns_none(self):
+    def test_non_dict_yaml_raises(self):
         content = "---\n- item1\n- item2\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
     def test_allowed_tools_as_string_normalized_to_list(self):
         content = "---\nname: my-skill\ndescription: desc\nallowed-tools: tool1 tool2\n---\nBody\n"
-        result = AgentSkillsProvider._parse_frontmatter(content, "test")
-        assert result is not None
+        result = parse_frontmatter(content, "test")
         assert result.allowed_tools == ["tool1", "tool2"]
 
     def test_allowed_tools_as_list_kept(self):
@@ -85,48 +95,41 @@ class TestParseFrontmatter:
             "---\nname: my-skill\ndescription: desc\n"
             "allowed-tools:\n  - tool1\n  - tool2\n---\nBody\n"
         )
-        result = AgentSkillsProvider._parse_frontmatter(content, "test")
-        assert result is not None
+        result = parse_frontmatter(content, "test")
         assert result.allowed_tools == ["tool1", "tool2"]
 
-    def test_description_exceeds_1024_chars_returns_none(self):
+    def test_description_exceeds_1024_chars_raises(self):
         long_desc = "x" * 1025
         content = f"---\nname: my-skill\ndescription: {long_desc}\n---\nBody\n"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
-    def test_no_frontmatter_returns_none(self):
+    def test_no_frontmatter_raises(self):
         content = "Just some text without frontmatter"
-        assert AgentSkillsProvider._parse_frontmatter(content, "test") is None
+        with pytest.raises(SkillValidationError):
+            parse_frontmatter(content, "test")
 
 
 # ---------------------------------------------------------------------------
-# _generate_xml unit tests
+# generate_skills_xml unit tests
 # ---------------------------------------------------------------------------
 
 
-class TestGenerateXml:
-    """Tests for AgentSkillsProvider._generate_xml()."""
-
-    def _make_provider_for_xml(self) -> AgentSkillsProvider:
-        """Create a minimal provider with builtin content for calling _generate_xml."""
-        provider = PredefinedContentProvider(PredefinedSettings())
-        return AgentSkillsProvider(provider)
+class TestGenerateSkillsXml:
+    """Tests for generate_skills_xml()."""
 
     def test_empty_list_returns_empty_string(self):
-        asp = self._make_provider_for_xml()
-        assert asp._generate_xml([]) == ""
+        assert generate_skills_xml([]) == ""
 
     def test_single_skill_required_fields_only(self):
-        asp = self._make_provider_for_xml()
         skill = SkillMetadata(name="test-skill", description="A test skill")
-        xml = asp._generate_xml([skill])
+        xml = generate_skills_xml([skill])
         assert "<available_skills>" in xml
         assert "<name>test-skill</name>" in xml
         assert "<description>A test skill</description>" in xml
         assert "</available_skills>" in xml
 
     def test_skill_with_all_optional_fields(self):
-        asp = self._make_provider_for_xml()
         skill = SkillMetadata(
             name="full-skill",
             description="Full skill",
@@ -135,16 +138,15 @@ class TestGenerateXml:
             metadata={"version": "2.0"},
             allowed_tools=["tool_a", "tool_b"],
         )
-        xml = asp._generate_xml([skill])
+        xml = generate_skills_xml([skill])
         assert "<license>MIT</license>" in xml
         assert "<compatibility>&gt;=1.0</compatibility>" in xml
         assert "<allowed_tools>tool_a tool_b</allowed_tools>" in xml
         assert '<entry key="version">2.0</entry>' in xml
 
     def test_xml_escaping_of_special_characters(self):
-        asp = self._make_provider_for_xml()
         skill = SkillMetadata(name="esc-skill", description="Use <b>&amp;</b> 'quotes'")
-        xml = asp._generate_xml([skill])
+        xml = generate_skills_xml([skill])
         assert "&lt;b&gt;&amp;amp;&lt;/b&gt;" in xml
         assert "&apos;quotes&apos;" in xml
 


### PR DESCRIPTION
### Applicable issues

<!-- N/A: preparatory refactor split off from the DIAL-prompts-as-skills feature PR. Stacked on top of #246. -->

### Description of changes

Extract single-responsibility modules out of \`AgentSkillsProvider\`:

- \`_skill_metadata.py\` — \`SkillMetadata\` data model
- \`_frontmatter.py\` — \`parse_frontmatter()\`, raises \`SkillValidationError\` instead of returning \`None\`
- \`_xml.py\` — \`generate_skills_xml()\` + \`escape_xml()\`
- \`_exceptions.py\` — \`SkillValidationError\`

\`AgentSkillsProvider\` now composes these helpers; public API (\`get_skills_xml\`, \`get_prompt_part\`, \`get_skill_content\`) is unchanged.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.