### PR TITLE
chore: bump python-multipart from 0.0.26 to 0.0.27

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -4163,14 +4163,14 @@ cli = ["click (>=5.0)"]
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.27"
 description = "A streaming multipart parser for Python"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185"},
-    {file = "python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17"},
+    {file = "python_multipart-0.0.27-py3-none-any.whl", hash = "sha256:6fccfad17a27334bd0193681b369f476eda3409f17381a2d65aa7df3f7275645"},
+    {file = "python_multipart-0.0.27.tar.gz", hash = "sha256:9870a6a8c5a20a5bf4f07c017bd1489006ff8836cff097b6933355ee2b49b602"},
 ]
 
 [[package]]


### PR DESCRIPTION
### Applicable issues

- N/A — security bump for [CVE-2026-42561](https://nvd.nist.gov/vuln/detail/CVE-2026-42561)

### Description of changes

Bumps `python-multipart` from `0.0.26` → `0.0.27` in `poetry.lock` to patch
**CVE-2026-42561** (HIGH severity) — Denial of Service via unbounded multipart
part headers in `python-multipart < 0.0.27`.

`python-multipart` is a transitive dependency (pulled in by `mcp`, which
requires `>=0.0.9`), so only the lock file changes; no `pyproject.toml`
constraint updates are needed.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

🤖 Generated with [Claude Code](https://claude.com/claude-code)