### PR TITLE
hotfix: revert toolset name usage in DIAL deployment tools

### DIFF
--- a/src/quickapp/dial_deployment_tooling/_deployment_tool_initializer.py
+++ b/src/quickapp/dial_deployment_tooling/_deployment_tool_initializer.py
@@ -4,7 +4,6 @@ from injector import AssistedBuilder, inject
 
 from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.exceptions import ToolInitializationException
-from quickapp.common.utils import sanitize_toolname
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.tools.deployment import DialDeploymentTool
 from quickapp.config.tools.deployment_simple import DialDeploymentSimpleTool
@@ -38,35 +37,21 @@ class _DeploymentToolInitializer(CompletionInitializer):
             if isinstance(toolset, DeploymentToolSet) and toolset.enabled:
                 for tool in toolset.tools:
                     if isinstance(tool, DialDeploymentTool) and tool.enabled:
-                        self.__init_deployment_tool(tool, toolset.name)
+                        self.__init_deployment_tool(tool)
                     if isinstance(tool, DialDeploymentSimpleTool) and tool.enabled:
-                        await self.__init_simple_deployment_tool(tool, toolset.name)
+                        await self.__init_simple_deployment_tool(tool)
 
-    def __init_deployment_tool(self, tool: DialDeploymentTool, toolset_name: str):
-        prefixed_name = sanitize_toolname(f"{toolset_name}_{tool.open_ai_tool.function.name}")
-        prefixed_tool = tool.model_copy(
-            update={
-                "open_ai_tool": tool.open_ai_tool.model_copy(
-                    update={
-                        "function": tool.open_ai_tool.function.model_copy(
-                            update={"name": prefixed_name}
-                        )
-                    }
-                )
-            }
-        )
+    def __init_deployment_tool(self, tool: DialDeploymentTool):
         built_tool = self.__builder.build(
             application_id=tool.deployment.name,
-            application_name=prefixed_name,
-            description=prefixed_tool.open_ai_tool.function.description,
+            application_name=tool.open_ai_tool.function.name,
+            description=tool.open_ai_tool.function.description,
             content_propagation=tool.content_propagation,
-            tool_config=prefixed_tool,
+            tool_config=tool,
         )
         self.__deployment_context.append_tool(built_tool)
 
-    async def __init_simple_deployment_tool(
-        self, tool_info: DialDeploymentSimpleTool, toolset_name: str
-    ):
+    async def __init_simple_deployment_tool(self, tool_info: DialDeploymentSimpleTool):
         try:
             tool_config = await self.__deployment_cache.get(
                 f"basic_config_{tool_info.deployment_id}",
@@ -75,7 +60,7 @@ class _DeploymentToolInitializer(CompletionInitializer):
             )
             if tool_config is None:
                 raise ToolInitializationException(f"No tool config for {tool_info.deployment_id}")
-            self.__init_deployment_tool(tool_config, toolset_name)
+            self.__init_deployment_tool(tool_config)
 
         except ToolInitializationException as e:
             logger.error(e, exc_info=True)

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_deployment_tool_initializer.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_deployment_tool_initializer.py
@@ -51,10 +51,10 @@ async def test_tool_names_prefixed_with_toolset_name():
     await _make_initializer(toolset, builder).initialize()
 
     builder.build.assert_called_once()
-    assert builder.build.call_args.kwargs["application_name"] == "chat-hub_image_generation_tool"
+    assert builder.build.call_args.kwargs["application_name"] == "image_generation_tool"
     assert (
         builder.build.call_args.kwargs["tool_config"].open_ai_tool.function.name
-        == "chat-hub_image_generation_tool"
+        == "image_generation_tool"
     )
 
 
@@ -67,8 +67,5 @@ async def test_tool_names_hyphenated_toolset_name_preserved():
 
     await _make_initializer(toolset, builder).initialize()
 
-    assert builder.build.call_args.kwargs["application_name"] == "my-api-toolset_search_web"
-    assert (
-        builder.build.call_args.kwargs["tool_config"].open_ai_tool.function.name
-        == "my-api-toolset_search_web"
-    )
+    assert builder.build.call_args.kwargs["application_name"] == "search_web"
+    assert builder.build.call_args.kwargs["tool_config"].open_ai_tool.function.name == "search_web"


### PR DESCRIPTION
### Description of changes

<!-- Please explain the changes you made right below this line. -->

Reverted toolset name usage in tool naming in DIAL deployment tools.

The issue, is that DIAL Deployment are not packed in natural toolsets, as it happens with MCP toolsets. That makes usage of toolset name in tool naming fragile and ambiguous for agent.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
