### PR TITLE
fix: surface MCP toolset init root cause #265

### DIFF
--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -70,7 +70,7 @@ def _format_leaf_for_user(label: str, exc: BaseException) -> str:
         # McpError("Session terminated") (mcp/client/streamable_http.py),
         # so the underlying httpx error never propagates. Surface this case
         # distinctly instead of leaking the raw "Session terminated" string.
-        message = getattr(exc.error, "message", str(exc))
+        message = exc.error.message
         if message == "Session terminated":
             return (
                 f"MCP endpoint for toolset '{label}' did not respond as an MCP server "
@@ -303,20 +303,17 @@ class _MCPToolInitializer(CompletionInitializer):
             logger.error(f"HTTP error: {e}", exc_info=True)
             self.__mcp_context.append_exception(
                 ToolInitializationException(
-                    message=str(e),
+                    message=_format_leaf_for_user(label, e),
                     toolset_name=label,
-                    details=f"HTTP error for {label}: {getattr(e.response, 'status_code', '')} {getattr(e.response, 'reason_phrase', '')}",
                 )
             )
         except Exception as e:
             label = _toolset_label_for_error(toolset_info)
             logger.error(e, exc_info=True)
-            leaves = _flatten_exceptions(e)
-            detail_lines = [_format_leaf_for_user(label, leaf) for leaf in leaves]
-            primary_message = detail_lines[0] if detail_lines else str(e)
+            detail_lines = [_format_leaf_for_user(label, leaf) for leaf in _flatten_exceptions(e)]
             self.__mcp_context.append_exception(
                 ToolInitializationException(
-                    message=primary_message,
+                    message=detail_lines[0],
                     toolset_name=label,
                     details="\n".join(detail_lines),
                 )

--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -6,6 +6,7 @@ from urllib.parse import unquote
 import httpx
 from aidial_client import ToolsetInfo
 from injector import AssistedBuilder, ProviderOf, inject
+from mcp.shared.exceptions import McpError
 
 from quickapp.common import DIAL_API_KEY, StagedBaseTool
 from quickapp.common.base_initializer import CompletionInitializer
@@ -46,6 +47,37 @@ def _human_readable_dial_id(dial_id: str) -> str:
     """
     last_part = dial_id.split("/")[-1] if "/" in dial_id else dial_id
     return unquote(last_part)
+
+
+def _flatten_exceptions(exc: BaseException) -> list[BaseException]:
+    """Walk nested BaseExceptionGroups and return their leaf exceptions in order."""
+    if isinstance(exc, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        for sub in exc.exceptions:
+            leaves.extend(_flatten_exceptions(sub))
+        return leaves
+    return [exc]
+
+
+def _format_leaf_for_user(label: str, exc: BaseException) -> str:
+    """Render a leaf exception into a single-line user-facing message."""
+    if isinstance(exc, httpx.HTTPStatusError):
+        status = getattr(exc.response, "status_code", "")
+        reason = getattr(exc.response, "reason_phrase", "")
+        return f"HTTP error for {label}: {status} {reason}".rstrip()
+    if isinstance(exc, McpError):
+        # The MCP streamable_http client converts upstream HTTP 404 into
+        # McpError("Session terminated") (mcp/client/streamable_http.py),
+        # so the underlying httpx error never propagates. Surface this case
+        # distinctly instead of leaking the raw "Session terminated" string.
+        message = getattr(exc.error, "message", str(exc))
+        if message == "Session terminated":
+            return (
+                f"MCP endpoint for toolset '{label}' did not respond as an MCP server "
+                f"(session terminated — the upstream may have returned 404)"
+            )
+        return f"MCP error for {label}: {message}"
+    return f"{type(exc).__name__}: {exc}"
 
 
 _LOGIN_RESULT_MESSAGES: dict[LoginResult, str] = {
@@ -279,21 +311,13 @@ class _MCPToolInitializer(CompletionInitializer):
         except Exception as e:
             label = _toolset_label_for_error(toolset_info)
             logger.error(e, exc_info=True)
-            details = ""
-            if hasattr(e, "exceptions"):
-                details_list = []
-                for sub_e in e.exceptions:
-                    if isinstance(sub_e, httpx.HTTPStatusError):
-                        details_list.append(
-                            f"HTTP error for {label}: {getattr(sub_e.response, 'status_code', '')} {getattr(sub_e.response, 'reason_phrase', '')}"
-                        )
-                    else:
-                        details_list.append(str(sub_e))
-                details = "\n".join(details_list)
+            leaves = _flatten_exceptions(e)
+            detail_lines = [_format_leaf_for_user(label, leaf) for leaf in leaves]
+            primary_message = detail_lines[0] if detail_lines else str(e)
             self.__mcp_context.append_exception(
                 ToolInitializationException(
-                    message=str(e),
+                    message=primary_message,
                     toolset_name=label,
-                    details=details,
+                    details="\n".join(detail_lines),
                 )
             )

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_tool_initializer.py
@@ -1,7 +1,10 @@
 import base64
 from unittest.mock import AsyncMock, MagicMock, Mock
 
+import httpx
 import pytest
+from mcp.shared.exceptions import McpError
+from mcp.types import ErrorData
 from pydantic import SecretStr
 
 from quickapp.common.dial_settings import DialSettings
@@ -17,7 +20,11 @@ from quickapp.mcp_tooling._mcp_connection_manager import _MCPConnectionManager
 from quickapp.mcp_tooling._mcp_tool import _MCPTool
 
 # noinspection PyProtectedMember
-from quickapp.mcp_tooling._mcp_tool_initializer import _MCPToolInitializer
+from quickapp.mcp_tooling._mcp_tool_initializer import (
+    _flatten_exceptions,
+    _format_leaf_for_user,
+    _MCPToolInitializer,
+)
 from tests.unit_tests.common.common import noop_timeout_resolver
 
 
@@ -449,3 +456,106 @@ async def test_connection_manager_handles_missing_request_bearer_for_dial_intern
     headers = await conn_manager._MCPConnectionManager__build_headers(server_info)
 
     assert "Authorization" not in headers
+
+
+# --- Error-handling helpers and integration ---
+
+
+def test_flatten_exceptions_returns_leaf_for_plain_exception():
+    exc = ValueError("boom")
+    assert _flatten_exceptions(exc) == [exc]
+
+
+def test_flatten_exceptions_unwraps_nested_groups():
+    inner = ValueError("inner")
+    middle = ExceptionGroup("middle", [inner])
+    outer = ExceptionGroup("outer", [middle])
+
+    assert _flatten_exceptions(outer) == [inner]
+
+
+def test_flatten_exceptions_collects_multiple_leaves_in_order():
+    a = ValueError("a")
+    b = RuntimeError("b")
+    eg = ExceptionGroup("g", [a, ExceptionGroup("g2", [b])])
+
+    assert _flatten_exceptions(eg) == [a, b]
+
+
+def test_format_leaf_renders_http_status_error():
+    request = httpx.Request("POST", "http://x")
+    response = httpx.Response(404, request=request)
+    err = httpx.HTTPStatusError("not found", request=request, response=response)
+
+    line = _format_leaf_for_user("My Toolset", err)
+
+    assert line == "HTTP error for My Toolset: 404 Not Found"
+
+
+def test_format_leaf_renders_session_terminated_with_404_hint():
+    err = McpError(ErrorData(code=32600, message="Session terminated"))
+
+    line = _format_leaf_for_user("My Toolset", err)
+
+    assert "My Toolset" in line
+    assert "session terminated" in line.lower()
+    assert "404" in line
+
+
+def test_format_leaf_renders_other_mcp_errors():
+    err = McpError(ErrorData(code=-32603, message="Internal error"))
+
+    line = _format_leaf_for_user("My Toolset", err)
+
+    assert line == "MCP error for My Toolset: Internal error"
+
+
+def test_format_leaf_renders_generic_exception():
+    line = _format_leaf_for_user("My Toolset", RuntimeError("kaboom"))
+
+    assert line == "RuntimeError: kaboom"
+
+
+@pytest.mark.asyncio
+async def test_initialize_surfaces_session_terminated_through_nested_exception_groups():
+    """The MCP streamable_http client converts upstream HTTP 404 into nested
+    ExceptionGroups containing McpError('Session terminated'). Verify we surface
+    a useful message instead of leaking the raw 'unhandled errors in a TaskGroup'."""
+    inner = McpError(ErrorData(code=32600, message="Session terminated"))
+    nested = ExceptionGroup("inner task group", [inner])
+    outer = ExceptionGroup("outer task group", [nested])
+
+    conn = MagicMock()
+    conn.get_tools_list = AsyncMock(side_effect=outer)
+    conn_builder = MagicMock()
+    conn_builder.build.return_value = conn
+
+    toolset_info = MCPToolSet(
+        mcp_server_info=MCPServerInfo(
+            url="https://test", authorization=None, protocol=MCPProtocol.streamable_http
+        ),
+        allowed_tools=None,
+        name="My Toolset",
+    )
+    mcp_context = MagicMock()
+    initializer = _MCPToolInitializer(
+        [toolset_info],
+        mcp_context,
+        MagicMock(),  # dial_setting
+        MagicMock(),  # api_key_provider
+        MagicMock(),  # tool_builder
+        conn_builder,
+        MagicMock(),  # dial_mcp_cache
+        MagicMock(),  # tool_config_service
+        MagicMock(),  # login_service
+    )
+
+    await initializer.initialize()
+
+    assert mcp_context.append_exception.call_count == 1
+    appended = mcp_context.append_exception.call_args[0][0]
+    assert appended.toolset_name == "My Toolset"
+    assert "session terminated" in appended.message.lower()
+    assert "404" in appended.message
+    assert "unhandled errors in a TaskGroup" not in appended.message
+    assert "unhandled errors in a TaskGroup" not in appended.details


### PR DESCRIPTION
### Applicable issues

- fixes #265

### Description of changes

The MCP streamable_http client converts upstream HTTP 404 into `McpError("Session terminated")` wrapped in nested anyio `ExceptionGroup`s. The catch-all in `_MCPToolInitializer` only walked `e.exceptions` one level deep and only formatted `httpx.HTTPStatusError`, so users saw `"unhandled errors in a TaskGroup (1 sub-exception)"` instead of the root cause.

Added a recursive `_flatten_exceptions` walker and a `_format_leaf_for_user` formatter that special-cases `McpError("Session terminated")`; the most informative leaf becomes the `ToolInitializationException` message.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.