### PR TITLE
fix: restore bearer token forwarding for deployment tools

### DIFF
--- a/src/quickapp/dial_deployment_tooling/dial_deployment_tooling_module.py
+++ b/src/quickapp/dial_deployment_tooling/dial_deployment_tooling_module.py
@@ -50,7 +50,7 @@ class DialDeploymentToolingModule(Module):
         headers = dict(forwarded_headers or {})
 
         if bearer:
-            headers.setdefault("Authorization", f"Bearer {bearer.get_secret_value()}")
+            headers["Authorization"] = f"Bearer {bearer.get_secret_value()}"
 
         return AsyncAzureOpenAI(
             azure_endpoint=dial_settings.url,

--- a/src/quickapp/dial_deployment_tooling/dial_deployment_tooling_module.py
+++ b/src/quickapp/dial_deployment_tooling/dial_deployment_tooling_module.py
@@ -4,7 +4,13 @@ from fastapi_injector import request_scope
 from injector import Binder, Module, ProviderOf, multiprovider, provider, singleton
 from openai.lib.azure import AsyncAzureOpenAI
 
-from quickapp.common import DEPLOYMENT_AZURE_CLIENT, DIAL_API_KEY, ForwardedHeaders, StagedBaseTool
+from quickapp.common import (
+    DEPLOYMENT_AZURE_CLIENT,
+    DIAL_API_KEY,
+    DIAL_BEARER,
+    ForwardedHeaders,
+    StagedBaseTool,
+)
 from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.exceptions import InitializationException
@@ -39,12 +45,18 @@ class DialDeploymentToolingModule(Module):
         api_key: DIAL_API_KEY,
         forwarded_headers: ForwardedHeaders,
         timeout_resolver: ToolTimeoutResolver,
+        bearer: DIAL_BEARER,
     ) -> DEPLOYMENT_AZURE_CLIENT:
+        headers = dict(forwarded_headers or {})
+
+        if bearer:
+            headers.setdefault("Authorization", f"Bearer {bearer.get_secret_value()}")
+
         return AsyncAzureOpenAI(
             azure_endpoint=dial_settings.url,
             api_key=api_key.get_secret_value(),
             api_version=dial_settings.api_version,
-            default_headers=forwarded_headers or None,
+            default_headers=headers,
             timeout=build_async_dial_timeout(timeout_resolver.resolve()),
         )
 

--- a/src/tests/unit_tests/application_tests/test_request_context_setup.py
+++ b/src/tests/unit_tests/application_tests/test_request_context_setup.py
@@ -76,3 +76,35 @@ async def test_configuration_request_sets_client_channel_id_none():
     with _PATCH_MODEL_VALIDATE:
         await setup.setup_context(request)
     assert context.client_channel_id is None
+
+
+@pytest.mark.asyncio
+async def test_chat_request_sets_bearer_from_request_token():
+    setup, context = _make_setup()
+    request = _make_chat_request(headers={})
+    with _PATCH_MODEL_VALIDATE:
+        await setup.setup_context(request)
+
+    assert context.bearer is not None
+    assert context.bearer.get_secret_value() == "test-bearer"
+
+
+@pytest.mark.asyncio
+async def test_configuration_request_sets_bearer_none():
+    setup, context = _make_setup()
+    request = _make_config_request()
+    with _PATCH_MODEL_VALIDATE:
+        await setup.setup_context(request)
+
+    assert context.bearer is None
+
+
+@pytest.mark.asyncio
+async def test_chat_request_handles_missing_bearer_token():
+    setup, context = _make_setup()
+    request = _make_chat_request(headers={})
+    request.bearer_token = None
+    with _PATCH_MODEL_VALIDATE:
+        await setup.setup_context(request)
+
+    assert context.bearer is None

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import openai
 from pydantic import SecretStr
@@ -20,8 +20,81 @@ def test_provide_deployment_openai_client_applies_resolved_timeout():
         api_key=api_key,
         forwarded_headers=None,
         timeout_resolver=resolver,
+        bearer=None,
     )
 
     expected = openai.Timeout(connect=5.0, read=42.0, write=42.0, pool=42.0)
     assert client.timeout == expected
     resolver.resolve.assert_called_once()
+
+
+def test_provide_deployment_openai_client_forwards_bearer_to_default_headers():
+    module = DialDeploymentToolingModule()
+    dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
+    api_key = SecretStr("test-key")
+    resolver = noop_timeout_resolver(value=42.0)
+
+    with patch(
+        "quickapp.dial_deployment_tooling.dial_deployment_tooling_module.AsyncAzureOpenAI"
+    ) as openai_client:
+        openai_client.return_value = MagicMock()
+
+        module.provide_deployment_openai_client(
+            dial_settings=dial_settings,
+            api_key=api_key,
+            forwarded_headers={"X-Request-Id": "req-1"},
+            timeout_resolver=resolver,
+            bearer=SecretStr("incoming-token"),
+        )
+
+    expected_timeout = openai.Timeout(connect=5.0, read=42.0, write=42.0, pool=42.0)
+    assert openai_client.call_args.kwargs["default_headers"] == {
+        "X-Request-Id": "req-1",
+        "Authorization": "Bearer incoming-token",
+    }
+    assert openai_client.call_args.kwargs["timeout"] == expected_timeout
+    resolver.resolve.assert_called_once()
+
+
+def test_provide_deployment_openai_client_keeps_forwarded_authorization_header():
+    module = DialDeploymentToolingModule()
+    dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
+    api_key = SecretStr("test-key")
+
+    with patch(
+        "quickapp.dial_deployment_tooling.dial_deployment_tooling_module.AsyncAzureOpenAI"
+    ) as openai_client:
+        openai_client.return_value = MagicMock()
+
+        module.provide_deployment_openai_client(
+            dial_settings=dial_settings,
+            api_key=api_key,
+            forwarded_headers={"Authorization": "Bearer forwarded-token"},
+            timeout_resolver=noop_timeout_resolver(),
+            bearer=SecretStr("incoming-token"),
+        )
+
+    assert openai_client.call_args.kwargs["default_headers"]["Authorization"] == (
+        "Bearer forwarded-token"
+    )
+
+
+def test_provide_deployment_openai_client_handles_missing_bearer_without_authorization_header():
+    module = DialDeploymentToolingModule()
+    dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
+    api_key = SecretStr("test-key")
+
+    with patch(
+        "quickapp.dial_deployment_tooling.dial_deployment_tooling_module.AsyncAzureOpenAI"
+    ) as openai_client:
+        openai_client.return_value = MagicMock()
+
+        module.provide_deployment_openai_client(
+            dial_settings=dial_settings,
+            api_key=api_key,
+            forwarded_headers={"X-Request-Id": "req-1"},
+            timeout_resolver=noop_timeout_resolver(),
+            bearer=None,
+        )
+
+    assert openai_client.call_args.kwargs["default_headers"] == {"X-Request-Id": "req-1"}

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
@@ -56,33 +56,6 @@ def test_provide_deployment_openai_client_forwards_bearer_to_default_headers():
     resolver.resolve.assert_called_once()
 
 
-def test_provide_deployment_openai_client_bearer_overwrites_forwarded_authorization_header():
-    module = DialDeploymentToolingModule()
-    dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
-    api_key = SecretStr("test-key")
-
-    with patch(
-        "quickapp.dial_deployment_tooling.dial_deployment_tooling_module.AsyncAzureOpenAI"
-    ) as openai_client:
-        openai_client.return_value = MagicMock()
-
-        module.provide_deployment_openai_client(
-            dial_settings=dial_settings,
-            api_key=api_key,
-            forwarded_headers={
-                "Authorization": "Bearer forwarded-token",
-                "X-Request-Id": "req-1",
-            },
-            timeout_resolver=noop_timeout_resolver(),
-            bearer=SecretStr("incoming-token"),
-        )
-
-    assert openai_client.call_args.kwargs["default_headers"] == {
-        "Authorization": "Bearer incoming-token",
-        "X-Request-Id": "req-1",
-    }
-
-
 def test_provide_deployment_openai_client_handles_missing_bearer_without_authorization_header():
     module = DialDeploymentToolingModule()
     dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_dial_deployment_tooling_module.py
@@ -56,7 +56,7 @@ def test_provide_deployment_openai_client_forwards_bearer_to_default_headers():
     resolver.resolve.assert_called_once()
 
 
-def test_provide_deployment_openai_client_keeps_forwarded_authorization_header():
+def test_provide_deployment_openai_client_bearer_overwrites_forwarded_authorization_header():
     module = DialDeploymentToolingModule()
     dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
     api_key = SecretStr("test-key")
@@ -69,14 +69,18 @@ def test_provide_deployment_openai_client_keeps_forwarded_authorization_header()
         module.provide_deployment_openai_client(
             dial_settings=dial_settings,
             api_key=api_key,
-            forwarded_headers={"Authorization": "Bearer forwarded-token"},
+            forwarded_headers={
+                "Authorization": "Bearer forwarded-token",
+                "X-Request-Id": "req-1",
+            },
             timeout_resolver=noop_timeout_resolver(),
             bearer=SecretStr("incoming-token"),
         )
 
-    assert openai_client.call_args.kwargs["default_headers"]["Authorization"] == (
-        "Bearer forwarded-token"
-    )
+    assert openai_client.call_args.kwargs["default_headers"] == {
+        "Authorization": "Bearer incoming-token",
+        "X-Request-Id": "req-1",
+    }
 
 
 def test_provide_deployment_openai_client_handles_missing_bearer_without_authorization_header():

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
@@ -2,6 +2,7 @@ import base64
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import pytest
+from pydantic import SecretStr
 
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.oauth_token_fetcher import OAuthTokenFetcher
@@ -388,3 +389,63 @@ async def test_tool_names_prefixed_with_toolset_name(initializer_factory, builde
     assert len(calls) == 2
     names = [c.kwargs["tool_config"].open_ai_tool.function.name for c in calls]
     assert names == ["mcp-local-toolset_tool1", "mcp-local-toolset_tool2"]
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_forwards_request_bearer_for_dial_internal_server():
+    server_info = MCPServerInfo(
+        url="https://dial.test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+    )
+    toolset_info = MCPToolSet(mcp_server_info=server_info, allowed_tools=None, name="set1")
+
+    conn_manager = _MCPConnectionManager(
+        toolset_info=toolset_info,
+        oauth_token_fetcher=AsyncMock(),
+        dial_settings=DialSettings(url="https://dial.test"),
+        timeout_resolver=noop_timeout_resolver(),
+        bearer=SecretStr("request-token"),
+    )
+
+    headers = await conn_manager._MCPConnectionManager__build_headers(server_info)
+
+    assert headers["Authorization"] == "Bearer request-token"
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_does_not_forward_request_bearer_for_external_server():
+    server_info = MCPServerInfo(
+        url="https://external.test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+    )
+    toolset_info = MCPToolSet(mcp_server_info=server_info, allowed_tools=None, name="set1")
+
+    conn_manager = _MCPConnectionManager(
+        toolset_info=toolset_info,
+        oauth_token_fetcher=AsyncMock(),
+        dial_settings=DialSettings(url="https://dial.test"),
+        timeout_resolver=noop_timeout_resolver(),
+        bearer=SecretStr("request-token"),
+    )
+
+    headers = await conn_manager._MCPConnectionManager__build_headers(server_info)
+
+    assert "Authorization" not in headers
+
+
+@pytest.mark.asyncio
+async def test_connection_manager_handles_missing_request_bearer_for_dial_internal_server():
+    server_info = MCPServerInfo(
+        url="https://dial.test/mcp", authorization=None, protocol=MCPProtocol.streamable_http
+    )
+    toolset_info = MCPToolSet(mcp_server_info=server_info, allowed_tools=None, name="set1")
+
+    conn_manager = _MCPConnectionManager(
+        toolset_info=toolset_info,
+        oauth_token_fetcher=AsyncMock(),
+        dial_settings=DialSettings(url="https://dial.test"),
+        timeout_resolver=noop_timeout_resolver(),
+        bearer=None,
+    )
+
+    headers = await conn_manager._MCPConnectionManager__build_headers(server_info)
+
+    assert "Authorization" not in headers


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- Regression: token forwarding to downstream deployments used by `DeploymentTool` stopped working.

### Description of changes

This PR adds regression coverage for forwarding the incoming bearer token into downstream DIAL calls and ensures the application does not fail when the incoming `Authorization` header is absent.

#### Functional changes
- Updated `provide_deployment_openai_client` to support forwarding bearer auth together with forwarded headers.
- Added tests to ensure token-forwarding mechanics work correctly for MCP and Deployment tools.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Changes are tested on review environment
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
