### PR TITLE
feat: graduate DIAL Prompt Skills feature to GA

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,12 +67,12 @@ Request → HTTP endpoint (`application/`) → Config resolution → Tool initia
 ### Skills
 
 Skills are reusable instruction modules. Predefined skills are loaded at startup from `config/predefined/skills/`.
-DIAL prompt skills (`dial_prompt_skills/`) are fetched at request time from DIAL Core's prompts API — this is a
-preview feature. `SkillsRegistry` merges both sources per request.
+DIAL prompt skills (`dial_prompt_skills/`) are fetched at request time from DIAL Core's prompts API.
+`SkillsRegistry` merges both sources per request.
 
 ### Configuration Model
 
-JSON-schema validated manifests with four sections: orchestrator config (deployment, system prompt, max iterations), contexts (file attachments), tool sets, and skills (optional, preview). Schema is auto-generated — run `make dump_app_schema` after changing config models.
+JSON-schema validated manifests with four sections: orchestrator config (deployment, system prompt, max iterations), contexts (file attachments), tool sets, and skills (optional). Schema is auto-generated — run `make dump_app_schema` after changing config models.
 
 ### Preview Features
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Features in Preview are marked with a `[Preview]` tag in documentation.
 ## Documentation
 
 - [Configuration Reference](./CONFIGURATION.md) - Full configuration model, environment variables, and examples
-- [Agent Skills](docs/skills.md) `[Preview]` - How to create and manage reusable agent skills
+- [Agent Skills](docs/skills.md) - How to create and manage reusable agent skills
 - [Technical Documentation](./docs/README.md) - Internal architecture and design documents
 
 ## Quick start (general)
@@ -129,7 +129,7 @@ your gateways or downstream services expect.
 
 > [!WARNING]
 > The `config/predefined/instructions/` directory convention (formerly documented as "Agent instructions") has been
-> removed. Instructions are replaced by [Agent Skills \[Preview\]](docs/skills.md), which offer richer
+> removed. Instructions are replaced by [Agent Skills](docs/skills.md), which offer richer
 > metadata,
 > on-demand retrieval, and layered overrides. See the
 > [migration guide](docs/skills.md#migrating-from-agent-instructions) for details.

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ This folder contains technical documentation for the Quick Apps backend.
 | [Application Schema](./application-schema.md) | How to configure QuickApps in DIAL Core (schema endpoint vs full schema).                                                            |
 | [ChatHub](./chathub.md)                       | Configuration guide for ChatHub variants — variant structure, authoring, and customization recipes.                                  |
 | [File Transfer](file_transfer.md)             | How Quick Apps handles file parameters in tool calls (`file:{prefix}::` convention, preprocessing pipeline).                         |
+| [Agent Skills](skills.md)                     | How to create and manage reusable agent skills (directory layout, metadata).                                                         |
 
 ## Preview Features
 
@@ -18,7 +19,6 @@ See [Feature Lifecycle](../README.md#feature-lifecycle) for details.
 
 | Document                              | Description                                                                  |
 |---------------------------------------|------------------------------------------------------------------------------|
-| [Agent Skills](skills.md)                        | How to create and manage reusable agent skills (directory layout, metadata). |
 | [Time Awareness](time_awareness.md) `[Preview]`  | How the agent knows the current time and reasons about data freshness.       |
 
 ## Diagrams

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,7 +18,7 @@ See [Feature Lifecycle](../README.md#feature-lifecycle) for details.
 
 | Document                              | Description                                                                  |
 |---------------------------------------|------------------------------------------------------------------------------|
-| [Agent Skills](skills.md) `[Preview]`            | How to create and manage reusable agent skills (directory layout, metadata). |
+| [Agent Skills](skills.md)                        | How to create and manage reusable agent skills (directory layout, metadata). |
 | [Time Awareness](time_awareness.md) `[Preview]`  | How the agent knows the current time and reasons about data freshness.       |
 
 ## Diagrams

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -395,7 +395,7 @@ The application is composed of 15 specialized DI modules:
 12. **Attachment Processing Module**: Context notification tool, attachment change detection injector
 13. **Timestamp Module** (preview): Timestamp tool, injection/annotation transformers, metadata enricher
 14. **Skills Module**: Skill reader tool, agent skills provider, skills registry
-15. **DIAL Prompt Skills Module** (preview): Resolver for DIAL-prompt-sourced skills
+15. **DIAL Prompt Skills Module**: Resolver for DIAL-prompt-sourced skills
 
 ### Scoping
 
@@ -459,7 +459,7 @@ Tools are organized into toolsets that share common configuration:
 
 `AgentSkillsProvider` also delegates to `PredefinedContentProvider` for skill file reading. At request time,
 `SkillsRegistry` merges predefined skills with any DIAL-prompt-sourced skills configured in the `skills` field
-(see [Skills documentation](skills.md#dial-prompt-skills-preview) for details).
+(see [Skills documentation](skills.md#dial-prompt-skills) for details).
 
 This enables reusable configuration building blocks that can be shared across applications, with layered override support for customization.
 

--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -3059,7 +3059,6 @@
       "default": null,
       "description": "Optional list of user-configured agent skills.",
       "title": "Skills",
-      "x-preview": true,
       "dial:meta": {
         "dial:propertyKind": "server",
         "dial:propertyOrder": 6

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,8 +1,4 @@
-# Agent Skills `[Preview]`
-
-> [!IMPORTANT]
-> Agent Skills is a **preview** feature. Its API and behavior may change in breaking ways without a major version bump.
-> See [Feature Lifecycle](../README.md#feature-lifecycle) for details.
+# Agent Skills
 
 Agent skills are reusable instruction modules that enhance agent capabilities. Skills follow the
 [Agent Skills](https://agentskills.io/) open standard and are defined as Markdown files with YAML frontmatter inside
@@ -125,7 +121,7 @@ optional features. The table below summarises what is and isn't supported.
 For the full specification, see [agentskills.io/specification](https://agentskills.io/specification).
 For design rationale and known limitations, see [the design doc](designs/skills_and_file_transfer.md).
 
-## DIAL Prompt Skills `[Preview]`
+## DIAL Prompt Skills
 
 In addition to predefined skills bundled at build time, users can configure skills sourced from
 **DIAL prompts** — text content stored via the DIAL Core prompts API (`/v1/prompts/`). A DIAL prompt

--- a/src/quickapp/config/application.py
+++ b/src/quickapp/config/application.py
@@ -115,7 +115,7 @@ class ApplicationConfig(BaseApplicationTypeConfig):
     conversation_starters: ConversationStartersConfig | None = Field(
         description="The configuration for conversation starters.", default=None
     )
-    skills: list[SkillConfig] | None = PreviewField(  # type: ignore[assignment]
+    skills: list[SkillConfig] | None = Field(
         default=None,
         description="Optional list of user-configured agent skills.",
     )

--- a/src/quickapp/dial_prompt_skills/dial_prompt_skills_module.py
+++ b/src/quickapp/dial_prompt_skills/dial_prompt_skills_module.py
@@ -5,7 +5,6 @@ from injector import Binder, Module, ProviderOf, multiprovider
 
 from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.exceptions import InitializationException
-from quickapp.common.preview import preview_module
 from quickapp.dial_prompt_skills._dial_prompt_skill_initializer import _DialPromptSkillInitializer
 from quickapp.dial_prompt_skills._dial_prompt_skill_resolver import DialPromptSkillResolver
 from quickapp.dial_prompt_skills._dial_prompt_skills_context import _DialPromptSkillsContext
@@ -13,7 +12,6 @@ from quickapp.dial_prompt_skills._dial_prompt_skills_context import _DialPromptS
 logger = logging.getLogger(__name__)
 
 
-@preview_module
 class DialPromptSkillsModule(Module):
 
     def configure(self, binder: Binder) -> None:


### PR DESCRIPTION
### Applicable issues

- fixes #289

### Description of changes

Graduate DIAL Prompt Skills (the `skills` config field and `DialPromptSkillsModule`) from preview to GA. The feature is no longer gated by `ENABLE_PREVIEW_FEATURES`.

> Note: once this PR and #290 both merge, the now-unused `PreviewField` import in `src/quickapp/config/application.py` and the empty `Preview Features` section in `docs/README.md` should be cleaned up in a follow-up commit.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.