### PR TITLE
chore: normalize DIAL deployment-id field naming #286

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -30,7 +30,7 @@ The project contains predefined configs of application and predefined tools
 {
   "orchestrator": {
     "deployment": {
-      "name": "gpt-4o-2024-05-13",
+      "deployment_id": "gpt-4o-2024-05-13",
       "parameters": {
         "temperature": 1.0,
         "seed": 820288
@@ -124,7 +124,7 @@ The project contains predefined configs of application and predefined tools
             }
           },
           "deployment": {
-            "name": "dall-e-3"
+            "deployment_id": "dall-e-3"
           },
           "open_ai_tool": {
             "type": "function",

--- a/config/predefined/tool/dial_rag.json
+++ b/config/predefined/tool/dial_rag.json
@@ -6,7 +6,7 @@
     }
   },
   "deployment": {
-    "name": "dial-rag"
+    "deployment_id": "dial-rag"
   },
   "content_propagation": {
     "propagate_history": true,

--- a/config/predefined/tool/image_generation.json
+++ b/config/predefined/tool/image_generation.json
@@ -6,7 +6,7 @@
     }
   },
   "deployment": {
-    "name": "gpt-image-1"
+    "deployment_id": "gpt-image-1"
   },
   "open_ai_tool": {
     "type": "function",

--- a/config/predefined/tool/web_search.json
+++ b/config/predefined/tool/web_search.json
@@ -6,7 +6,7 @@
     }
   },
   "deployment": {
-    "name": "gemini-2.5-pro-google-search"
+    "deployment_id": "gemini-2.5-pro-google-search"
   },
   "content_propagation": {
     "propagate_history": true,

--- a/docker_compose_files/core/configuration/applications.json
+++ b/docker_compose_files/core/configuration/applications.json
@@ -7,7 +7,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gpt-5-2025-08-07",
+            "deployment_id": "gpt-5-2025-08-07",
             "parameters": {
               "temperature": 1.0
             }
@@ -81,7 +81,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gpt-4.1-2025-04-14"
+            "deployment_id": "gpt-4.1-2025-04-14"
           },
           "system_prompt": {
             "type": "custom",
@@ -132,7 +132,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gpt-4.1-2025-04-14"
+            "deployment_id": "gpt-4.1-2025-04-14"
           },
           "system_prompt": {
             "type": "custom",
@@ -155,7 +155,7 @@
                   }
                 },
                 "deployment": {
-                  "name": "nested_quick_app"
+                  "deployment_id": "nested_quick_app"
                 },
                 "content_propagation": {
                   "propagate_history": true,
@@ -226,7 +226,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "anthropic.claude-sonnet-4-6"
+            "deployment_id": "anthropic.claude-sonnet-4-6"
           },
           "system_prompt": {
             "type": "custom",

--- a/docker_compose_files/core/configuration/chathub/anthropic.json
+++ b/docker_compose_files/core/configuration/chathub/anthropic.json
@@ -7,7 +7,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "anthropic.claude-opus-4-6-v1",
+            "deployment_id": "anthropic.claude-opus-4-6-v1",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288
@@ -42,7 +42,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+            "deployment_id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288
@@ -76,7 +76,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "claude-sonnet-4@20250514",
+            "deployment_id": "claude-sonnet-4@20250514",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288
@@ -110,7 +110,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "us.anthropic.claude-3-7-sonnet-20250219-v1",
+            "deployment_id": "us.anthropic.claude-3-7-sonnet-20250219-v1",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288

--- a/docker_compose_files/core/configuration/chathub/gemini.json
+++ b/docker_compose_files/core/configuration/chathub/gemini.json
@@ -7,7 +7,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gemini-2.5-pro",
+            "deployment_id": "gemini-2.5-pro",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288
@@ -41,7 +41,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gemini-3.1-pro-preview",
+            "deployment_id": "gemini-3.1-pro-preview",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288

--- a/docker_compose_files/core/configuration/chathub/openai.json
+++ b/docker_compose_files/core/configuration/chathub/openai.json
@@ -7,7 +7,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gpt-4o-2024-11-20",
+            "deployment_id": "gpt-4o-2024-11-20",
             "parameters": {
               "temperature": 1.0,
               "seed": 820288
@@ -46,7 +46,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gpt-5-2025-08-07",
+            "deployment_id": "gpt-5-2025-08-07",
             "parameters": {
               "seed": 820288
             }
@@ -84,7 +84,7 @@
       "applicationProperties": {
         "orchestrator": {
           "deployment": {
-            "name": "gpt-5.2-2025-12-11"
+            "deployment_id": "gpt-5.2-2025-12-11"
           },
           "system_prompt": {
             "type": "predefined",

--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -763,20 +763,35 @@
       "type": "object"
     },
     "DialDeploymentConfig": {
+      "anyOf": [
+        {
+          "required": [
+            "deployment_id"
+          ]
+        },
+        {
+          "required": [
+            "name"
+          ]
+        }
+      ],
       "properties": {
-        "name": {
-          "description": "The name of the DIAL deployment.",
-          "title": "Name",
+        "deployment_id": {
+          "description": "The id of the DIAL deployment.",
+          "dial:resource": true,
+          "title": "Deployment Id",
           "type": "string"
         },
         "parameters": {
           "$ref": "#/$defs/DialDeploymentParameters",
           "description": "The predefined parameters for the DIAL deployment."
+        },
+        "name": {
+          "deprecated": true,
+          "description": "DEPRECATED. Legacy alias for `deployment_id`.",
+          "type": "string"
         }
       },
-      "required": [
-        "name"
-      ],
       "title": "DialDeploymentConfig",
       "type": "object"
     },
@@ -1025,6 +1040,18 @@
       "type": "object"
     },
     "DialMCPToolSet": {
+      "anyOf": [
+        {
+          "required": [
+            "deployment_id"
+          ]
+        },
+        {
+          "required": [
+            "dial_id"
+          ]
+        }
+      ],
       "properties": {
         "name": {
           "default": "untitled-mcp-toolset",
@@ -1058,10 +1085,10 @@
           "title": "Type",
           "type": "string"
         },
-        "dial_id": {
-          "description": "The Dial ID associated with this MCP toolset.",
+        "deployment_id": {
+          "description": "The id of the DIAL deployment associated with this MCP toolset.",
           "dial:resource": true,
-          "title": "Dial Id",
+          "title": "Deployment Id",
           "type": "string"
         },
         "transport": {
@@ -1097,11 +1124,13 @@
         "fallback_configuration": {
           "$ref": "#/$defs/ToolFallbackConfig",
           "description": "Tool fallback configuration."
+        },
+        "dial_id": {
+          "deprecated": true,
+          "description": "DEPRECATED. Legacy alias for `deployment_id`.",
+          "type": "string"
         }
       },
-      "required": [
-        "dial_id"
-      ],
       "title": "DialMCPToolSet",
       "type": "object"
     },

--- a/src/quickapp/agent/agent_module.py
+++ b/src/quickapp/agent/agent_module.py
@@ -87,7 +87,7 @@ class AgentModule(Module):
         azure_client = AsyncAzureOpenAI(
             azure_endpoint=dial_settings.url,
             api_key=api_key.get_secret_value(),
-            azure_deployment=config.orchestrator.deployment.name,
+            azure_deployment=config.orchestrator.deployment.deployment_id,
             api_version=dial_settings.api_version,
             default_headers=headers,
         )

--- a/src/quickapp/agent/assistant_invoker.py
+++ b/src/quickapp/agent/assistant_invoker.py
@@ -58,7 +58,7 @@ class AssistantInvoker:
         payload: dict[str, Any] = {
             "messages": prepared_messages,
             "stream": True,
-            "model": self.__config.orchestrator.deployment.name,
+            "model": self.__config.orchestrator.deployment.deployment_id,
             "tools": self.__tools,
         }
 

--- a/src/quickapp/agent/orchestrator.py
+++ b/src/quickapp/agent/orchestrator.py
@@ -56,7 +56,7 @@ class Orchestrator:
         self.__stream_handler = stream_handler
         self.__iterations_counter = 0
         self.__MAX_ITERATIONS_COUNT = app_config.orchestrator.max_iterations
-        self.__orchestrator_deployment_name = app_config.orchestrator.deployment.name
+        self.__orchestrator_deployment_name = app_config.orchestrator.deployment.deployment_id
         self.__propagate_orchestrator_stages: bool = app_config.orchestrator.propagate_stages
         self.__usage_statistics_list: list[DeploymentUsage] = []
         self.__perf_timer: PerformanceTimer = perf_timer

--- a/src/quickapp/common/base_config.py
+++ b/src/quickapp/common/base_config.py
@@ -1,8 +1,9 @@
 from collections import deque
 from copy import deepcopy
+from dataclasses import dataclass
 from typing import Any, ClassVar, Literal
 
-from pydantic import BaseModel, Field
+from pydantic import AliasChoices, BaseModel, Field
 from pydantic.fields import FieldInfo
 
 from quickapp.common.dial_schema import DialJSONSchemaExtensions
@@ -203,6 +204,84 @@ def _preview_field(default=None, **kwargs) -> FieldInfo:
     if has_factory:
         return Field(**kwargs)
     return Field(default, **kwargs)
+
+
+@dataclass(frozen=True)
+class LegacyAlias:
+    """Annotation declaring that a field accepts a legacy property name as input.
+
+    Compose with any field helper inside ``Annotated[...]``::
+
+        deployment_id: Annotated[
+            str,
+            DialResourceConfigField(description="..."),
+            LegacyAlias("name"),
+        ]
+
+    Active when the model inherits from :class:`LegacyAliasModel`.
+    """
+
+    name: str
+    description: str | None = None
+
+
+def _find_legacy_alias(field_info: FieldInfo) -> LegacyAlias | None:
+    for item in field_info.metadata:
+        if isinstance(item, LegacyAlias):
+            return item
+    return None
+
+
+class LegacyAliasModel(BaseModel):
+    """Base for models that opt into :class:`LegacyAlias` field annotations.
+
+    For each field carrying a ``LegacyAlias``:
+
+    - At class init: extends the field's ``validation_alias`` to
+      ``AliasChoices(<field>, <legacy>)`` and forces ``model_rebuild`` so the
+      change takes effect at validation time.
+    - At ``model_json_schema()``: adds the legacy name as a deprecated sibling
+      property, removes the canonical from the top-level ``required`` list,
+      and appends an ``anyOf`` clause requiring at least one of
+      (canonical, legacy) — so DIAL Core's schema validator accepts both keys.
+    """
+
+    _legacy_alias_pairs: ClassVar[list[tuple[str, LegacyAlias]]] = []
+
+    @classmethod
+    def __pydantic_init_subclass__(cls, **kwargs: Any) -> None:
+        super().__pydantic_init_subclass__(**kwargs)
+        pairs: list[tuple[str, LegacyAlias]] = []
+        for field_name, field_info in cls.model_fields.items():
+            legacy = _find_legacy_alias(field_info)
+            if legacy is None:
+                continue
+            field_info.validation_alias = AliasChoices(field_name, legacy.name)
+            pairs.append((field_name, legacy))
+        cls._legacy_alias_pairs = pairs
+        if pairs:
+            cls.model_rebuild(force=True)
+
+    @classmethod
+    def __get_pydantic_json_schema__(cls, schema: Any, handler: Any) -> dict[str, Any]:
+        json_schema = handler(schema)
+        if not cls._legacy_alias_pairs:
+            return json_schema
+        properties = json_schema.setdefault("properties", {})
+        required = json_schema.get("required") or []
+        any_of = json_schema.setdefault("anyOf", [])
+        for canonical, legacy in cls._legacy_alias_pairs:
+            properties[legacy.name] = {
+                "type": "string",
+                "description": legacy.description or f"DEPRECATED. Legacy alias for `{canonical}`.",
+                "deprecated": True,
+            }
+            if canonical in required:
+                required.remove(canonical)
+            any_of.extend([{"required": [canonical]}, {"required": [legacy.name]}])
+        if not required:
+            json_schema.pop("required", None)
+        return json_schema
 
 
 def has_preview_marker(field_info: FieldInfo) -> bool:

--- a/src/quickapp/config/dial_deployment.py
+++ b/src/quickapp/config/dial_deployment.py
@@ -1,6 +1,8 @@
-from typing import Any
+from typing import Annotated, Any
 
 from pydantic import BaseModel, Field, PrivateAttr
+
+from quickapp.common.base_config import DialResourceConfigField, LegacyAlias, LegacyAliasModel
 
 
 class CustomFieldsConfig(BaseModel):
@@ -51,8 +53,12 @@ class DialDeploymentParameters(BaseModel):
     # ToDo: add more parameters according to the DIAL API reference
 
 
-class DialDeploymentConfig(BaseModel):
-    name: str = Field(description="The name of the DIAL deployment.")
+class DialDeploymentConfig(LegacyAliasModel):
+    deployment_id: Annotated[
+        str,
+        DialResourceConfigField(description="The id of the DIAL deployment."),
+        LegacyAlias("name"),
+    ]
     parameters: DialDeploymentParameters = Field(
         default_factory=DialDeploymentParameters,
         description="The predefined parameters for the DIAL deployment.",

--- a/src/quickapp/config/toolsets/dial_mcp.py
+++ b/src/quickapp/config/toolsets/dial_mcp.py
@@ -2,18 +2,22 @@ from typing import Annotated, Literal
 
 from pydantic import Field
 
-from quickapp.common.base_config import DialResourceConfigField
+from quickapp.common.base_config import DialResourceConfigField, LegacyAlias, LegacyAliasModel
 from quickapp.config.tools.base import AttachmentConfig
 from quickapp.config.tools.tool_fallback import ToolFallbackConfig
 from quickapp.config.toolsets.base import BaseToolSet
 
 
-class DialMCPToolSet(BaseToolSet):
+class DialMCPToolSet(BaseToolSet, LegacyAliasModel):
     type: Literal["dial-mcp"] = Field(default="dial-mcp", description="The type of the tool set.")
     # Override name of BaseToolSet. UI team doesn't send us this field.
     name: str = Field(default="untitled-mcp-toolset", description="default name of the toolset")
-    dial_id: Annotated[
-        str, DialResourceConfigField(description="The Dial ID associated with this MCP toolset.")
+    deployment_id: Annotated[
+        str,
+        DialResourceConfigField(
+            description="The id of the DIAL deployment associated with this MCP toolset.",
+        ),
+        LegacyAlias("dial_id"),
     ]
     # Deprecated. This field is read from DialCore. This value is ignored and should be removed.
     transport: Literal["HTTP", "SSE"] = Field(

--- a/src/quickapp/dial_core_services/tool_config_service.py
+++ b/src/quickapp/dial_core_services/tool_config_service.py
@@ -127,7 +127,7 @@ class ToolConfigCoreService:
 
         output_tool = DialDeploymentTool(
             display=ToolDisplayConfig(stage=ToolStageConfig(name=f"Call {deployment_name}: ")),
-            deployment=DialDeploymentConfig(name=deployment.id),
+            deployment=DialDeploymentConfig(deployment_id=deployment.id),
             fallback_configuration=ToolFallbackConfig(strategies=[ContinueStrategyModel()]),
             open_ai_tool=OpenAiToolConfig(
                 function=OpenAiToolFunction(

--- a/src/quickapp/dial_deployment_tooling/_deployment_tool_initializer.py
+++ b/src/quickapp/dial_deployment_tooling/_deployment_tool_initializer.py
@@ -44,7 +44,7 @@ class _DeploymentToolInitializer(CompletionInitializer):
 
     def __init_deployment_tool(self, tool: DialDeploymentTool):
         built_tool = self.__builder.build(
-            application_id=tool.deployment.name,
+            application_id=tool.deployment.deployment_id,
             application_name=tool.open_ai_tool.function.name,
             description=tool.open_ai_tool.function.description,
             content_propagation=tool.content_propagation,

--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -95,10 +95,10 @@ def _login_result_message(result: LoginResult, toolset_label: str) -> str:
 
 def _toolset_label_for_error(toolset_info: MCPToolSet | DialMCPToolSet) -> str:
     """Return a label for this toolset suitable for error messages.
-    For DialMCPToolSet with default name, use a human-readable form of dial_id.
+    For DialMCPToolSet with default name, use a human-readable form of deployment_id.
     """
     if isinstance(toolset_info, DialMCPToolSet) and toolset_info.name == _UNTITLED_MCP_TOOLSET:
-        return _human_readable_dial_id(toolset_info.dial_id)
+        return _human_readable_dial_id(toolset_info.deployment_id)
     return getattr(toolset_info, "name", "")
 
 
@@ -190,12 +190,12 @@ class _MCPToolInitializer(CompletionInitializer):
 
     async def _interactive_login_and_retry(self, unauthorized: list[DialMCPToolSet]) -> None:
         """Batch interactive login for unauthorized toolsets, then retry successful ones."""
-        dial_ids = [ts.dial_id for ts in unauthorized]
-        signin_results = await self.__login_service.request_signin_batch(dial_ids)
+        deployment_ids = [ts.deployment_id for ts in unauthorized]
+        signin_results = await self.__login_service.request_signin_batch(deployment_ids)
 
         retry_toolsets: list[DialMCPToolSet] = []
         for ts in unauthorized:
-            login_result = signin_results.get(ts.dial_id, LoginResult.ERROR)
+            login_result = signin_results.get(ts.deployment_id, LoginResult.ERROR)
             if login_result == LoginResult.SUCCESS:
                 retry_toolsets.append(ts)
             else:
@@ -241,13 +241,13 @@ class _MCPToolInitializer(CompletionInitializer):
             # Resolve DialMCPToolSet data asynchronously if needed
             if isinstance(toolset_info, DialMCPToolSet):
                 dial_toolset_info: ToolsetInfo | None = await self.__mcp_cache.get(
-                    f"mcp_toolset_{toolset_info.dial_id}",
+                    f"mcp_toolset_{toolset_info.deployment_id}",
                     self.__tool_config_service.get_basic_toolset_config,
-                    toolset_info.dial_id,
+                    toolset_info.deployment_id,
                 )
                 if not dial_toolset_info:
                     raise ToolInitializationException(
-                        message=f"Failed to retrieve toolset info for DIAL ID {toolset_info.dial_id}",
+                        message=f"Failed to retrieve toolset info for DIAL ID {toolset_info.deployment_id}",
                         toolset_name=_toolset_label_for_error(toolset_info),
                     )
                 resolved_toolset = MCPToolSet(
@@ -258,7 +258,7 @@ class _MCPToolInitializer(CompletionInitializer):
                     attachment=toolset_info.attachment,
                     fallback_configuration=toolset_info.fallback_configuration,
                     mcp_server_info=MCPServerInfo(
-                        url=f"{self.__dial_setting.url}/v1/toolset/{toolset_info.dial_id}/mcp",
+                        url=f"{self.__dial_setting.url}/v1/toolset/{toolset_info.deployment_id}/mcp",
                         authorization=MCPApiKeyAuthorization(
                             key=self.__api_key_provider.get().get_secret_value(), name="Api-Key"
                         ),
@@ -293,7 +293,9 @@ class _MCPToolInitializer(CompletionInitializer):
                     ),
                     connection_manager=connection_manager,
                     dial_toolset_id=(
-                        toolset_info.dial_id if isinstance(toolset_info, DialMCPToolSet) else None
+                        toolset_info.deployment_id
+                        if isinstance(toolset_info, DialMCPToolSet)
+                        else None
                     ),
                 )
                 created_tools.append(mcp_tool)

--- a/src/scripts/dump_internal_tools.py
+++ b/src/scripts/dump_internal_tools.py
@@ -45,7 +45,7 @@ def build_dump_application_config() -> ApplicationConfig:
     return ApplicationConfig(
         orchestrator=OrchestratorConfig(
             deployment=DialDeploymentConfig(
-                name="gpt-4o-mini-2024-07-18",
+                deployment_id="gpt-4o-mini-2024-07-18",
                 parameters=DialDeploymentParameters(),
             ),
             system_prompt=CustomSystemPromptConfig(

--- a/src/tests/integration_tests/test_runner/config.py
+++ b/src/tests/integration_tests/test_runner/config.py
@@ -68,7 +68,8 @@ class TestConfig:
         return ApplicationConfig(
             orchestrator=OrchestratorConfig(
                 deployment=DialDeploymentConfig(
-                    name=model, parameters=DialDeploymentParameters(temperature=temperature)
+                    deployment_id=model,
+                    parameters=DialDeploymentParameters(temperature=temperature),
                 ),
                 system_prompt=PredefinedSystemPromptConfig(template=template),
             ),

--- a/src/tests/unit_tests/agent_tests/test_agent_module.py
+++ b/src/tests/unit_tests/agent_tests/test_agent_module.py
@@ -9,7 +9,7 @@ def test_provide_openai_client_forwards_bearer_to_default_headers():
     module = AgentModule()
     dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
     config = MagicMock()
-    config.orchestrator.deployment.name = "orchestrator-model"
+    config.orchestrator.deployment.deployment_id = "orchestrator-model"
 
     with patch("quickapp.agent.agent_module.AsyncAzureOpenAI") as openai_client:
         openai_client.return_value = MagicMock()
@@ -32,7 +32,7 @@ def test_provide_openai_client_handles_missing_bearer_without_authorization_head
     module = AgentModule()
     dial_settings = MagicMock(url="https://dial.example", api_version="2024-05-01-preview")
     config = MagicMock()
-    config.orchestrator.deployment.name = "orchestrator-model"
+    config.orchestrator.deployment.deployment_id = "orchestrator-model"
 
     with patch("quickapp.agent.agent_module.AsyncAzureOpenAI") as openai_client:
         openai_client.return_value = MagicMock()

--- a/src/tests/unit_tests/agent_tests/test_assistant_invoker.py
+++ b/src/tests/unit_tests/agent_tests/test_assistant_invoker.py
@@ -35,7 +35,7 @@ class DummyParams:
 class DummyDeployment:
     def __init__(self):
         self.parameters = DummyParams()
-        self.name = "test-model"
+        self.deployment_id = "test-model"
 
 
 class DummyOrchestrator:

--- a/src/tests/unit_tests/agent_tests/test_orchestrator.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator.py
@@ -60,7 +60,7 @@ async def test_invoke_no_tool_calls_processes_usage_and_sets_state():
     app_config = SimpleNamespace(
         orchestrator=SimpleNamespace(
             max_iterations=5,
-            deployment=SimpleNamespace(name="test-model"),
+            deployment=SimpleNamespace(deployment_id="test-model"),
             propagate_stages=True,
         )
     )
@@ -161,7 +161,7 @@ async def test_invoke_with_tool_calls_executes_tools_and_updates_state_and_messa
     app_config = SimpleNamespace(
         orchestrator=SimpleNamespace(
             max_iterations=10,
-            deployment=SimpleNamespace(name="test-model"),
+            deployment=SimpleNamespace(deployment_id="test-model"),
             propagate_stages=True,
         )
     )
@@ -248,7 +248,7 @@ async def test_invoke_with_stream_state_puts_only_response_state_under_orchestra
         app_config=SimpleNamespace(
             orchestrator=SimpleNamespace(
                 max_iterations=5,
-                deployment=SimpleNamespace(name="m"),
+                deployment=SimpleNamespace(deployment_id="m"),
                 propagate_stages=True,
             )
         ),
@@ -318,7 +318,7 @@ async def test_invoke_tool_calls_returns_no_results_raises_runtime_error():
     app_config = SimpleNamespace(
         orchestrator=SimpleNamespace(
             max_iterations=5,
-            deployment=SimpleNamespace(name="test-model"),
+            deployment=SimpleNamespace(deployment_id="test-model"),
             propagate_stages=True,
         )
     )
@@ -368,7 +368,7 @@ def _make_orchestrator(messages_list: list[Message]) -> Orchestrator:
         app_config=SimpleNamespace(
             orchestrator=SimpleNamespace(
                 max_iterations=10,
-                deployment=SimpleNamespace(name="m"),
+                deployment=SimpleNamespace(deployment_id="m"),
                 propagate_stages=True,
             )
         ),

--- a/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
+++ b/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
@@ -28,7 +28,7 @@ def _make_injector(contexts: list[Context] = None) -> _AttachmentNotificationInj
     config = ApplicationConfig(
         contexts=contexts,
         orchestrator=OrchestratorConfig(
-            deployment=DialDeploymentConfig(name="gpt-4"),
+            deployment=DialDeploymentConfig(deployment_id="gpt-4"),
             system_prompt=CustomSystemPromptConfig(content="", variables={}),
         ),
         tool_sets=[],

--- a/src/tests/unit_tests/common/common.py
+++ b/src/tests/unit_tests/common/common.py
@@ -78,7 +78,8 @@ def create_app_configuration(toolsets: list[ToolSet]) -> ApplicationConfig:
     return ApplicationConfig(
         orchestrator=OrchestratorConfig(
             deployment=DialDeploymentConfig(
-                name="gpt-4o-mini-2024-07-18", parameters=DialDeploymentParameters()
+                deployment_id="gpt-4o-mini-2024-07-18",
+                parameters=DialDeploymentParameters(),
             ),
             system_prompt=CustomSystemPromptConfig(
                 type="custom", content="test", variables={"test": "test"}

--- a/src/tests/unit_tests/config_tests/test_legacy_aliases.py
+++ b/src/tests/unit_tests/config_tests/test_legacy_aliases.py
@@ -1,0 +1,79 @@
+"""
+Pin the legacy-alias behavior introduced when `DialDeploymentConfig.name` was
+renamed to `deployment_id` and `DialMCPToolSet.dial_id` was renamed to
+`deployment_id`.
+
+The aliases must keep working at two layers:
+- Pydantic runtime validation (so existing manifests still load).
+- The published JSON schema (so DIAL Core's config validator still accepts
+  manifests using the legacy keys).
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from quickapp.common.dial_schema import DialJSONSchemaExtensions
+from quickapp.config.dial_deployment import DialDeploymentConfig
+from quickapp.config.toolsets.dial_mcp import DialMCPToolSet
+
+
+class TestDialDeploymentConfigLegacyAlias:
+    def test_accepts_canonical_deployment_id(self):
+        cfg = DialDeploymentConfig.model_validate({"deployment_id": "gpt-4"})
+        assert cfg.deployment_id == "gpt-4"
+
+    def test_accepts_legacy_name(self):
+        cfg = DialDeploymentConfig.model_validate({"name": "gpt-4"})
+        assert cfg.deployment_id == "gpt-4"
+
+    def test_rejects_when_neither_present(self):
+        with pytest.raises(ValidationError):
+            DialDeploymentConfig.model_validate({})
+
+    def test_schema_publishes_both_keys(self):
+        schema = DialDeploymentConfig.model_json_schema()
+        properties = schema["properties"]
+
+        assert "deployment_id" in properties
+        assert properties["deployment_id"].get(DialJSONSchemaExtensions.RESOURCE) is True
+
+        assert "name" in properties
+        assert properties["name"].get("deprecated") is True
+
+    def test_schema_uses_anyOf_for_required(self):
+        schema = DialDeploymentConfig.model_json_schema()
+        assert "deployment_id" not in schema.get("required", [])
+        assert {"required": ["deployment_id"]} in schema["anyOf"]
+        assert {"required": ["name"]} in schema["anyOf"]
+
+
+class TestDialMCPToolSetLegacyAlias:
+    def test_accepts_canonical_deployment_id(self):
+        cfg = DialMCPToolSet.model_validate(
+            {"type": "dial-mcp", "deployment_id": "toolsets/public/x"}
+        )
+        assert cfg.deployment_id == "toolsets/public/x"
+
+    def test_accepts_legacy_dial_id(self):
+        cfg = DialMCPToolSet.model_validate({"type": "dial-mcp", "dial_id": "toolsets/public/x"})
+        assert cfg.deployment_id == "toolsets/public/x"
+
+    def test_rejects_when_neither_present(self):
+        with pytest.raises(ValidationError):
+            DialMCPToolSet.model_validate({"type": "dial-mcp"})
+
+    def test_schema_publishes_both_keys(self):
+        schema = DialMCPToolSet.model_json_schema()
+        properties = schema["properties"]
+
+        assert "deployment_id" in properties
+        assert properties["deployment_id"].get(DialJSONSchemaExtensions.RESOURCE) is True
+
+        assert "dial_id" in properties
+        assert properties["dial_id"].get("deprecated") is True
+
+    def test_schema_uses_anyOf_for_required(self):
+        schema = DialMCPToolSet.model_json_schema()
+        assert "deployment_id" not in schema.get("required", [])
+        assert {"required": ["deployment_id"]} in schema["anyOf"]
+        assert {"required": ["dial_id"]} in schema["anyOf"]

--- a/src/tests/unit_tests/dial_app_tooling_tests/_helpers.py
+++ b/src/tests/unit_tests/dial_app_tooling_tests/_helpers.py
@@ -42,7 +42,7 @@ def make_async_loader(returns: Any) -> AsyncMock:
 
 def make_tool_config(name: str = "deployment_id_tool") -> DialDeploymentTool:
     return DialDeploymentTool(
-        deployment=DialDeploymentConfig(name="deployment-id"),
+        deployment=DialDeploymentConfig(deployment_id="deployment-id"),
         open_ai_tool=OpenAiToolConfig(
             function=OpenAiToolFunction(
                 name=name,

--- a/src/tests/unit_tests/dial_core_services_tests/test_async_dial_http_calls.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_async_dial_http_calls.py
@@ -153,7 +153,7 @@ class TestToolConfigServiceHttpCalls:
 
         result = await _tool_config_service(_dial_client()).get_basic_tool_config("test-model")
 
-        assert result.deployment.name == "test-model"
+        assert result.deployment.deployment_id == "test-model"
         requests = httpx_mock.get_requests()
         assert len(requests) == 1
         assert "openai/deployments/test-model" in str(requests[0].url)
@@ -174,7 +174,7 @@ class TestToolConfigServiceHttpCalls:
 
         result = await _tool_config_service(_dial_client()).get_basic_tool_config("test-app")
 
-        assert result.deployment.name == "test-app"
+        assert result.deployment.deployment_id == "test-app"
         urls = [str(r.url) for r in httpx_mock.get_requests()]
         assert any("openai/deployments/test-app" in u for u in urls)
         assert any("openai/applications/test-app" in u for u in urls)
@@ -225,7 +225,7 @@ class TestToolConfigServiceHttpCalls:
         )
         result = await svc.get_basic_tool_config("test-model", api_key=SecretStr(API_KEY))
 
-        assert result.deployment.name == "test-model"
+        assert result.deployment.deployment_id == "test-model"
         provider.get.assert_not_called()
 
     @pytest.mark.asyncio

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -90,7 +90,7 @@ class TestGetBasicToolConfig:
 
         result = await svc.get_basic_tool_config("gpt-4")
 
-        assert result.deployment.name == "gpt-4"
+        assert result.deployment.deployment_id == "gpt-4"
         dial_client.deployments.get.assert_awaited_once_with("gpt-4")
         dial_client.application.get.assert_not_called()
 
@@ -105,7 +105,7 @@ class TestGetBasicToolConfig:
 
         result = await svc.get_basic_tool_config("my-app")
 
-        assert result.deployment.name == "my-app"
+        assert result.deployment.deployment_id == "my-app"
         dial_client.application.get.assert_awaited_once_with("my-app")
 
     @pytest.mark.asyncio

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -345,7 +345,7 @@ def _make_tool_config(
 ) -> DialDeploymentTool:
     """Build a real DialDeploymentTool for _pre_process_params tests."""
     deployment = DialDeploymentConfig(
-        name="test-deployment",
+        deployment_id="test-deployment",
         parameters=parameters or DialDeploymentParameters(),
     )
     if configuration_param_names:

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_deployment_tool_initializer.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_deployment_tool_initializer.py
@@ -17,7 +17,9 @@ from tests.unit_tests.common.common import make_provider
 
 def _make_deployment_tool(name: str) -> DialDeploymentTool:
     return DialDeploymentTool(
-        deployment=DialDeploymentConfig(name="my-app", parameters=DialDeploymentParameters()),
+        deployment=DialDeploymentConfig(
+            deployment_id="my-app", parameters=DialDeploymentParameters()
+        ),
         open_ai_tool=OpenAiToolConfig(
             function=OpenAiToolFunction(
                 name=name,

--- a/src/tests/unit_tests/mcp_tool_tests/test_mcp_initializer_interactive_login.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_mcp_initializer_interactive_login.py
@@ -17,9 +17,11 @@ from quickapp.mcp_tooling._mcp_unauthorized_exception import MCPUnauthorizedExce
 from tests.unit_tests.common.common import make_provider, noop_timeout_resolver
 
 
-def _make_dial_toolset(dial_id: str = "toolsets/public/ts1", name: str = "ts1") -> DialMCPToolSet:
+def _make_dial_toolset(
+    deployment_id: str = "toolsets/public/ts1", name: str = "ts1"
+) -> DialMCPToolSet:
     return DialMCPToolSet(
-        dial_id=dial_id,
+        deployment_id=deployment_id,
         name=name,
         enabled=True,
     )
@@ -128,7 +130,7 @@ async def test_no_401_no_login_called():
 @pytest.mark.asyncio
 async def test_dial_toolset_401_triggers_batch_login():
     """DialMCPToolSet returning 401 triggers batch interactive login."""
-    ts = _make_dial_toolset(dial_id="toolsets/public/ts1")
+    ts = _make_dial_toolset(deployment_id="toolsets/public/ts1")
 
     conn = MagicMock()
     conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts1"))
@@ -155,7 +157,7 @@ async def test_dial_toolset_401_triggers_batch_login():
 @pytest.mark.asyncio
 async def test_dial_toolset_401_success_retries():
     """DialMCPToolSet 401 → login SUCCESS → retry succeeds."""
-    ts = _make_dial_toolset(dial_id="toolsets/public/ts1")
+    ts = _make_dial_toolset(deployment_id="toolsets/public/ts1")
 
     call_count = 0
 
@@ -189,7 +191,7 @@ async def test_dial_toolset_401_success_retries():
 @pytest.mark.asyncio
 async def test_retry_failure_appends_exception():
     """Login SUCCESS but retry still fails → ToolInitializationException appended."""
-    ts = _make_dial_toolset(dial_id="toolsets/public/ts1", name="ts1")
+    ts = _make_dial_toolset(deployment_id="toolsets/public/ts1", name="ts1")
 
     conn = MagicMock()
     conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts1"))
@@ -235,8 +237,8 @@ async def test_plain_mcp_toolset_401_not_eligible():
 @pytest.mark.asyncio
 async def test_batch_multiple_toolsets():
     """Multiple DialMCPToolSets fail with 401 → single batch login call."""
-    ts1 = _make_dial_toolset(dial_id="toolsets/public/ts1", name="ts1")
-    ts2 = _make_dial_toolset(dial_id="toolsets/public/ts2", name="ts2")
+    ts1 = _make_dial_toolset(deployment_id="toolsets/public/ts1", name="ts1")
+    ts2 = _make_dial_toolset(deployment_id="toolsets/public/ts2", name="ts2")
 
     conn = MagicMock()
     conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts"))
@@ -270,7 +272,7 @@ async def test_batch_multiple_toolsets():
 @pytest.mark.asyncio
 async def test_no_channel_appends_exception():
     """Login returns NO_CHANNEL → ToolInitializationException with appropriate message."""
-    ts = _make_dial_toolset(dial_id="toolsets/public/ts1", name="ts1")
+    ts = _make_dial_toolset(deployment_id="toolsets/public/ts1", name="ts1")
 
     conn = MagicMock()
     conn.get_tools_list = AsyncMock(side_effect=MCPUnauthorizedException("ts1"))

--- a/src/tests/unit_tests/predefined_tooling_tests/test_config_resolver.py
+++ b/src/tests/unit_tests/predefined_tooling_tests/test_config_resolver.py
@@ -100,7 +100,7 @@ class TestResolverAppliesMerge:
         mock_provider.read_json.return_value = _minimal_deployment_tool_template()
         result = resolver.resolve_tool(PredefinedTool(template_name="dial_rag"))
         assert isinstance(result, DialDeploymentTool)
-        assert result.deployment.name == "dial-rag"
+        assert result.deployment.deployment_id == "dial-rag"
         mock_provider.read_json.assert_called_once_with(ContentType.TOOL, "dial_rag")
 
     def test_resolve_tool_applies_deployment_name_swap(
@@ -114,7 +114,7 @@ class TestResolverAppliesMerge:
             )
         )
         assert isinstance(result, DialDeploymentTool)
-        assert result.deployment.name == "hr-rag-prod"
+        assert result.deployment.deployment_id == "hr-rag-prod"
 
     def test_resolve_tool_applies_function_description_revision(
         self, resolver: PredefinedConfigResolver, mock_provider: MagicMock
@@ -132,7 +132,7 @@ class TestResolverAppliesMerge:
         assert result.open_ai_tool.function.description == "Search internal HR docs."
         # Other fields untouched.
         assert result.open_ai_tool.function.name == "rag_search_tool"
-        assert result.deployment.name == "dial-rag"
+        assert result.deployment.deployment_id == "dial-rag"
 
     def test_resolve_tool_does_not_mutate_template(
         self, resolver: PredefinedConfigResolver, mock_provider: MagicMock
@@ -215,8 +215,8 @@ class TestErrorWrapping:
     ):
         mock_provider.read_json.return_value = _minimal_deployment_tool_template()
         with pytest.raises(ConfigResolutionException) as excinfo:
-            # `deployment.name` must be a string; passing an int triggers
-            # pydantic validation after the merge.
+            # `deployment.name` (legacy alias for `deployment_id`) must be a string;
+            # passing an int triggers pydantic validation after the merge.
             resolver.resolve_tool(
                 PredefinedTool(
                     template_name="dial_rag",
@@ -330,7 +330,7 @@ class TestResolveConfigPartialTolerance:
 
         assert isinstance(result, DeploymentToolSet)
         resolved_names = [
-            t.deployment.name for t in result.tools if isinstance(t, DialDeploymentTool)
+            t.deployment.deployment_id for t in result.tools if isinstance(t, DialDeploymentTool)
         ]
         assert resolved_names == ["dial-rag", "dial-rag"]
         assert len(result.tools) == 2


### PR DESCRIPTION
### Applicable issues

- fixes #286

### Description of changes

Renames `DialDeploymentConfig.name` → `deployment_id` and `DialMCPToolSet.dial_id` → `deployment_id` so both fields match `DialDeploymentSimpleTool` / `DialAppToolSet` and carry the `dial:resource: true` schema extension (the DIAL UI uses this to recognize deployment-resource references).

Backward compatibility is preserved at two layers:

- **Pydantic runtime**: legacy keys (`name`, `dial_id`) keep validating via `validation_alias=AliasChoices(...)`.
- **Published JSON schema** (consumed by DIAL Core for config validation): each model gains a deprecated sibling property and an `anyOf` clause requiring at least one of (canonical, legacy), so manifests using the old keys keep passing schema validation.

The legacy-alias machinery is factored into a reusable primitive in `src/quickapp/common/base_config.py`:

- `LegacyAlias` — composable `Annotated` metadata, usable with any field helper (`DialResourceConfigField`, `DialFileConfigField`, plain `Field`, etc.).
- `LegacyAliasModel` — base class that wires up `validation_alias` and JSON-schema injection at class init.

Future field renames are one extra annotation on the field plus inheriting the base.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated (`CONFIGURATION.md` examples switched to `deployment_id`)
- [x] App schema changes are backward compatible (legacy keys still accepted via `anyOf`; deprecated sibling property in schema)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.