### PR TITLE
chore: enhance issue templates and add tech debt template

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,5 +1,6 @@
 name: 🐞 Bug report
 description: Create a report to help us improve
+type: Bug
 labels: ["bug"]
 body:
   - type: markdown
@@ -11,13 +12,16 @@ body:
     attributes:
       label: QuickApps version
       description: Application version
-      placeholder: 0.1.0
+      placeholder: latest
+      value: latest
     validations:
       required: true
   - type: textarea
     attributes:
       label: What steps will reproduce the bug?
-      description: Enter details about your bug.
+      description: >
+        Enter details about your bug. For bugs related to orchestrator model, include the model name and version.
+        For bugs related to toolsets or subagents, include details on toolset/subagent configuration.
       placeholder: |
         1. In this environment...
         2. With this config...

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,5 +1,6 @@
 name: "🚀 Feature request"
 description: Suggest an idea for this project
+type: Feature
 labels: ["enhancement"]
 body:
   - type: markdown
@@ -11,7 +12,8 @@ body:
     attributes:
       label: QuickApps version
       description: Application version
-      placeholder: 0.1.0
+      placeholder: latest
+      value: latest
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/03_tech_debt.yml
+++ b/.github/ISSUE_TEMPLATE/03_tech_debt.yml
@@ -1,0 +1,79 @@
+name: "🛠️ Tech debt"
+description: Report code, design, or infrastructure debt that should be paid down
+type: Task
+labels: ["tech debt"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for flagging tech debt in DIAL QuickApps.
+        Please fill in as much of the following form as you're able.
+  - type: input
+    attributes:
+      label: QuickApps version
+      description: Application version where the debt was observed
+      placeholder: latest
+      value: latest
+    validations:
+      required: true
+  - type: dropdown
+    attributes:
+      label: Area
+      description: Which parts of the codebase are affected? Select all that apply.
+      multiple: true
+      options:
+        - Orchestrator / agent loop
+        - Toolsets (REST / DIAL deployment / MCP / internal)
+        - Skills
+        - Configuration / schema
+        - Application / HTTP layer
+        - Tests / CI
+        - Build / dependencies / tooling
+        - Documentation
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: What is the current state?
+      description: >
+        Describe the existing code, design, or process that you consider tech debt.
+        Link to specific files, modules, or commits where helpful.
+      placeholder: |
+        - File / module:
+        - Current behavior or pattern:
+        - How it got this way (if known):
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Why is this debt?
+      description: >
+        Explain the impact — e.g. maintainability, performance, security, developer velocity,
+        risk of bugs, blocked features, onboarding friction.
+      placeholder: |
+        - Impact today:
+        - Risk if left unaddressed:
+        - Features or fixes it currently blocks:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Proposed remediation
+      description: >
+        Outline how you'd pay this debt down. Prefer a sketch over a full design;
+        link to a design doc under `docs/designs/` if one exists.
+      placeholder: |
+        - Approach:
+        - Affected modules:
+        - Migration / rollout considerations:
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed and why you didn't pick them.
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Anything else — benchmarks, profiler output, related issues/PRs.


### PR DESCRIPTION
## Summary
- Set GitHub issue `type` on bug and feature templates; default version to `latest`
- Add hint to bug template about orchestrator/toolset details
- Add `🛠️ Tech debt` template with multiselect Area field