### PR TITLE
fix(time-awareness): preserve millisecond precision in timestamp metadata #278

### DIFF
--- a/src/quickapp/common/message_metadata.py
+++ b/src/quickapp/common/message_metadata.py
@@ -2,7 +2,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, field_serializer
 
 MESSAGE_METADATA_KEY = "_message_metadata"
 
@@ -16,6 +16,12 @@ class TimestampMetadata(BaseModel):
     response_timestamp: datetime | None = None
     timestamp_source: TimestampSource | None = None
     timezone_name: str | None = None
+
+    @field_serializer("response_timestamp", when_used="json")
+    def _serialize_response_timestamp(self, dt: datetime | None) -> str | None:
+        if dt is None:
+            return None
+        return dt.isoformat(timespec="milliseconds")
 
 
 class MessageMetadata(BaseModel):

--- a/src/tests/unit_tests/common/test_message_metadata.py
+++ b/src/tests/unit_tests/common/test_message_metadata.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timezone
 
+import pytest
+
 from quickapp.common.message_metadata import (
     MESSAGE_METADATA_KEY,
     MessageMetadata,
@@ -42,3 +44,60 @@ class TestMessageMetadata:
         state: dict = {}
         set_metadata_in_state(state, MessageMetadata())
         assert MESSAGE_METADATA_KEY in state
+
+
+class TestTimestampMetadataSerialization:
+    def test_response_timestamp_json_dump_uses_millisecond_precision(self):
+        metadata = TimestampMetadata(
+            response_timestamp=datetime(2026, 3, 24, 14, 30, 0, 123456, tzinfo=timezone.utc),
+        )
+        dumped = metadata.model_dump(mode="json")
+        assert dumped["response_timestamp"] == "2026-03-24T14:30:00.123+00:00"
+        assert "123456" not in dumped["response_timestamp"]
+
+    def test_response_timestamp_json_dump_zero_microseconds_emits_three_digits(self):
+        metadata = TimestampMetadata(
+            response_timestamp=datetime(2026, 3, 24, 14, 30, 0, tzinfo=timezone.utc),
+        )
+        dumped = metadata.model_dump(mode="json")
+        assert dumped["response_timestamp"] == "2026-03-24T14:30:00.000+00:00"
+
+    def test_response_timestamp_round_trip_preserves_milliseconds(self):
+        original = TimestampMetadata(
+            response_timestamp=datetime(2026, 3, 24, 14, 30, 0, 123456, tzinfo=timezone.utc),
+        )
+        dumped = original.model_dump(mode="json")
+        restored = TimestampMetadata.model_validate(dumped)
+        assert restored.response_timestamp is not None
+        assert restored.response_timestamp.microsecond == 123000
+
+    def test_response_timestamp_python_mode_dump_returns_datetime(self):
+        ts = datetime(2026, 3, 24, 14, 30, 0, 123456, tzinfo=timezone.utc)
+        metadata = TimestampMetadata(response_timestamp=ts)
+        dumped = metadata.model_dump()
+        assert dumped["response_timestamp"] == ts
+
+    def test_none_response_timestamp_serializes_to_none(self):
+        metadata = TimestampMetadata()
+        dumped = metadata.model_dump(mode="json")
+        assert dumped["response_timestamp"] is None
+
+    @pytest.mark.parametrize(
+        "timestamp_str,expected_microsecond",
+        [
+            ("2026-03-24T14:30:00+00:00", 0),
+            ("2026-03-24T14:30:00.123456+00:00", 123456),
+        ],
+    )
+    def test_legacy_timestamp_strings_still_parse(
+        self, timestamp_str: str, expected_microsecond: int
+    ):
+        legacy = {
+            "response_timestamp": timestamp_str,
+            "timestamp_source": "default",
+            "timezone_name": "UTC",
+        }
+        restored = TimestampMetadata.model_validate(legacy)
+        assert restored.response_timestamp == datetime(
+            2026, 3, 24, 14, 30, 0, expected_microsecond, tzinfo=timezone.utc
+        )


### PR DESCRIPTION
### Applicable issues

- fixes #278

### Description of changes

Add a JSON-mode `field_serializer` to `TimestampMetadata.response_timestamp` so the serialized form always carries 3 fractional digits, regardless of microsecond value. Pydantic's default `datetime.isoformat()` drops the fractional part on whole-second boundaries and emits 6 digits otherwise — leaving downstream consumers of state metadata (UI, analytics, persistence) with inconsistent sub-second precision.

**Scope:** Metadata-only. Agent-facing timestamp strings — the `current_timestamp` tool response, the synthetic injection content, and the `[Timestamp: ...]` annotation prefix — intentionally remain at seconds precision.

**Backward compatibility:** Pre-change serialized forms (both seconds-only `2026-03-24T14:30:00+00:00` and microseconds `2026-03-24T14:30:00.123456+00:00`) still parse via Pydantic's default datetime validator. Locked in by `test_legacy_timestamp_strings_still_parse`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable) — N/A, internal serialization detail
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)