### PR TITLE
feat: graduate Time Awareness feature to GA

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This folder contains technical documentation for the Quick Apps backend.
 | [ChatHub](./chathub.md)                       | Configuration guide for ChatHub variants — variant structure, authoring, and customization recipes.                                  |
 | [File Transfer](file_transfer.md)             | How Quick Apps handles file parameters in tool calls (`file:{prefix}::` convention, preprocessing pipeline).                         |
 | [Agent Skills](skills.md)                     | How to create and manage reusable agent skills (directory layout, metadata).                                                         |
+| [Time Awareness](time_awareness.md)           | How the agent knows the current time and reasons about data freshness.                                                               |
 
 ## Preview Features
 
@@ -19,7 +20,6 @@ See [Feature Lifecycle](../README.md#feature-lifecycle) for details.
 
 | Document                              | Description                                                                  |
 |---------------------------------------|------------------------------------------------------------------------------|
-| [Time Awareness](time_awareness.md) `[Preview]`  | How the agent knows the current time and reasons about data freshness.       |
 
 ## Diagrams
 

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -267,7 +267,7 @@ The setup pipeline runs the following steps in order:
    notification. If changes are detected, inserts synthetic tool call and tool result message pairs into the history
    using the `available_context` tool. Returns messages unchanged when inactive.
 
-4. **Timestamp Injection Transformer** (`_TimestampInjectionTransformer`, preview): Appends a synthetic
+4. **Timestamp Injection Transformer** (`_TimestampInjectionTransformer`): Appends a synthetic
    `current_timestamp` tool-call + result pair at the end of the message list so the agent knows "when" the
    interaction is happening. Historical timestamps are restored from state with their original times.
 
@@ -276,7 +276,7 @@ The setup pipeline runs the following steps in order:
 Before each LLM call, `AssistantInvoker` runs all `PreInvocationTransformer` instances. Current implementations:
 
 1. **Attachment Filter** (`_AttachmentFilter`): Filters unsupported attachment types and injects attachment XML metadata.
-2. **Timestamp Annotation Transformer** (`_TimestampAnnotationTransformer`, preview): Appends human-readable
+2. **Timestamp Annotation Transformer** (`_TimestampAnnotationTransformer`): Appends human-readable
    `[Timestamp: ...]` annotations to tool messages that carry timestamp metadata.
 
 ### Streaming Response Processing
@@ -393,7 +393,7 @@ The application is composed of 15 specialized DI modules:
 10. **DIAL Core Services Module**: DIAL Core integration (`InteractiveLoginService`, `InteractiveLoginSettings`)
 11. **File Transfer Module**: `ToolArgumentTransformer` for `file:` prefix resolution, file transfer instruction injection
 12. **Attachment Processing Module**: Context notification tool, attachment change detection injector
-13. **Timestamp Module** (preview): Timestamp tool, injection/annotation transformers, metadata enricher
+13. **Timestamp Module**: Timestamp tool, injection/annotation transformers, metadata enricher
 14. **Skills Module**: Skill reader tool, agent skills provider, skills registry
 15. **DIAL Prompt Skills Module**: Resolver for DIAL-prompt-sourced skills
 

--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -1188,8 +1188,7 @@
               "type": "null"
             }
           ],
-          "description": "Time awareness configuration.",
-          "x-preview": true
+          "description": "Time awareness configuration."
         },
         "file_loading": {
           "$ref": "#/$defs/FileLoadingConfig",

--- a/docs/time_awareness.md
+++ b/docs/time_awareness.md
@@ -1,8 +1,4 @@
-# Time Awareness `[Preview]`
-
-> [!IMPORTANT]
-> Time Awareness is a **preview** feature. Its API and behavior may change in breaking ways without a major
-> version bump. See [Feature Lifecycle](../README.md#feature-lifecycle) for details.
+# Time Awareness
 
 ## Why
 
@@ -43,8 +39,7 @@ Add a `features` section to the application config:
 }
 ```
 
-The feature is enabled by default when preview features are active. To explicitly disable it for a specific app,
-set `"timestamp": null`.
+The feature is enabled by default. To explicitly disable it for a specific app, set `"timestamp": null`.
 
 ## What the agent sees
 

--- a/src/quickapp/config/application.py
+++ b/src/quickapp/config/application.py
@@ -3,7 +3,7 @@ import logging
 from pydantic import BaseModel, Field, model_validator
 
 from quickapp.agent.agent_settings import AgentSettings
-from quickapp.common.base_config import BaseApplicationTypeConfig, PreviewField, has_preview_marker
+from quickapp.common.base_config import BaseApplicationTypeConfig, has_preview_marker
 from quickapp.common.feature_settings import FeatureSettings
 from quickapp.config.context import Context
 from quickapp.config.dial_deployment import DialDeploymentConfig
@@ -69,7 +69,7 @@ class FileLoadingConfig(BaseModel):
 
 
 class Features(BaseModel):
-    timestamp: TimestampConfig | None = PreviewField(  # type: ignore[assignment]
+    timestamp: TimestampConfig | None = Field(
         default_factory=ToolCallTimestampConfig,
         description="Time awareness configuration.",
     )

--- a/src/quickapp/timestamp_tooling/timestamp_module.py
+++ b/src/quickapp/timestamp_tooling/timestamp_module.py
@@ -6,7 +6,6 @@ from injector import AssistedBuilder, Binder, Module, multiprovider
 from quickapp.common import StagedBaseTool
 from quickapp.common.abstract.base_transformer import MessagesTransformer, PreInvocationTransformer
 from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
-from quickapp.common.preview import preview_module
 from quickapp.common.time_provider import TimeProvider
 from quickapp.config.application import ApplicationConfig
 from quickapp.timestamp_tooling._current_timestamp_tool import _CurrentTimestampTool
@@ -22,7 +21,6 @@ from quickapp.timestamp_tooling._tool_configs import CURRENT_TIMESTAMP_TOOL_CONF
 logger = logging.getLogger(__name__)
 
 
-@preview_module
 class TimestampModule(Module):
 
     def configure(self, binder: Binder) -> None:

--- a/src/tests/unit_tests/config_tests/test_features_config.py
+++ b/src/tests/unit_tests/config_tests/test_features_config.py
@@ -3,32 +3,20 @@ from quickapp.config.timestamp import ToolCallTimestampConfig
 
 
 class TestFeaturesConfig:
-    def test_default_features_has_timestamp_enabled(self, monkeypatch):
-        monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
+    def test_default_features_has_timestamp_enabled(self):
         features = Features()
         assert features.timestamp is not None
         assert isinstance(features.timestamp, ToolCallTimestampConfig)
 
-    def test_timestamp_none_disables(self, monkeypatch):
-        monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
+    def test_timestamp_none_disables(self):
         features = Features(timestamp=None)
         assert features.timestamp is None
 
-    def test_explicit_timestamp_config(self, monkeypatch):
-        monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
+    def test_explicit_timestamp_config(self):
         features = Features(timestamp=ToolCallTimestampConfig())
         assert features.timestamp is not None
         assert features.timestamp.injection_strategy == "tool_call"
 
-    def test_empty_dict_creates_default(self, monkeypatch):
-        monkeypatch.setenv("ENABLE_PREVIEW_FEATURES", "true")
+    def test_empty_dict_creates_default(self):
         features = Features.model_validate({})
         assert features.timestamp is not None
-
-    def test_preview_gating_nullifies_timestamp(self, monkeypatch):
-        monkeypatch.delenv("ENABLE_PREVIEW_FEATURES", raising=False)
-        from quickapp.config.application import nullify_preview_fields
-
-        features = Features()
-        nullify_preview_fields(features)
-        assert features.timestamp is None


### PR DESCRIPTION
### Applicable issues

- fixes #288

### Description of changes

Graduate the Time Awareness (`features.timestamp`) feature from preview to GA. The feature is no longer gated by `ENABLE_PREVIEW_FEATURES`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.