### PR TITLE
fix: sanitize deployment tool names to handle spaces and slashes #260

### DIFF
--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -9,7 +9,7 @@ from quickapp.config.tools.const import ALL_MIME_TYPES
 logger = logging.getLogger(__name__)
 
 
-_INVALID_TOOLNAME_CHARS_REGEXP: re.Pattern[str] = re.compile(r"[^a-zA-Z0-9_-]")
+_INVALID_TOOLNAME_CHARS_REGEXP: re.Pattern[str] = re.compile(r"[^a-zA-Z0-9_-]+")
 
 
 # Normalize propagation types (split wildcards like 'image/*' for matching)

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -46,19 +46,11 @@ def sanitize_toolname(input_str: str) -> str:
     """
     Sanitizes a string to match the pattern ^[a-zA-Z0-9_-]{1,64}$
 
-    Args:
-        input_str: Input string to sanitize
-
-    Returns:
-        Sanitized string containing only allowed characters (a-z, A-Z, 0-9, _, -)
-        with length 1-64 characters. Returns empty string if no valid characters exist.
+    Invalid characters are replaced with '_' and the result is truncated
+    to 64 characters.
     """
-    # Step 1: Remove all invalid characters
-    sanitized = _INVALID_TOOLNAME_CHARS_REGEXP.sub('', input_str)
-
-    # Step 2: Truncate to max 64 characters
+    sanitized = _INVALID_TOOLNAME_CHARS_REGEXP.sub('_', input_str)
     sanitized = sanitized[:64]
-
     return sanitized
 
 

--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -10,6 +10,7 @@ from pydantic import SecretStr
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.tool_timeout_resolver import ToolTimeoutResolver
 from quickapp.common.tool_timeout_utils import build_async_dial_timeout
+from quickapp.common.utils import sanitize_toolname
 from quickapp.config.dial_deployment import DialDeploymentConfig
 from quickapp.config.tools.base import (
     ConfigurableSchemaArray,
@@ -111,13 +112,15 @@ class ToolConfigCoreService:
         Returns:
             A DialDeploymentTool representing the final tool configuration.
         """
+
+        name = f"{sanitize_toolname(deployment.display_name or deployment.id.split('/')[-1])}_tool"
         output_tool = DialDeploymentTool(
-            display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {deployment.id}: ")),
+            display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {name}: ")),
             deployment=DialDeploymentConfig(name=deployment.id),
             fallback_configuration=ToolFallbackConfig(strategies=[ContinueStrategyModel()]),
             open_ai_tool=OpenAiToolConfig(
                 function=OpenAiToolFunction(
-                    name=f"{deployment.id.replace('-', '_')}_tool",
+                    name=name,
                     description=deployment.description or "",
                     parameters=OpenAiToolFunctionParameters(
                         type=JsonTypeEnum.object, properties={}, required=[]

--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -113,14 +113,22 @@ class ToolConfigCoreService:
             A DialDeploymentTool representing the final tool configuration.
         """
 
-        name = f"{sanitize_toolname(deployment.display_name or deployment.id.split('/')[-1])}_tool"
+        # Deployment display_name could contain anything including Cyrillic symbols
+        # deployment.id is already quoted url string like applications/{hash}/deployment%20name.
+        # To make it more readable:
+        # - replace %20(space) with _
+        # - remove bucket prefix
+        deployment_name = sanitize_toolname(
+            f"{deployment.id.split('/')[-1].replace('%20', '_')}_tool"
+        )
+
         output_tool = DialDeploymentTool(
-            display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {name}: ")),
+            display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {deployment_name}: ")),
             deployment=DialDeploymentConfig(name=deployment.id),
             fallback_configuration=ToolFallbackConfig(strategies=[ContinueStrategyModel()]),
             open_ai_tool=OpenAiToolConfig(
                 function=OpenAiToolFunction(
-                    name=name,
+                    name=deployment_name,
                     description=deployment.description or "",
                     parameters=OpenAiToolFunctionParameters(
                         type=JsonTypeEnum.object, properties={}, required=[]

--- a/src/tests/unit_tests/common/test_sanitize_toolname.py
+++ b/src/tests/unit_tests/common/test_sanitize_toolname.py
@@ -1,0 +1,29 @@
+from quickapp.common.utils import sanitize_toolname
+
+
+class TestSanitizeToolname:
+
+    def test_spaces_replaced_with_underscore(self):
+        assert sanitize_toolname("my tool name") == "my_tool_name"
+
+    def test_slashes_replaced_with_underscore(self):
+        assert sanitize_toolname("applications/public/my-app") == "applications_public_my-app"
+
+    def test_periods_replaced_with_underscore(self):
+        assert sanitize_toolname("my_app_1.0") == "my_app_1_0"
+
+    def test_alphanumeric_hyphen_underscore_unchanged(self):
+        assert sanitize_toolname("my-valid_tool123") == "my-valid_tool123"
+
+    def test_truncates_at_64_chars(self):
+        long_name = "a" * 70
+        assert sanitize_toolname(long_name) == "a" * 64
+
+    def test_real_display_name_with_spaces(self):
+        assert (
+            sanitize_toolname("App with fetch and internal docs")
+            == "App_with_fetch_and_internal_docs"
+        )
+
+    def test_empty_string_returns_empty(self):
+        assert sanitize_toolname("") == ""

--- a/src/tests/unit_tests/common/test_sanitize_toolname.py
+++ b/src/tests/unit_tests/common/test_sanitize_toolname.py
@@ -6,6 +6,9 @@ class TestSanitizeToolname:
     def test_spaces_replaced_with_underscore(self):
         assert sanitize_toolname("my tool name") == "my_tool_name"
 
+    def test_multiple_slash_replaced_with_underscore(self):
+        assert sanitize_toolname("my//tool//name") == "my_tool_name"
+
     def test_slashes_replaced_with_underscore(self):
         assert sanitize_toolname("applications/public/my-app") == "applications_public_my-app"
 

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -27,11 +27,13 @@ def _make_deployment_model(
     description: str = "desc",
     input_attachment_types: list[str] | None = None,
     has_configuration: bool = False,
+    display_name: str | None = None,
 ) -> MagicMock:
     features = MagicMock()
     features.configuration = has_configuration
     model = MagicMock()
     model.id = deployment_id
+    model.display_name = display_name
     model.description = description
     model.input_attachment_types = input_attachment_types
     model.features = features
@@ -182,10 +184,12 @@ def _make_deployment(
     deployment_id: str = "test-deployment",
     description: str = "A test deployment",
     input_attachment_types: list[str] | None = None,
+    display_name: str | None = None,
 ):
     """Create a minimal deployment-like object for ToolConfigCoreService."""
     return SimpleNamespace(
         id=deployment_id,
+        display_name=display_name,
         description=description,
         input_attachment_types=input_attachment_types,
         features=None,
@@ -257,3 +261,50 @@ def test_config_without_properties_leaves_configuration_param_names_empty():
     result = ToolConfigCoreService._convert_to_openai_tool_format(deployment, config)
 
     assert result.deployment._configuration_param_names == set()
+
+
+class TestConvertToOpenaiToolFormatName:
+
+    def test_display_name_used_as_tool_name_base(self):
+        deployment = SimpleNamespace(
+            id="applications/abc123/App with spaces__0.0.1",
+            display_name="App with spaces",
+            description="",
+            input_attachment_types=None,
+            features=None,
+        )
+        result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+        assert result.open_ai_tool.function.name == "App_with_spaces_tool"
+
+    def test_id_used_as_fallback_when_no_display_name(self):
+        deployment = SimpleNamespace(
+            id="my-simple-app",
+            display_name=None,
+            description="",
+            input_attachment_types=None,
+            features=None,
+        )
+        result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+        assert result.open_ai_tool.function.name == "my-simple-app_tool"
+
+    def test_tool_name_has_no_spaces(self):
+        deployment = SimpleNamespace(
+            id="x",
+            display_name="My Quick App 1.0",
+            description="",
+            input_attachment_types=None,
+            features=None,
+        )
+        result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+        assert " " not in result.open_ai_tool.function.name
+
+    def test_tool_name_has_no_deployment_id_prefix(self):
+        deployment = SimpleNamespace(
+            id="applications/abc/my-app",
+            display_name=None,
+            description="",
+            input_attachment_types=None,
+            features=None,
+        )
+        result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
+        assert result.open_ai_tool.function.name == "my-app_tool"

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -267,36 +267,14 @@ class TestConvertToOpenaiToolFormatName:
 
     def test_display_name_used_as_tool_name_base(self):
         deployment = SimpleNamespace(
-            id="applications/abc123/App with spaces__0.0.1",
+            id="applications/abc123/App%20with%20spaces__0.0.1",
             display_name="App with spaces",
             description="",
             input_attachment_types=None,
             features=None,
         )
         result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
-        assert result.open_ai_tool.function.name == "App_with_spaces_tool"
-
-    def test_id_used_as_fallback_when_no_display_name(self):
-        deployment = SimpleNamespace(
-            id="my-simple-app",
-            display_name=None,
-            description="",
-            input_attachment_types=None,
-            features=None,
-        )
-        result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
-        assert result.open_ai_tool.function.name == "my-simple-app_tool"
-
-    def test_tool_name_has_no_spaces(self):
-        deployment = SimpleNamespace(
-            id="x",
-            display_name="My Quick App 1.0",
-            description="",
-            input_attachment_types=None,
-            features=None,
-        )
-        result = ToolConfigCoreService._convert_to_openai_tool_format(deployment)
-        assert " " not in result.open_ai_tool.function.name
+        assert result.open_ai_tool.function.name == "App_with_spaces__0_0_1_tool"
 
     def test_tool_name_has_no_deployment_id_prefix(self):
         deployment = SimpleNamespace(


### PR DESCRIPTION
### Applicable issues

- fixes #260

### Description of changes

Tool names generated from DIAL deployment IDs could contain characters invalid for LLM tool name schemas (`^[a-zA-Z0-9_-]{1,64}$`) — e.g. spaces, slashes, dots, Cyrillic symbols. This caused Quick App 2.0 to error when a Quick App 1.0 was added to Agents & Toolsets.

Changes:
- Tool name is now derived from the **last path segment of `deployment.id`** (which is a URL-encoded string like `applications/{hash}/My%20App%201.0`)
- `%20` (URL-encoded space) is explicitly replaced with `_` before sanitization for readability
- `sanitize_toolname` now **replaces** consecutive invalid characters with a single `_` instead of removing them (regex changed to greedy `+` quantifier), preserving word boundaries and handling Cyrillic/any non-ASCII characters
- Result is always truncated to 64 characters
- Added unit tests for `sanitize_toolname` and tool name generation

### Testing
Here is call to nested app with name `App with fetch and internal docs та кирилиця`:
<img width="984" height="393" alt="Screenshot 2026-04-29 at 18 15 53" src="https://github.com/user-attachments/assets/cd526b0f-4df2-4429-b7bf-e41caea2f4c6" />

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Design documented is updated/created and approved by the team (if applicable)
- [ ] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.