### PR TITLE
fix: skip <attachments> XML on assistant messages #262

### DIFF
--- a/docs/agent.md
+++ b/docs/agent.md
@@ -298,8 +298,10 @@ The processor builds an aggregated result containing all accumulated data for th
 The system uses two separate mechanisms to inform the agent about available files:
 
 - **Attachments**: The `_AttachmentFilter` (used in `AssistantInvoker`) appends structured XML metadata
-  (`<attachments>`) to message content. Each attachment is represented as an `<attachment>` element with
-  `<title>`, `<type>`, `<url>`, and optionally `<reference_url>` sub-elements.
+  (`<attachments>`) to USER and TOOL message content. Each attachment is represented as an `<attachment>`
+  element with `<title>`, `<type>`, `<url>`, and optionally `<reference_url>` sub-elements. ASSISTANT
+  messages are exempt: those attachments originated from the model's own prior output, and re-presenting
+  them as XML conditions the model to mimic the format in its responses.
 - **Admin context files**: The Attachment Notification Injector uses synthetic tool call/result messages via the
   `available_context` internal tool. This provides structured metadata without modifying user messages.
 
@@ -356,8 +358,9 @@ LLM. The agent can call it at any point during the conversation to re-check avai
 
 ### Interaction with Existing Components
 
-- **Attachment Filter**: Appends text metadata to user messages for all attachments and keeps only supported types
-  inline in `custom_content` for vision model support. Used in `AssistantInvoker`, not a pre-transformer.
+- **Attachment Filter**: Appends text metadata to USER and TOOL messages for all attachments and keeps only
+  supported types inline in `custom_content` for vision model support. ASSISTANT messages are skipped to
+  avoid conditioning the model to emit the metadata format. Used in `AssistantInvoker`, not a pre-transformer.
 - **Python Interpreter Tool**: Continues to access attachments from user messages via `custom_content` for file
   transfer to the interpreter session.
 - **Content Downloader Tool**: The agent can use this tool to fetch actual file content when needed.

--- a/src/quickapp/agent/_attachment_filter.py
+++ b/src/quickapp/agent/_attachment_filter.py
@@ -55,9 +55,12 @@ class _AttachmentFilter(PreInvocationTransformer):
                 ):
                     updated_attachments.append(attachment)
                 all_attachments.append(attachment)
-            # Inform agent that message had contained some attachment.
-            # As adapter would resolve the actual bytes and URL would be lost.
-            content += "\n" + self._build_attachment_xml(all_attachments)
+            # Surface attachment URL/title via XML — bytes are stripped by the
+            # adapter and the URL would otherwise be lost. Skip ASSISTANT:
+            # re-presenting the model's own prior attachments conditions it to
+            # mimic the XML format in responses.
+            if message.role != Role.ASSISTANT:
+                content += "\n" + self._build_attachment_xml(all_attachments)
             message.custom_content.attachments = updated_attachments  # type: ignore[union-attr]
         message.content = content
 

--- a/src/tests/unit_tests/agent_tests/test_attachment_filter.py
+++ b/src/tests/unit_tests/agent_tests/test_attachment_filter.py
@@ -167,7 +167,7 @@ class Test_AttachmentFilter:
 
     # --- Role-based tests ---
 
-    def test_assistant_message_image_attachments_stripped(self):
+    def test_assistant_message_attachments_stripped_without_xml(self):
         transformer = _AttachmentFilter()
         msg = _msg(
             Role.ASSISTANT,
@@ -177,8 +177,11 @@ class Test_AttachmentFilter:
         result = transformer.transform([msg])
         # Non-USER roles: images are NOT kept inline
         assert len(result[0].custom_content.attachments) == 0
+        # ASSISTANT messages do not get XML metadata injected — those attachments
+        # came from the model's own prior output and would create few-shot bias.
         content = str(result[0].content)
-        assert "<title>photo.png</title>" in content
+        assert "<attachments>" not in content
+        assert content == "response"
 
     def test_tool_message_attachments_stripped(self):
         transformer = _AttachmentFilter()


### PR DESCRIPTION
### Applicable issues

- fixes #262

### Description of changes

The pre-invocation attachment filter previously appended an `<attachments>` XML
block to every message carrying attachments, regardless of role. On assistant
messages this fed the model its own prior output as a few-shot example and
conditioned it to mimic the format in responses.

The filter now skips `ASSISTANT` messages. The XML metadata is only injected on
`USER` and `TOOL` messages, where it genuinely introduces files the model has
not seen yet. Behaviour for those roles is unchanged, and the existing
`custom_content.attachments` stripping on assistant messages is preserved.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
