### PR TITLE
fix: enrich synthetic tool results with metadata (#296)

### DIFF
--- a/src/quickapp/attachment_processing/_attachment_notification_injector.py
+++ b/src/quickapp/attachment_processing/_attachment_notification_injector.py
@@ -11,6 +11,7 @@ from quickapp.attachment_processing._context_entries import (
     should_activate_context_tool,
 )
 from quickapp.attachment_processing._tool_configs import AVAILABLE_CONTEXT_TOOL_NAME
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
 from quickapp.common.synthetic_injection.injection_enums import InjectionFrequency
 from quickapp.common.synthetic_injection.synthetic_tool_call_injector import (
     SyntheticToolCallInjector,
@@ -25,7 +26,12 @@ class _AttachmentNotificationInjector(SyntheticToolCallInjector):
     available contexts when changes are detected."""
 
     @inject
-    def __init__(self, config_provider: ProviderOf[ApplicationConfig]):
+    def __init__(
+        self,
+        config_provider: ProviderOf[ApplicationConfig],
+        enrichers_provider: ProviderOf[list[ToolCallResultEnricher]],
+    ):
+        super().__init__(enrichers_provider)
         self.__config_provider: ProviderOf[ApplicationConfig] = config_provider
 
     async def get_tool_name(self) -> str:

--- a/src/quickapp/common/abstract/tool_call_result_enricher.py
+++ b/src/quickapp/common/abstract/tool_call_result_enricher.py
@@ -4,11 +4,13 @@ from quickapp.common.tool_call_result import ToolCallResult
 
 
 class ToolCallResultEnricher(ABC):
-    """Enriches a ToolCallResult after tool execution.
+    """Enriches a ToolCallResult after it is produced.
 
-    Implementations are applied by ToolExecutor to every tool result.
-    Enrichers should use "fill if absent" semantics — if the result
-    already contains the metadata they would set, they should preserve it.
+    Implementations are applied to every tool result — both real ones
+    returned by ``ToolExecutor`` and synthetic ones produced by
+    ``SyntheticToolCallInjector`` subclasses. Enrichers should use
+    "fill if absent" semantics — if the result already contains the
+    metadata they would set, they should preserve it.
     """
 
     @abstractmethod

--- a/src/quickapp/common/synthetic_injection/staged_tool_synthetic_injector.py
+++ b/src/quickapp/common/synthetic_injection/staged_tool_synthetic_injector.py
@@ -2,8 +2,9 @@ import logging
 from abc import ABC
 
 from aidial_sdk.chat_completion import Message
-from injector import inject
+from injector import ProviderOf, inject
 
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
 from quickapp.common.staged_base_tool import StagedBaseTool
 from quickapp.common.synthetic_injection.synthetic_tool_call_injector import (
     SyntheticToolCallInjector,
@@ -19,7 +20,12 @@ class StagedToolSyntheticInjector(SyntheticToolCallInjector, ABC):
     OpenAI function name and calling `tool.arun()` with the declared arguments."""
 
     @inject
-    def __init__(self, tools: list[StagedBaseTool]):
+    def __init__(
+        self,
+        tools: list[StagedBaseTool],
+        enrichers_provider: ProviderOf[list[ToolCallResultEnricher]],
+    ):
+        super().__init__(enrichers_provider)
         self.__tools: dict[str, StagedBaseTool] = {
             tool.tool_config.open_ai_tool.function.name: tool for tool in tools
         }

--- a/src/quickapp/common/synthetic_injection/synthetic_tool_call_injector.py
+++ b/src/quickapp/common/synthetic_injection/synthetic_tool_call_injector.py
@@ -2,19 +2,32 @@ import hashlib
 import json
 import logging
 from abc import ABC, abstractmethod
+from typing import Any
 from uuid import uuid4
 
-from aidial_sdk.chat_completion import Message, Role
+from aidial_sdk.chat_completion import CustomContent, Message, Role
 from aidial_sdk.chat_completion.request import FunctionCall, ToolCall
+from injector import ProviderOf
 
 from quickapp.common.abstract.base_transformer import MessagesTransformer
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
+from quickapp.common.media_types import MediaTypes
 from quickapp.common.synthetic_injection.injection_enums import InjectionFrequency
+from quickapp.common.tool_call_result import ToolCallResult
 
 logger = logging.getLogger(__name__)
 
 
 class SyntheticToolCallInjector(MessagesTransformer, ABC):
     call_id_prefix: str = "synth_"
+
+    def __init__(
+        self,
+        enrichers_provider: ProviderOf[list[ToolCallResultEnricher]] | None = None,
+    ) -> None:
+        # Lazy: resolved at transform() time so this class can be constructed
+        # during _RequestContextSetup, before ApplicationConfig is populated.
+        self._enrichers_provider = enrichers_provider
 
     @abstractmethod
     async def get_tool_name(self) -> str: ...
@@ -35,19 +48,16 @@ class SyntheticToolCallInjector(MessagesTransformer, ABC):
         ...
 
     async def transform(self, messages: list[Message]) -> list[Message]:
-        # 1. Precondition gate
         if not await self.should_inject(messages):
             return messages
 
         tool_name = await self.get_tool_name()
         arguments = await self.get_arguments()
 
-        # 2. Content fetch
         content = await self.get_content(messages)
         if content is None:
             return messages
 
-        # 3. Frequency gate + implicit position
         frequency = await self.get_frequency(messages)
 
         match frequency:
@@ -65,9 +75,26 @@ class SyntheticToolCallInjector(MessagesTransformer, ABC):
                 )
                 idx = len(messages) if has_prior else _after_first_user_idx(messages)
 
-        # 4. Pair construction + splice
-        pair = _build_pair(tool_name, call_id, arguments, content)
+        # Enrich the synthetic result so metadata matches real tool results.
+        state = self._enrich_state(call_id, content)
+
+        pair = _build_pair(tool_name, call_id, arguments, content, state)
         return messages[:idx] + list(pair) + messages[idx:]
+
+    def _enrich_state(self, call_id: str, content: str) -> dict[str, Any] | None:
+        if self._enrichers_provider is None:
+            return None
+        enrichers = self._enrichers_provider.get()
+        if not enrichers:
+            return None
+        transient = ToolCallResult(
+            tool_call_id=call_id,
+            content=content,
+            content_type=MediaTypes.PLAIN_TEXT,
+        )
+        for enricher in enrichers:
+            enricher.enrich(transient)
+        return transient.state
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +137,11 @@ def _has_any_pair_for_tool_and_args(
 
 
 def _build_pair(
-    tool_name: str, call_id: str, arguments: dict, content: str
+    tool_name: str,
+    call_id: str,
+    arguments: dict,
+    content: str,
+    state: dict[str, Any] | None = None,
 ) -> tuple[Message, Message]:
     assistant_msg = Message(
         role=Role.ASSISTANT,
@@ -130,5 +161,6 @@ def _build_pair(
         role=Role.TOOL,
         content=content,
         tool_call_id=call_id,
+        custom_content=CustomContent(state=state) if state else None,
     )
     return assistant_msg, tool_msg

--- a/src/quickapp/skills/_inject_file_transfer_instruction_transformer.py
+++ b/src/quickapp/skills/_inject_file_transfer_instruction_transformer.py
@@ -1,8 +1,9 @@
 import logging
 
 from aidial_sdk.chat_completion import Message
-from injector import inject
+from injector import ProviderOf, inject
 
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
 from quickapp.common.synthetic_injection.injection_enums import InjectionFrequency
 from quickapp.common.synthetic_injection.synthetic_tool_call_injector import (
     SyntheticToolCallInjector,
@@ -20,7 +21,12 @@ class _InjectFileTransferInstructionTransformer(SyntheticToolCallInjector):
     exactly once per conversation."""
 
     @inject
-    def __init__(self, skills_provider: AgentSkillsProvider):
+    def __init__(
+        self,
+        skills_provider: AgentSkillsProvider,
+        enrichers_provider: ProviderOf[list[ToolCallResultEnricher]],
+    ):
+        super().__init__(enrichers_provider)
         self.__skills_provider = skills_provider
 
     async def get_tool_name(self) -> str:

--- a/src/quickapp/timestamp_tooling/_timestamp_injection_transformer.py
+++ b/src/quickapp/timestamp_tooling/_timestamp_injection_transformer.py
@@ -1,6 +1,7 @@
 from aidial_sdk.chat_completion import Message
 from injector import ProviderOf, inject
 
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
 from quickapp.common.synthetic_injection.injection_enums import InjectionFrequency
 from quickapp.common.synthetic_injection.synthetic_tool_call_injector import (
     SyntheticToolCallInjector,
@@ -24,7 +25,9 @@ class _TimestampInjectionTransformer(SyntheticToolCallInjector):
         self,
         time_provider: TimeProvider,
         config_provider: ProviderOf[ApplicationConfig],
+        enrichers_provider: ProviderOf[list[ToolCallResultEnricher]],
     ):
+        super().__init__(enrichers_provider)
         self.__time_provider = time_provider
         self.__config_provider = config_provider
 

--- a/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
+++ b/src/tests/unit_tests/application_tests/test_pre_transformer_pipeline_di.py
@@ -13,12 +13,13 @@ import json
 
 from aidial_sdk.chat_completion import Attachment, CustomContent, Message, Role
 from fastapi_injector import Injected
-from injector import Binder
+from injector import Binder, Module, multiprovider
 from starlette.testclient import TestClient
 
 from quickapp.application._messages_setup import _MessagesSetup
 from quickapp.attachment_processing._tool_configs import AVAILABLE_CONTEXT_TOOL_NAME
 from quickapp.attachment_processing.attachment_processing_module import AttachmentProcessingModule
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.context import FileContextConfig
 from tests.unit_tests.common.common import create_app_configuration, create_test_app
@@ -39,6 +40,15 @@ def _attachment(title: str, url: str, mime_type: str) -> Attachment:
     )
 
 
+class _EmptyEnrichersModule(Module):
+    def configure(self, binder: Binder) -> None:
+        pass
+
+    @multiprovider
+    def _enrichers(self) -> list[ToolCallResultEnricher]:
+        return []
+
+
 def _make_context_app(ctx_url: str):
     ctx = FileContextConfig(url=ctx_url, description="Reference doc")
 
@@ -47,7 +57,7 @@ def _make_context_app(ctx_url: str):
         app_config.contexts = [ctx]
         binder.bind(ApplicationConfig, to=app_config)
 
-    return create_test_app([AttachmentProcessingModule, configure])
+    return create_test_app([AttachmentProcessingModule, _EmptyEnrichersModule, configure])
 
 
 def test_context_file_notified_via_synthetic_tool_call():

--- a/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
+++ b/src/tests/unit_tests/attachment_processing_tests/test_attachment_notification_injector.py
@@ -12,6 +12,7 @@ from quickapp.config.application import ApplicationConfig, OrchestratorConfig
 from quickapp.config.context import Context, FileContextConfig
 from quickapp.config.dial_deployment import DialDeploymentConfig
 from quickapp.config.prompt import CustomSystemPromptConfig
+from tests.unit_tests.common.common import make_provider
 
 
 def _user_msg(content: str = "", attachments: list[Attachment] | None = None) -> Message:
@@ -34,7 +35,10 @@ def _make_injector(contexts: list[Context] = None) -> _AttachmentNotificationInj
         tool_sets=[],
     )
     provider = SimpleNamespace(get=lambda: config)
-    return _AttachmentNotificationInjector(config_provider=provider)
+    return _AttachmentNotificationInjector(
+        config_provider=provider,
+        enrichers_provider=make_provider([]),
+    )
 
 
 def _extract_synthetic(result: list[Message], original_count: int) -> list[Message]:

--- a/src/tests/unit_tests/common/test_staged_tool_synthetic_injector.py
+++ b/src/tests/unit_tests/common/test_staged_tool_synthetic_injector.py
@@ -9,6 +9,7 @@ from quickapp.common.synthetic_injection.injection_enums import InjectionFrequen
 from quickapp.common.synthetic_injection.staged_tool_synthetic_injector import (
     StagedToolSyntheticInjector,
 )
+from tests.unit_tests.common.common import make_provider
 
 
 def _make_staged_tool(sanitized_name: str, run_content: str = "tool result") -> MagicMock:
@@ -28,7 +29,7 @@ def _make_staged_tool(sanitized_name: str, run_content: str = "tool result") -> 
 
 class _ConcreteInjector(StagedToolSyntheticInjector):
     def __init__(self, tools, tool_name: str):
-        super().__init__(tools)
+        super().__init__(tools, enrichers_provider=make_provider([]))
         self._tool_name = tool_name
 
     async def get_tool_name(self) -> str:

--- a/src/tests/unit_tests/common/test_synthetic_tool_call_injector.py
+++ b/src/tests/unit_tests/common/test_synthetic_tool_call_injector.py
@@ -1,10 +1,13 @@
 import pytest
 from aidial_sdk.chat_completion import Message, Role
 
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
 from quickapp.common.synthetic_injection.injection_enums import InjectionFrequency
 from quickapp.common.synthetic_injection.synthetic_tool_call_injector import (
     SyntheticToolCallInjector,
 )
+from quickapp.common.tool_call_result import ToolCallResult
+from tests.unit_tests.common.common import make_provider
 
 # ---------------------------------------------------------------------------
 # Minimal concrete implementations for testing
@@ -23,7 +26,12 @@ class _AlwaysInjector(SyntheticToolCallInjector):
 
 
 class _AppendIfChangedInjector(SyntheticToolCallInjector):
-    def __init__(self, content: str = "append content"):
+    def __init__(
+        self,
+        content: str = "append content",
+        enrichers: list[ToolCallResultEnricher] | None = None,
+    ):
+        super().__init__(make_provider(enrichers) if enrichers else None)
         self._content = content
 
     async def get_tool_name(self) -> str:
@@ -43,6 +51,7 @@ class _ParamDrivenInjector(SyntheticToolCallInjector):
         frequency: InjectionFrequency,
         content: str | None = None,
     ):
+        super().__init__()
         self._arguments = arguments
         self._frequency = frequency
         self._content = content
@@ -62,6 +71,7 @@ class _ParamDrivenInjector(SyntheticToolCallInjector):
 
 class _ConditionalInjector(SyntheticToolCallInjector):
     def __init__(self, condition_result: bool = True):
+        super().__init__()
         self._condition_result = condition_result
 
     async def get_tool_name(self) -> str:
@@ -312,6 +322,65 @@ class TestNullContent:
         result = await injector.transform(messages)
 
         assert result is messages
+
+
+# ---------------------------------------------------------------------------
+# Tests: enrichment
+# ---------------------------------------------------------------------------
+
+
+class _StampingEnricher(ToolCallResultEnricher):
+    def __init__(self, marker: str = "x"):
+        self._marker = marker
+
+    def enrich(self, result: ToolCallResult) -> None:
+        if result.state is None:
+            result.state = {}
+        result.state["marker"] = self._marker
+
+
+class TestEnrichment:
+    @pytest.mark.asyncio
+    async def test_enriched_state_lands_on_synthetic_tool_message(self):
+        injector = _AppendIfChangedInjector(enrichers=[_StampingEnricher("seen")])
+        result = await injector.transform([_user("hi")])
+
+        tool_msg = result[2]
+        assert tool_msg.custom_content is not None
+        assert tool_msg.custom_content.state == {"marker": "seen"}
+
+    @pytest.mark.asyncio
+    async def test_no_custom_content_when_no_enrichers(self):
+        injector = _AppendIfChangedInjector()
+        result = await injector.transform([_user("hi")])
+
+        tool_msg = result[2]
+        assert tool_msg.custom_content is None
+
+    @pytest.mark.asyncio
+    async def test_multiple_enrichers_compose(self):
+        class _SecondEnricher(ToolCallResultEnricher):
+            def enrich(self, result: ToolCallResult) -> None:
+                if result.state is None:
+                    result.state = {}
+                result.state["extra"] = "yes"
+
+        injector = _AppendIfChangedInjector(
+            enrichers=[_StampingEnricher("first"), _SecondEnricher()],
+        )
+        result = await injector.transform([_user("hi")])
+
+        tool_msg = result[2]
+        assert tool_msg.custom_content is not None
+        assert tool_msg.custom_content.state == {"marker": "first", "extra": "yes"}
+
+    @pytest.mark.asyncio
+    async def test_assistant_message_has_no_custom_content(self):
+        injector = _AppendIfChangedInjector(enrichers=[_StampingEnricher()])
+        result = await injector.transform([_user("hi")])
+
+        assistant_msg = result[1]
+        assert assistant_msg.custom_content is None
 
 
 # ---------------------------------------------------------------------------

--- a/src/tests/unit_tests/skills_tests/test_inject_file_transfer_instruction_transformer.py
+++ b/src/tests/unit_tests/skills_tests/test_inject_file_transfer_instruction_transformer.py
@@ -11,6 +11,7 @@ from quickapp.skills._inject_file_transfer_instruction_transformer import (
 )
 from quickapp.skills._tool_configs import SKILL_READER_TOOL_NAME
 from quickapp.skills.agent_skills_provider import AgentSkillsProvider
+from tests.unit_tests.common.common import make_provider
 
 EXPECTED_CALL_ID_NAME_START = f"synth_{SKILL_READER_TOOL_NAME}"
 
@@ -18,7 +19,9 @@ EXPECTED_CALL_ID_NAME_START = f"synth_{SKILL_READER_TOOL_NAME}"
 def _make_transformer() -> _InjectFileTransferInstructionTransformer:
     provider = PredefinedContentProvider(PredefinedSettings())
     skills_provider = AgentSkillsProvider(provider)
-    return _InjectFileTransferInstructionTransformer(skills_provider)
+    return _InjectFileTransferInstructionTransformer(
+        skills_provider, enrichers_provider=make_provider([])
+    )
 
 
 def _assert_synthetic_pair(messages: list[Message], assistant_idx: int) -> None:

--- a/src/tests/unit_tests/timestamp_tooling/test_timestamp_injection_transformer.py
+++ b/src/tests/unit_tests/timestamp_tooling/test_timestamp_injection_transformer.py
@@ -4,15 +4,19 @@ from unittest.mock import Mock
 import pytest
 from aidial_sdk.chat_completion import Message, Role
 
+from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
+from quickapp.common.message_metadata import get_metadata_from_state
 from quickapp.common.time_provider import TimeProvider
 from quickapp.config.timestamp import ToolCallTimestampConfig
 from quickapp.timestamp_tooling._timestamp_injection_transformer import (
     _TimestampInjectionTransformer,
 )
+from quickapp.timestamp_tooling._timestamp_metadata_enricher import _TimestampMetadataEnricher
 from quickapp.timestamp_tooling._tool_configs import (
     CURRENT_TIMESTAMP_TOOL_NAME,
     SYNTHETIC_TIMESTAMP_CALL_PREFIX,
 )
+from tests.unit_tests.common.common import make_provider
 
 
 def _make_config_provider(enabled: bool = True) -> Mock:
@@ -23,10 +27,14 @@ def _make_config_provider(enabled: bool = True) -> Mock:
     return provider
 
 
-def _make_transformer(enabled: bool = True) -> _TimestampInjectionTransformer:
+def _make_transformer(
+    enabled: bool = True,
+    enrichers: list[ToolCallResultEnricher] | None = None,
+) -> _TimestampInjectionTransformer:
     return _TimestampInjectionTransformer(
         time_provider=TimeProvider(),
         config_provider=_make_config_provider(enabled),
+        enrichers_provider=make_provider(enrichers if enrichers is not None else []),
     )
 
 
@@ -98,3 +106,26 @@ class TestTimestampInjectionTransformer:
         result = await transformer.transform(messages)
 
         assert result is messages
+
+    @pytest.mark.asyncio
+    async def test_synthetic_tool_message_carries_enriched_metadata(self):
+        transformer = _make_transformer(
+            enrichers=[_TimestampMetadataEnricher(TimeProvider())],
+        )
+        result = await transformer.transform([Message(role=Role.USER, content="hi")])
+
+        tool_msg = result[2]
+        assert tool_msg.custom_content is not None
+        metadata = get_metadata_from_state(tool_msg.custom_content.state)
+        assert metadata is not None
+        assert metadata.timestamp is not None
+        assert metadata.timestamp.response_timestamp is not None
+        assert metadata.timestamp.timezone_name == "UTC"
+
+    @pytest.mark.asyncio
+    async def test_synthetic_tool_message_has_no_state_without_enrichers(self):
+        transformer = _make_transformer()
+        result = await transformer.transform([Message(role=Role.USER, content="hi")])
+
+        tool_msg = result[2]
+        assert tool_msg.custom_content is None


### PR DESCRIPTION
### Applicable issues

- fixes #296

### Description of changes

Synthetic tool messages produced by `SyntheticToolCallInjector` bypassed `ToolExecutor` and so received no `ToolCallResultEnricher` pass — synthetic responses had no `_message_metadata` (e.g. timestamp) on their `custom_content.state`.

They now flow through the same enricher pipeline as real tool results: the base injector resolves enrichers lazily via `ProviderOf[list[ToolCallResultEnricher]]` (so it can still be constructed during `_RequestContextSetup`, before `ApplicationConfig` is set), runs them against a transient `ToolCallResult` inside `transform()`, and threads the resulting state into the synthetic TOOL message.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.