### PR TITLE
chore: add the internal tools list dump script.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export PYDANTIC_V2=True
 
 .PHONY: init_venv install install_dev install_integration install_all clean \
 	lint mypy format install_pre_commit_hooks run_chat test test_cov \
-	dump_app_schema generate_dial_config start_test_server stop_test_server \
+	dump_app_schema dump_internal_tools generate_dial_config start_test_server stop_test_server \
 	integration_test integration_test_run e2e_test run_python \
 	black black_check isort isort_check autoflake autoflake_check flake8
 
@@ -45,6 +45,7 @@ lint: install_dev
 	$(POETRY) run autoflake $(SRC_DIRS) --check
 	$(POETRY) run mypy --show-error-codes $(MYPY_DIRS)
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json --check
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_internal_tools.py docs/generated-internal-tools.json --check
 
 mypy: install_dev
 	$(POETRY) run mypy --show-error-codes $(MYPY_DIRS)
@@ -57,6 +58,7 @@ format: install_dev
 	$(POETRY) run isort $(FILES)
 ifeq ($(FILES), $(SRC_DIRS))
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_internal_tools.py docs/generated-internal-tools.json
 endif
 
 # --- Individual tool targets (honor FILES variable) ---
@@ -106,6 +108,9 @@ test_cov: install_dev
 
 dump_app_schema: install_dev
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
+
+dump_internal_tools: install_dev
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_internal_tools.py docs/generated-internal-tools.json
 
 generate_dial_config: install_dev
 	$(POETRY) run python src/scripts/generate_dial_config.py --models \

--- a/docs/generated-internal-tools.json
+++ b/docs/generated-internal-tools.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name": "internal_attachments_available_context",
+    "description": "Returns metadata about admin-configured context files. **IMPORTANT**: this tool is not applicable to user-attached files or files from tool results, and will not return any information about them. If you see file in <attachments> section of user message, it means that the file was attached by the user, and is available for you to use."
+  },
+  {
+    "name": "internal_skills_read_skill",
+    "description": "Read the full content of an agent skill. Use this tool when you need to get detailed instructions about a specific skill that is available to you."
+  },
+  {
+    "name": "internal_timeawareness_current_timestamp",
+    "description": "Returns the current date and time. Optionally converts to a specific timezone."
+  }
+]

--- a/docs/generated-internal-tools.json
+++ b/docs/generated-internal-tools.json
@@ -1,14 +1,46 @@
 [
   {
     "name": "internal_attachments_available_context",
-    "description": "Returns metadata about admin-configured context files. **IMPORTANT**: this tool is not applicable to user-attached files or files from tool results, and will not return any information about them. If you see file in <attachments> section of user message, it means that the file was attached by the user, and is available for you to use."
+    "description": "Returns metadata about admin-configured context files. **IMPORTANT**: this tool is not applicable to user-attached files or files from tool results, and will not return any information about them. If you see file in <attachments> section of user message, it means that the file was attached by the user, and is available for you to use.",
+    "signature": {
+      "type": "object",
+      "properties": {}
+    }
   },
   {
     "name": "internal_skills_read_skill",
-    "description": "Read the full content of an agent skill. Use this tool when you need to get detailed instructions about a specific skill that is available to you."
+    "description": "Read the full content of an agent skill. Use this tool when you need to get detailed instructions about a specific skill that is available to you.",
+    "signature": {
+      "type": "object",
+      "properties": {
+        "skill_name": {
+          "display": {
+            "stage": {
+              "ignore": true,
+              "ignore_parameter_name": false,
+              "show_value_in_stage_title": true
+            }
+          },
+          "type": "string",
+          "description": "The name of the skill to read. This should match the name from the available_skills list."
+        }
+      },
+      "required": [
+        "skill_name"
+      ]
+    }
   },
   {
     "name": "internal_timeawareness_current_timestamp",
-    "description": "Returns the current date and time. Optionally converts to a specific timezone."
+    "description": "Returns the current date and time. Optionally converts to a specific timezone.",
+    "signature": {
+      "type": "object",
+      "properties": {
+        "timezone": {
+          "type": "string",
+          "description": "IANA timezone name (e.g. 'Asia/Tokyo'). Defaults to UTC."
+        }
+      }
+    }
   }
 ]

--- a/docs/generated-internal-tools.json
+++ b/docs/generated-internal-tools.json
@@ -2,44 +2,35 @@
   {
     "name": "internal_attachments_available_context",
     "description": "Returns metadata about admin-configured context files. **IMPORTANT**: this tool is not applicable to user-attached files or files from tool results, and will not return any information about them. If you see file in <attachments> section of user message, it means that the file was attached by the user, and is available for you to use.",
-    "signature": {
-      "type": "object",
-      "properties": {}
-    }
+    "properties": {}
   },
   {
     "name": "internal_skills_read_skill",
     "description": "Read the full content of an agent skill. Use this tool when you need to get detailed instructions about a specific skill that is available to you.",
-    "signature": {
-      "type": "object",
-      "properties": {
-        "skill_name": {
-          "display": {
-            "stage": {
-              "ignore": true,
-              "ignore_parameter_name": false,
-              "show_value_in_stage_title": true
-            }
-          },
-          "type": "string",
-          "description": "The name of the skill to read. This should match the name from the available_skills list."
-        }
-      },
-      "required": [
-        "skill_name"
-      ]
-    }
+    "properties": {
+      "skill_name": {
+        "display": {
+          "stage": {
+            "ignore": true,
+            "ignore_parameter_name": false,
+            "show_value_in_stage_title": true
+          }
+        },
+        "type": "string",
+        "description": "The name of the skill to read. This should match the name from the available_skills list."
+      }
+    },
+    "required": [
+      "skill_name"
+    ]
   },
   {
     "name": "internal_timeawareness_current_timestamp",
     "description": "Returns the current date and time. Optionally converts to a specific timezone.",
-    "signature": {
-      "type": "object",
-      "properties": {
-        "timezone": {
-          "type": "string",
-          "description": "IANA timezone name (e.g. 'Asia/Tokyo'). Defaults to UTC."
-        }
+    "properties": {
+      "timezone": {
+        "type": "string",
+        "description": "IANA timezone name (e.g. 'Asia/Tokyo'). Defaults to UTC."
       }
     }
   }

--- a/src/quickapp/app_factory.py
+++ b/src/quickapp/app_factory.py
@@ -1,7 +1,7 @@
 import logging
 
 from fastapi import FastAPI
-from injector import Injector
+from injector import Injector, Module
 
 from quickapp.agent.agent_module import AgentModule
 from quickapp.application import AppModule
@@ -29,15 +29,12 @@ class AppFactory:
     """
 
     @staticmethod
-    def create() -> FastAPI:
+    def build_di_modules() -> list[Module]:
         """
-        Creates and configures the FastAPI application with the necessary modules.
-
-        Returns:
-            FastAPI: The configured FastAPI application instance.
+        Returns the same injector module list used to assemble the live application,
+        including preview-module filtering when ``ENABLE_PREVIEW_FEATURES`` is false.
         """
-        LoggingConfig(settings=LoggingSettings())
-        modules = [
+        modules: list[Module] = [
             AppModule(),
             AgentModule(),
             RestApiToolingModule(),
@@ -60,6 +57,17 @@ class AppFactory:
             )
         else:
             modules = [m for m in modules if not is_preview_module(m)]
-        injector = Injector(modules)
+        return modules
+
+    @staticmethod
+    def create() -> FastAPI:
+        """
+        Creates and configures the FastAPI application with the necessary modules.
+
+        Returns:
+            FastAPI: The configured FastAPI application instance.
+        """
+        LoggingConfig(settings=LoggingSettings())
+        injector = Injector(AppFactory.build_di_modules())
         app = injector.get(FastAPI)
         return app

--- a/src/quickapp/app_factory.py
+++ b/src/quickapp/app_factory.py
@@ -30,10 +30,6 @@ class AppFactory:
 
     @staticmethod
     def build_di_modules() -> list[Module]:
-        """
-        Returns the same injector module list used to assemble the live application,
-        including preview-module filtering when ``ENABLE_PREVIEW_FEATURES`` is false.
-        """
         modules: list[Module] = [
             AppModule(),
             AgentModule(),
@@ -61,12 +57,6 @@ class AppFactory:
 
     @staticmethod
     def create() -> FastAPI:
-        """
-        Creates and configures the FastAPI application with the necessary modules.
-
-        Returns:
-            FastAPI: The configured FastAPI application instance.
-        """
         LoggingConfig(settings=LoggingSettings())
         injector = Injector(AppFactory.build_di_modules())
         app = injector.get(FastAPI)

--- a/src/scripts/dump_internal_tools.py
+++ b/src/scripts/dump_internal_tools.py
@@ -2,7 +2,8 @@
 #
 # Collects every DI multiprovider named ``_provide_<feature>_tools`` (except
 # ``_provide_mcp_tools``), plus the python interpreter from the predefined tool JSON
-# (not configured via ``InternalToolSet`` here).
+# (not configured via ``InternalToolSet`` here). Each entry includes name, description,
+# and ``signature`` (JSON Schema for ``function.parameters``).
 #
 # Usage:
 #   python dump_internal_tools.py docs/generated-internal-tools.json
@@ -16,6 +17,7 @@ import os
 import sys
 from collections.abc import Callable, Iterator
 from pathlib import Path
+from typing import Any
 
 if __name__ == "__main__":
     from utils import add_src_to_system_path, load_env
@@ -79,24 +81,33 @@ def _iter_staged_tool_providers(mod: object) -> Iterator[Callable[..., list[Stag
             yield attr
 
 
-def _manifest_entry(tool: StagedBaseTool) -> dict[str, str]:
+def _parameters_signature(tool_fn: Any) -> dict[str, Any]:
+    """JSON Schema for ``function.parameters`` (OpenAI tools format)."""
+    return tool_fn.parameters.model_dump(mode="json", exclude_none=True)
+
+
+def _manifest_entry(tool: StagedBaseTool) -> dict[str, Any]:
     dumped = tool.model_dump(mode="python")
     fn = tool.tool_config.open_ai_tool.function
     name = dumped.get("name") or fn.name
     description = dumped.get("description")
     if description is None:
         description = fn.description or ""
-    return {"name": name, "description": description}
+    return {
+        "name": name,
+        "description": description,
+        "signature": _parameters_signature(fn),
+    }
 
 
-def _stable_manifest(entries: list[dict[str, str]]) -> list[dict[str, str]]:
-    by_name: dict[str, dict[str, str]] = {}
+def _stable_manifest(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    by_name: dict[str, dict[str, Any]] = {}
     for entry in sorted(entries, key=lambda e: e["name"]):
         by_name[entry["name"]] = entry
     return list(by_name.values())
 
 
-async def _gather_internal_tools_manifest() -> list[dict[str, str]]:
+async def _gather_internal_tools_manifest() -> list[dict[str, Any]]:
     # Minimal DIAL URL so `DialSettings` and dependents validate without a real deployment.
     os.environ.setdefault("DIAL_URL", "http://dump-internal-tools.invalid")
 

--- a/src/scripts/dump_internal_tools.py
+++ b/src/scripts/dump_internal_tools.py
@@ -1,0 +1,179 @@
+# CLI script that dumps internal tool names/descriptors for lint drift detection.
+#
+# Collects every DI multiprovider named ``_provide_<feature>_tools`` (except
+# ``_provide_mcp_tools``), plus the python interpreter from the predefined tool JSON
+# (not configured via ``InternalToolSet`` here).
+#
+# Usage:
+#   python dump_internal_tools.py docs/generated-internal-tools.json
+#   python dump_internal_tools.py docs/generated-internal-tools.json --check
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import sys
+from collections.abc import Callable, Iterator
+from pathlib import Path
+
+if __name__ == "__main__":
+    from utils import add_src_to_system_path, load_env
+
+    add_src_to_system_path()
+    load_env()
+
+from aidial_sdk.chat_completion import Message, Role
+from fastapi import FastAPI
+from fastapi_injector import RequestScopeFactory, RequestScopeOptions, attach_injector
+from injector import Injector
+from pydantic import SecretStr
+
+from quickapp.app_factory import AppFactory
+from quickapp.application._request_context import _RequestContext
+from quickapp.common import StagedBaseTool
+from quickapp.config.application import ApplicationConfig, Features, OrchestratorConfig
+from quickapp.config.context import FileContextConfig
+from quickapp.config.dial_deployment import DialDeploymentConfig, DialDeploymentParameters
+from quickapp.config.prompt import CustomSystemPromptConfig
+from quickapp.config.timestamp import ToolCallTimestampConfig
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent.parent
+
+
+def build_dump_application_config() -> ApplicationConfig:
+    """Synthetic config so gated multiproviders (e.g. timestamp) materialize tools."""
+    return ApplicationConfig(
+        orchestrator=OrchestratorConfig(
+            deployment=DialDeploymentConfig(
+                name="gpt-4o-mini-2024-07-18",
+                parameters=DialDeploymentParameters(),
+            ),
+            system_prompt=CustomSystemPromptConfig(
+                type="custom",
+                content="dump-internal-tools",
+                variables={},
+            ),
+        ),
+        contexts=[
+            FileContextConfig(
+                url="files/dump-internal-tools/context.txt",
+            ),
+        ],
+        tool_sets=[],
+        features=Features(timestamp=ToolCallTimestampConfig()),
+    )
+
+
+def _iter_staged_tool_providers(mod: object) -> Iterator[Callable[..., list[StagedBaseTool]]]:
+    """Multiproviders named ``_provide_<feature>_tools`` except MCP (external protocol tools)."""
+    for name in dir(type(mod)):
+        if not name.startswith("_provide_") or not name.endswith("_tools"):
+            continue
+        if name == "_provide_mcp_tools":
+            continue
+        attr = getattr(mod, name, None)
+        if callable(attr):
+            yield attr
+
+
+def _manifest_entry(tool: StagedBaseTool) -> dict[str, str]:
+    dumped = tool.model_dump(mode="python")
+    fn = tool.tool_config.open_ai_tool.function
+    name = dumped.get("name") or fn.name
+    description = dumped.get("description")
+    if description is None:
+        description = fn.description or ""
+    return {"name": name, "description": description}
+
+
+def _stable_manifest(entries: list[dict[str, str]]) -> list[dict[str, str]]:
+    by_name: dict[str, dict[str, str]] = {}
+    for entry in sorted(entries, key=lambda e: e["name"]):
+        by_name[entry["name"]] = entry
+    return list(by_name.values())
+
+
+async def _gather_internal_tools_manifest() -> list[dict[str, str]]:
+    # Minimal DIAL URL so `DialSettings` and dependents validate without a real deployment.
+    os.environ.setdefault("DIAL_URL", "http://dump-internal-tools.invalid")
+
+    modules = AppFactory.build_di_modules()
+    injector = Injector(modules)
+    attach_injector(FastAPI(), injector, RequestScopeOptions())
+
+    factory = injector.get(RequestScopeFactory)
+    manifest_entries: list[dict[str, str]] = []
+
+    async with factory.create_scope():
+        ctx = injector.get(_RequestContext)
+        ctx.api_key = SecretStr("dump-internal-tools")
+        ctx.bearer = None
+        ctx.application_config = build_dump_application_config()
+        # Non-empty: ``MessagesMixin.messages`` treats ``[]`` as unset (falsy guard).
+        ctx.messages = [Message(role=Role.USER, content="dump-internal-tools")]
+
+        for mod in modules:
+            for provider in _iter_staged_tool_providers(mod):
+                tools: list[StagedBaseTool] = injector.call_with_injection(provider)
+                for tool in tools:
+                    manifest_entries.append(_manifest_entry(tool))
+
+    return _stable_manifest(manifest_entries)
+
+
+def get_internal_tools_manifest_json() -> str:
+    entries = asyncio.run(_gather_internal_tools_manifest())
+    return json.dumps(entries, ensure_ascii=False, indent=2) + "\n"
+
+
+def dump_internal_tools(output_file: str) -> None:
+    generated = get_internal_tools_manifest_json()
+    Path(output_file).write_text(generated, encoding="utf-8")
+    print(f"Internal tools manifest dumped to {output_file}")
+
+
+def check_internal_tools(output_file: str) -> None:
+    generated = get_internal_tools_manifest_json()
+
+    try:
+        existing = Path(output_file).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(
+            f"ERROR: Internal tools file '{output_file}' not found. "
+            f"Run 'make format' to generate it."
+        )
+        sys.exit(1)
+
+    if generated != existing:
+        print(
+            f"ERROR: Internal tools file '{output_file}' is out of date. "
+            f"Run 'make format' to regenerate it."
+        )
+        sys.exit(1)
+
+    print(f"Internal tools file '{output_file}' is up to date.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Dump internal tools manifest to a file.")
+    parser.add_argument(
+        "output_file",
+        type=str,
+        help="The output file path for the JSON manifest.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check that the file matches the generated manifest instead of overwriting.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        check_internal_tools(args.output_file)
+    else:
+        dump_internal_tools(args.output_file)

--- a/src/scripts/dump_internal_tools.py
+++ b/src/scripts/dump_internal_tools.py
@@ -1,9 +1,8 @@
 # CLI script that dumps internal tool names/descriptors for lint drift detection.
 #
 # Collects every DI multiprovider named ``_provide_<feature>_tools`` (except
-# ``_provide_mcp_tools``), plus the python interpreter from the predefined tool JSON
-# (not configured via ``InternalToolSet`` here). Each entry includes name, description,
-# and ``signature`` (JSON Schema for ``function.parameters``).
+# ``_provide_mcp_tools``). Each entry includes ``name``, ``description``, and the
+# parameter object schema
 #
 # Usage:
 #   python dump_internal_tools.py docs/generated-internal-tools.json
@@ -39,10 +38,6 @@ from quickapp.config.context import FileContextConfig
 from quickapp.config.dial_deployment import DialDeploymentConfig, DialDeploymentParameters
 from quickapp.config.prompt import CustomSystemPromptConfig
 from quickapp.config.timestamp import ToolCallTimestampConfig
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parent.parent.parent
 
 
 def build_dump_application_config() -> ApplicationConfig:
@@ -81,9 +76,15 @@ def _iter_staged_tool_providers(mod: object) -> Iterator[Callable[..., list[Stag
             yield attr
 
 
-def _parameters_signature(tool_fn: Any) -> dict[str, Any]:
-    """JSON Schema for ``function.parameters`` (OpenAI tools format)."""
-    return tool_fn.parameters.model_dump(mode="json", exclude_none=True)
+def _parameter_properties_and_required(parameters: Any) -> dict[str, Any]:
+    """From OpenAI ``function.parameters``, emit only ``properties`` and ``required``."""
+    raw = parameters.model_dump(mode="json", exclude_none=True)
+    out: dict[str, Any] = {}
+    if "properties" in raw:
+        out["properties"] = raw["properties"]
+    if raw.get("required"):
+        out["required"] = raw["required"]
+    return out
 
 
 def _manifest_entry(tool: StagedBaseTool) -> dict[str, Any]:
@@ -93,11 +94,12 @@ def _manifest_entry(tool: StagedBaseTool) -> dict[str, Any]:
     description = dumped.get("description")
     if description is None:
         description = fn.description or ""
-    return {
+    entry: dict[str, Any] = {
         "name": name,
         "description": description,
-        "signature": _parameters_signature(fn),
     }
+    entry.update(_parameter_properties_and_required(fn.parameters))
+    return entry
 
 
 def _stable_manifest(entries: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -116,7 +118,7 @@ async def _gather_internal_tools_manifest() -> list[dict[str, Any]]:
     attach_injector(FastAPI(), injector, RequestScopeOptions())
 
     factory = injector.get(RequestScopeFactory)
-    manifest_entries: list[dict[str, str]] = []
+    manifest_entries: list[dict[str, Any]] = []
 
     async with factory.create_scope():
         ctx = injector.get(_RequestContext)


### PR DESCRIPTION
### Description of changes

Adds an automated, reviewable catalog of internal tools (OpenAI function name + description) used by QuickApps, and fails lint when it drifts from the code.

**Behavior**

- New script src/scripts/dump_internal_tools.py writes docs/generated-internal-tools.json (sorted, deduped).
- Discovery is aligned with the real DI graph: refactors AppFactory to expose build_di_modules() (same module list and preview gating as create()).
- Tool providers are collected by iterating each DI module’s multiproviders named _provide_*_tools, excluding _provide_mcp_tools so MCP-backed tools are not mixed into this “internal” list.
- Runs providers inside FastAPI Injector request scope with a minimal populated _RequestContext (including a non-empty messages list so MessagesMixin behaves correctly).
- Synthetic ApplicationConfig enables attachment context and timestamp feature paths where needed so conditional providers still emit tools for the manifest.

**Repo wiring**

- make lint runs the script with --check on the committed JSON (alongside the existing app schema check).
- make format (full tree) regenerates the manifest; make dump_internal_tools regenerates it on demand.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
