### PR TITLE
feat: prefetch orchestrator deployment capabilities #303

### DIFF
--- a/src/quickapp/agent/_orchestrator_deployment_initializer.py
+++ b/src/quickapp/agent/_orchestrator_deployment_initializer.py
@@ -1,0 +1,58 @@
+"""Prefetch orchestrator deployment metadata for each chat completion."""
+
+import logging
+
+from injector import inject
+
+from quickapp.agent.orchestrator_capabilities import OrchestratorCapabilities
+from quickapp.agent.orchestrator_deployment_cache_service import OrchestratorDeploymentCacheService
+from quickapp.common.base_initializer import CompletionInitializer
+from quickapp.config.application import ApplicationConfig
+from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
+
+logger = logging.getLogger(__name__)
+
+
+@inject
+class _OrchestratorDeploymentInitializer(CompletionInitializer):
+    def __init__(
+        self,
+        app_config: ApplicationConfig,
+        tool_config_service: ToolConfigCoreService,
+        orchestrator_deployment_cache: OrchestratorDeploymentCacheService,
+    ) -> None:
+        self.__app_config: ApplicationConfig = app_config
+        self.__tool_config_service: ToolConfigCoreService = tool_config_service
+        self.__orchestrator_deployment_cache: OrchestratorDeploymentCacheService = (
+            orchestrator_deployment_cache
+        )
+        self._capabilities: OrchestratorCapabilities | None = None
+
+    async def initialize(self) -> None:
+        deployment = self.__app_config.orchestrator.deployment.deployment_id
+        cache_key = f"orchestrator_deployment_{deployment}"
+
+        model = await self.__orchestrator_deployment_cache.get(
+            cache_key,
+            self.__tool_config_service.get_deployment_metadata,
+            deployment,
+        )
+        if model is None:
+            raise RuntimeError(
+                f"Orchestrator deployment cache returned no model for '{deployment}'"
+            )
+        self._capabilities = OrchestratorCapabilities(deployment=model)
+        logger.debug(
+            "Orchestrator deployment capabilities loaded id=%s input_attachment_types=%s",
+            self._capabilities.deployment_id,
+            self._capabilities.input_attachment_types,
+        )
+
+    @property
+    def capabilities(self) -> OrchestratorCapabilities:
+        if self._capabilities is None:
+            raise RuntimeError(
+                "OrchestratorCapabilities accessed before "
+                "_OrchestratorDeploymentInitializer.initialize() ran"
+            )
+        return self._capabilities

--- a/src/quickapp/agent/_orchestrator_deployment_initializer.py
+++ b/src/quickapp/agent/_orchestrator_deployment_initializer.py
@@ -1,7 +1,5 @@
 """Prefetch orchestrator deployment metadata for each chat completion."""
 
-import logging
-
 from injector import inject
 
 from quickapp.agent.orchestrator_capabilities import OrchestratorCapabilities
@@ -9,8 +7,6 @@ from quickapp.agent.orchestrator_deployment_cache_service import OrchestratorDep
 from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.config.application import ApplicationConfig
 from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
-
-logger = logging.getLogger(__name__)
 
 
 @inject
@@ -30,23 +26,11 @@ class _OrchestratorDeploymentInitializer(CompletionInitializer):
 
     async def initialize(self) -> None:
         deployment = self.__app_config.orchestrator.deployment.deployment_id
-        cache_key = f"orchestrator_deployment_{deployment}"
-
-        model = await self.__orchestrator_deployment_cache.get(
-            cache_key,
+        model = await self.__orchestrator_deployment_cache.fetch_metadata(
             self.__tool_config_service.get_deployment_metadata,
             deployment,
         )
-        if model is None:
-            raise RuntimeError(
-                f"Orchestrator deployment cache returned no model for '{deployment}'"
-            )
         self._capabilities = OrchestratorCapabilities(deployment=model)
-        logger.debug(
-            "Orchestrator deployment capabilities loaded id=%s input_attachment_types=%s",
-            self._capabilities.deployment_id,
-            self._capabilities.input_attachment_types,
-        )
 
     @property
     def capabilities(self) -> OrchestratorCapabilities:

--- a/src/quickapp/agent/agent_module.py
+++ b/src/quickapp/agent/agent_module.py
@@ -1,16 +1,19 @@
 import copy
 
 from fastapi_injector import request_scope
-from injector import Binder, Module, NoScope, multiprovider, provider, singleton
+from injector import Binder, Module, NoScope, ProviderOf, multiprovider, provider, singleton
 from openai.lib.azure import AsyncAzureOpenAI
 
 from quickapp.agent._attachment_filter import _AttachmentFilter
 from quickapp.agent._messages_transformers import _AddSystemPromptTransformer
+from quickapp.agent._orchestrator_deployment_initializer import _OrchestratorDeploymentInitializer
 from quickapp.agent._prompt_providers import ConfigBasedPromptProvider
 from quickapp.agent.agent_settings import AgentSettings
 from quickapp.agent.assistant_invoker import AssistantInvoker
 from quickapp.agent.models import OpenAiToolConfigDict
 from quickapp.agent.orchestrator import Orchestrator
+from quickapp.agent.orchestrator_capabilities import OrchestratorCapabilities
+from quickapp.agent.orchestrator_deployment_cache_service import OrchestratorDeploymentCacheService
 from quickapp.common import (
     DIAL_API_KEY,
     DIAL_BEARER,
@@ -21,6 +24,7 @@ from quickapp.common import (
 from quickapp.common.abstract.base_prompt_provider import PromptPartProvider
 from quickapp.common.abstract.base_transformer import MessagesTransformer, PreInvocationTransformer
 from quickapp.common.abstract.tool_call_result_enricher import ToolCallResultEnricher
+from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.chat_completion_stream.handler import ChatCompletionStreamHandler
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.state_holder import StateHolder
@@ -69,6 +73,28 @@ class AgentModule(Module):
         )
         binder.bind(AgentSettings, to=AgentSettings, scope=singleton)
         binder.bind(ConfigBasedPromptProvider, to=ConfigBasedPromptProvider, scope=request_scope)
+        binder.bind(
+            OrchestratorDeploymentCacheService,
+            to=OrchestratorDeploymentCacheService,
+            scope=singleton,
+        )
+        binder.bind(
+            _OrchestratorDeploymentInitializer,
+            to=_OrchestratorDeploymentInitializer,
+            scope=request_scope,
+        )
+
+    @multiprovider
+    def _provide_completion_initializers(
+        self, initializer_provider: ProviderOf[_OrchestratorDeploymentInitializer]
+    ) -> list[CompletionInitializer]:
+        return [initializer_provider.get()]
+
+    @provider
+    def provide_orchestrator_capabilities(
+        self, initializer: _OrchestratorDeploymentInitializer
+    ) -> OrchestratorCapabilities:
+        return initializer.capabilities
 
     @provider
     def provide_openai_client(

--- a/src/quickapp/agent/orchestrator_capabilities.py
+++ b/src/quickapp/agent/orchestrator_capabilities.py
@@ -7,11 +7,9 @@ from quickapp.common.utils import matches_type
 class OrchestratorCapabilities:
     """Request-scoped DialCore metadata for the orchestrator deployment.
 
-    Constructed with a populated :class:`Deployment` or :class:`Application`;
-    production instances are built by
-    :class:`quickapp.agent._OrchestratorDeploymentInitializer` once per chat
-    completion and exposed via the ``provide_orchestrator_capabilities`` DI
-    provider in :class:`AgentModule`.
+    Wraps a populated :class:`Deployment` or :class:`Application`; production
+    instances are built once per chat completion and exposed via DI from
+    :class:`AgentModule`.
     """
 
     def __init__(self, deployment: Deployment | Application) -> None:

--- a/src/quickapp/agent/orchestrator_capabilities.py
+++ b/src/quickapp/agent/orchestrator_capabilities.py
@@ -1,0 +1,30 @@
+from aidial_client.types.application import Application
+from aidial_client.types.deployment import Deployment
+
+from quickapp.common.utils import matches_type
+
+
+class OrchestratorCapabilities:
+    """Request-scoped DialCore metadata for the orchestrator deployment.
+
+    Constructed with a populated :class:`Deployment` or :class:`Application`;
+    production instances are built by
+    :class:`quickapp.agent._OrchestratorDeploymentInitializer` once per chat
+    completion and exposed via the ``provide_orchestrator_capabilities`` DI
+    provider in :class:`AgentModule`.
+    """
+
+    def __init__(self, deployment: Deployment | Application) -> None:
+        self._deployment: Deployment | Application = deployment
+
+    @property
+    def deployment_id(self) -> str:
+        return self._deployment.id
+
+    @property
+    def input_attachment_types(self) -> list[str] | None:
+        return self._deployment.input_attachment_types
+
+    def orchestrator_accepts_mime_type(self, mime_type: str | None) -> bool:
+        """Whether the orchestrator deployment accepts ``mime_type`` (DialCore patterns)."""
+        return matches_type(mime_type, self.input_attachment_types)

--- a/src/quickapp/agent/orchestrator_deployment_cache_service.py
+++ b/src/quickapp/agent/orchestrator_deployment_cache_service.py
@@ -1,0 +1,13 @@
+from aidial_client.types.application import Application
+from aidial_client.types.deployment import Deployment
+
+from quickapp.common.cache import CacheService
+
+
+class OrchestratorDeploymentCacheService(CacheService[Deployment | Application]):
+    """Cache for orchestrator deployment metadata.
+
+    Held separately from :class:`DialDeploymentToolCacheService` so that orchestrator
+    capability lookups can evict independently of deployment-tool config caching, and
+    so neither path can starve the other on TTL renewal.
+    """

--- a/src/quickapp/agent/orchestrator_deployment_cache_service.py
+++ b/src/quickapp/agent/orchestrator_deployment_cache_service.py
@@ -1,7 +1,12 @@
+from collections.abc import Awaitable, Callable
+
 from aidial_client.types.application import Application
 from aidial_client.types.deployment import Deployment
 
 from quickapp.common.cache import CacheService
+from quickapp.common.exceptions import OrchestratorInitializationException
+
+_ORCHESTRATOR_DEPLOYMENT_CACHE_KEY_PREFIX = "orchestrator_deployment_"
 
 
 class OrchestratorDeploymentCacheService(CacheService[Deployment | Application]):
@@ -11,3 +16,20 @@ class OrchestratorDeploymentCacheService(CacheService[Deployment | Application])
     capability lookups can evict independently of deployment-tool config caching, and
     so neither path can starve the other on TTL renewal.
     """
+
+    async def fetch_metadata(
+        self,
+        loader: Callable[[str], Awaitable[Deployment | Application | None]],
+        deployment_id: str,
+    ) -> Deployment | Application:
+        model = await self.get(
+            f"{_ORCHESTRATOR_DEPLOYMENT_CACHE_KEY_PREFIX}{deployment_id}",
+            loader,
+            deployment_id,
+        )
+        if model is None:
+            raise OrchestratorInitializationException(
+                message="No deployment metadata returned",
+                deployment_id=deployment_id,
+            )
+        return model

--- a/src/quickapp/application/_exception_message_resolver.py
+++ b/src/quickapp/application/_exception_message_resolver.py
@@ -4,7 +4,10 @@ from aidial_sdk.exceptions import ContextLengthExceededError, DeploymentNotFound
 from aidial_sdk.exceptions import HTTPException as AiDialHTTPException
 from aidial_sdk.exceptions import InvalidRequestError, RequestValidationError, ResourceNotFoundError
 
-from quickapp.common.exceptions import OrchestratorExceedMaxIterationsException
+from quickapp.common.exceptions import (
+    OrchestratorExceedMaxIterationsException,
+    OrchestratorInitializationException,
+)
 from quickapp.dial_core_services.exceptions import (
     ToolsetForbiddenException,
     ToolsetNotFoundException,
@@ -137,6 +140,8 @@ def _resolve_aidial_error(e: AiDialHTTPException) -> str:
 def _resolve_internal_error(e: Exception) -> str:
     if isinstance(e, OrchestratorExceedMaxIterationsException):
         return str(e)
+    if isinstance(e, OrchestratorInitializationException):
+        return _MSG_AI_MODEL_NOT_FOUND
     if isinstance(e, ToolsetNotFoundException):
         return "A required toolset could not be found. Please contact your administrator."
     if isinstance(e, ToolsetForbiddenException):

--- a/src/quickapp/attachment_processing/_context_entries.py
+++ b/src/quickapp/attachment_processing/_context_entries.py
@@ -6,6 +6,7 @@ from aidial_sdk.chat_completion import Message, Role
 from pydantic import BaseModel, Field, ValidationError
 
 from quickapp.attachment_processing._tool_configs import AVAILABLE_CONTEXT_TOOL_NAME
+from quickapp.common.utils import posix_path_last_segment
 from quickapp.config.context import Context, FileContextConfig
 
 
@@ -52,7 +53,7 @@ def build_context_entries(
         if url in current_urls:
             continue
         current_urls.add(url)
-        title = url.rsplit("/", 1)[-1]
+        title = posix_path_last_segment(url)
         mime_type = mimetypes.guess_type(title)[0] or ""
         if url not in seen_entries:
             status = ContextEntryStatus.new

--- a/src/quickapp/attachment_processing/_tool_configs.py
+++ b/src/quickapp/attachment_processing/_tool_configs.py
@@ -1,3 +1,4 @@
+from quickapp.common.tool_names import INTERNAL_ATTACHMENTS_AVAILABLE_CONTEXT_TOOL_NAME
 from quickapp.config.tools.base import (
     JsonTypeEnum,
     OpenAiToolConfig,
@@ -10,7 +11,7 @@ from quickapp.config.tools.internal import InternalTool
 AVAILABLE_CONTEXT_TOOL_CONFIG = InternalTool(
     open_ai_tool=OpenAiToolConfig(
         function=OpenAiToolFunction(
-            name="internal_attachments_available_context",
+            name=INTERNAL_ATTACHMENTS_AVAILABLE_CONTEXT_TOOL_NAME,
             description=(
                 "Returns metadata about admin-configured context files."
                 " **IMPORTANT**: this tool is not applicable to user-attached files or files from tool results, "
@@ -27,4 +28,4 @@ AVAILABLE_CONTEXT_TOOL_CONFIG = InternalTool(
 )
 
 # Tool name as sent to the LLM (sanitized, no hash)
-AVAILABLE_CONTEXT_TOOL_NAME = AVAILABLE_CONTEXT_TOOL_CONFIG.open_ai_tool.function.name
+AVAILABLE_CONTEXT_TOOL_NAME = INTERNAL_ATTACHMENTS_AVAILABLE_CONTEXT_TOOL_NAME

--- a/src/quickapp/common/chat_completion_stream/driver.py
+++ b/src/quickapp/common/chat_completion_stream/driver.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from collections.abc import AsyncIterable, AsyncIterator, Callable
 from typing import TypeAlias, TypeVar
 

--- a/src/quickapp/common/chat_completion_stream/exceptions.py
+++ b/src/quickapp/common/chat_completion_stream/exceptions.py
@@ -1,6 +1,3 @@
-from __future__ import annotations
-
-
 class ChatStreamHandlerError(Exception):
     """Base class for chat stream handler failures."""
 

--- a/src/quickapp/common/chat_completion_stream/handler.py
+++ b/src/quickapp/common/chat_completion_stream/handler.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import logging
 from collections.abc import AsyncIterable
 

--- a/src/quickapp/common/chat_completion_stream/models.py
+++ b/src/quickapp/common/chat_completion_stream/models.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from typing import Any
 
 from aidial_sdk.chat_completion import Attachment

--- a/src/quickapp/common/chat_completion_stream/stream_result.py
+++ b/src/quickapp/common/chat_completion_stream/stream_result.py
@@ -1,7 +1,5 @@
 """Mutable accumulator for OpenAI-style chat completion streams (orchestrator + deployment)."""
 
-from __future__ import annotations
-
 import logging
 from typing import Any
 

--- a/src/quickapp/common/chat_completion_stream/tool_call.py
+++ b/src/quickapp/common/chat_completion_stream/tool_call.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from aidial_sdk.chat_completion import FunctionCall, ToolCall
 from openai.types.chat.chat_completion_chunk import ChoiceDeltaToolCall
 

--- a/src/quickapp/common/exceptions/__init__.py
+++ b/src/quickapp/common/exceptions/__init__.py
@@ -2,6 +2,7 @@ from .config_resolution import ConfigResolutionException
 from .initialization import InitializationException
 from .invalid_tool_call_parameter import InvalidToolCallParameterException
 from .orchestrator_exceed_max_iterations import OrchestratorExceedMaxIterationsException
+from .orchestrator_initialization import OrchestratorInitializationException
 from .skill_initialization import (
     SkillCatastrophicInitializationException,
     SkillInitializationException,
@@ -15,6 +16,7 @@ __all__ = [
     "InitializationException",
     "InvalidToolCallParameterException",
     "OrchestratorExceedMaxIterationsException",
+    "OrchestratorInitializationException",
     "SkillCatastrophicInitializationException",
     "SkillInitializationException",
     "ToolInitializationException",

--- a/src/quickapp/common/exceptions/orchestrator_initialization.py
+++ b/src/quickapp/common/exceptions/orchestrator_initialization.py
@@ -1,0 +1,19 @@
+from typing import ClassVar
+
+from .initialization import InitializationException
+
+
+class OrchestratorInitializationException(InitializationException):
+    """Raised when the orchestrator deployment (the application's primary LLM)
+    cannot be initialized — typically because its DIAL Core metadata is missing
+    or unreachable. Hard: the request cannot proceed without an orchestrator.
+    """
+
+    is_hard: ClassVar[bool] = True
+
+    def __init__(self, message: str, deployment_id: str):
+        super().__init__(
+            f"Orchestrator initialization error: {message} (deployment_id={deployment_id})"
+        )
+        self.message = message
+        self.deployment_id = deployment_id

--- a/src/quickapp/common/tool_names.py
+++ b/src/quickapp/common/tool_names.py
@@ -4,14 +4,7 @@ Kept free of heavy imports so it can be cited from identity checks anywhere in t
 without pulling in DI or config.
 """
 
-# Attachment processing
 INTERNAL_ATTACHMENTS_AVAILABLE_CONTEXT_TOOL_NAME = "internal_attachments_available_context"
-
-# Skills
 INTERNAL_SKILLS_READ_SKILL_TOOL_NAME = "internal_skills_read_skill"
-
-# Timestamp
 INTERNAL_TIMEAWARENESS_CURRENT_TIMESTAMP_TOOL_NAME = "internal_timeawareness_current_timestamp"
-
-# Python code interpreter (internal tooling)
 INTERNAL_CODE_EXECUTION_PYTHON_INTERPRETER_TOOL_NAME = "internal_code_execution_python_interpreter"

--- a/src/quickapp/common/tool_names.py
+++ b/src/quickapp/common/tool_names.py
@@ -1,0 +1,17 @@
+"""Canonical OpenAI function names for internal QuickApp tools (sent to the LLM).
+
+Kept free of heavy imports so it can be cited from identity checks anywhere in the tree
+without pulling in DI or config.
+"""
+
+# Attachment processing
+INTERNAL_ATTACHMENTS_AVAILABLE_CONTEXT_TOOL_NAME = "internal_attachments_available_context"
+
+# Skills
+INTERNAL_SKILLS_READ_SKILL_TOOL_NAME = "internal_skills_read_skill"
+
+# Timestamp
+INTERNAL_TIMEAWARENESS_CURRENT_TIMESTAMP_TOOL_NAME = "internal_timeawareness_current_timestamp"
+
+# Python code interpreter (internal tooling)
+INTERNAL_CODE_EXECUTION_PYTHON_INTERPRETER_TOOL_NAME = "internal_code_execution_python_interpreter"

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -2,6 +2,7 @@ import logging
 import mimetypes
 import re
 from datetime import datetime
+from pathlib import PurePosixPath
 from typing import Any
 
 from quickapp.config.tools.const import ALL_MIME_TYPES
@@ -30,6 +31,19 @@ def matches_type(mime_type: str | None, allowed_mime_types: list[str] | None) ->
         elif mime_type == mt:
             return True
     return False
+
+
+def posix_path_last_segment(path: str) -> str:
+    """Return the final segment of a POSIX-style path (``/`` separators only).
+
+    For DIAL ``files/...`` URLs and similar strings; uses :class:`pathlib.PurePosixPath`
+    instead of :func:`os.path.basename` so behavior does not depend on OS path rules.
+    Trailing slashes are normalized away by ``pathlib`` (e.g. ``files/bucket/`` →
+    segment ``bucket``). If ``.name`` is empty, returns the stripped path as a fallback.
+    """
+    stripped = path.strip()
+    name = PurePosixPath(stripped).name
+    return name if name else stripped
 
 
 def substitute_media_type(

--- a/src/quickapp/internal_tooling/internal_tooling_module.py
+++ b/src/quickapp/internal_tooling/internal_tooling_module.py
@@ -5,6 +5,7 @@ from injector import AssistedBuilder, Binder, Module, multiprovider, provider, s
 
 from quickapp.common import DIAL_API_KEY, StagedBaseTool
 from quickapp.common.dial_settings import DialSettings
+from quickapp.common.tool_names import INTERNAL_CODE_EXECUTION_PYTHON_INTERPRETER_TOOL_NAME
 from quickapp.common.tool_timeout_resolver import ToolTimeoutResolver
 from quickapp.config.application import ApplicationConfig
 from quickapp.config.tools.predefined import PredefinedTool
@@ -50,7 +51,7 @@ class InternalToolModule(Module):
                                 "Predefined tool wasn't substituted by real tool. Check application settings."
                             )
                         elif tool_config.open_ai_tool.function.name.startswith(
-                            'internal_code_execution_python_interpreter'
+                            INTERNAL_CODE_EXECUTION_PYTHON_INTERPRETER_TOOL_NAME
                         ):
                             # TODO: remove this filtering by name, the user may configure any name of the tool.
                             tools.append(

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_exceptions.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_exceptions.py
@@ -1,6 +1,7 @@
 from quickapp.common.exceptions import ToolTimeoutError
-
-_PY_INTERPRETER_TOOL_NAME = "internal_code_execution_python_interpreter"
+from quickapp.common.tool_names import (
+    INTERNAL_CODE_EXECUTION_PYTHON_INTERPRETER_TOOL_NAME as _PY_INTERPRETER_TOOL_NAME,
+)
 
 
 class _PyInterpreterError(Exception):

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/_py_interpreter_tool.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/_py_interpreter_tool.py
@@ -1,5 +1,4 @@
 import logging
-import os
 from typing import Any
 from urllib.parse import unquote
 
@@ -14,6 +13,7 @@ from quickapp.common.media_types import MediaTypes
 from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.tool_timeout_resolver import ToolTimeoutResolver
+from quickapp.common.utils import posix_path_last_segment
 from quickapp.config.tools.internal import InternalTool
 from quickapp.internal_tooling.py_interpreter_tooling._exceptions import _PyInterpreterError
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_client import (
@@ -173,7 +173,7 @@ class _PyInterpreterTool(StagedBaseTool):
 
         # Transfer each required file that's not already loaded
         for file_name in attachment_urls:
-            target_path = unquote(os.path.basename(file_name))
+            target_path = unquote(posix_path_last_segment(file_name))
 
             if target_path in loaded_file_names:
                 continue
@@ -210,7 +210,7 @@ class _PyInterpreterTool(StagedBaseTool):
             if not matched:
                 logger.warning("No matching attachment found for: %s", file_name)
                 errors.append(
-                    f"{unquote(os.path.basename(file_name))}: "
+                    f"{unquote(posix_path_last_segment(file_name))}: "
                     f"no matching attachment found in conversation"
                 )
 

--- a/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/input_file_handler.py
+++ b/src/quickapp/internal_tooling/py_interpreter_tooling/handlers/input_file_handler.py
@@ -1,4 +1,3 @@
-import os
 from io import BytesIO
 
 from aidial_client import AsyncDial
@@ -6,6 +5,7 @@ from aidial_sdk.chat_completion import Attachment
 
 from quickapp.common import DIAL_API_KEY
 from quickapp.common.tool_timeout_utils import build_async_dial_timeout
+from quickapp.common.utils import posix_path_last_segment
 from quickapp.internal_tooling.py_interpreter_tooling._py_interpreter_settings import (
     _PyInterpreterSettings,
 )
@@ -40,7 +40,7 @@ class InputFileHandler:
             )
             bucket_resp = await dev_dial.bucket.get_raw()
             bucket = bucket_resp.appdata or bucket_resp.bucket
-            filename = os.path.basename(attachment_url)
+            filename = posix_path_last_segment(attachment_url)
             metadata = await dev_dial.files.upload(
                 f"files/{bucket}/{filename}",
                 (filename, BytesIO(file_content), attachment.type),

--- a/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
+++ b/src/quickapp/mcp_tooling/_mcp_tool_initializer.py
@@ -13,7 +13,7 @@ from quickapp.common.base_initializer import CompletionInitializer
 from quickapp.common.dial_settings import DialSettings
 from quickapp.common.exceptions import ToolInitializationException
 from quickapp.common.json_schema_converter import JsonSchemaConverter
-from quickapp.common.utils import sanitize_toolname
+from quickapp.common.utils import posix_path_last_segment, sanitize_toolname
 from quickapp.config.tools.base import (
     JsonTypeEnum,
     OpenAiToolConfig,
@@ -45,8 +45,7 @@ def _human_readable_dial_id(dial_id: str) -> str:
     E.g. 'toolsets/684f6.../TestMCP__0.0.1' or 'toolsets/TestMCP__0.0.1' -> 'TestMCP__0.0.1'.
     URL-decodes the result to convert %20 to spaces and other encoded characters.
     """
-    last_part = dial_id.split("/")[-1] if "/" in dial_id else dial_id
-    return unquote(last_part)
+    return unquote(posix_path_last_segment(dial_id))
 
 
 def _flatten_exceptions(exc: BaseException) -> list[BaseException]:

--- a/src/quickapp/skills/_tool_configs.py
+++ b/src/quickapp/skills/_tool_configs.py
@@ -1,3 +1,4 @@
+from quickapp.common.tool_names import INTERNAL_SKILLS_READ_SKILL_TOOL_NAME
 from quickapp.config.tools.base import (
     ConfigurableSchemaSimpleType,
     JsonTypeEnum,
@@ -12,8 +13,6 @@ from quickapp.config.tools.display.paramenter import (
 from quickapp.config.tools.display.tool import ToolDisplayConfig, ToolStageConfig
 from quickapp.config.tools.internal import InternalTool
 
-SKILL_READER_TOOL_NAME_PREFIX = "internal_skills_read_skill"
-
 SKILL_READER_TOOL_CONFIG = InternalTool(
     enabled=True,
     display=ToolDisplayConfig(
@@ -25,7 +24,7 @@ SKILL_READER_TOOL_CONFIG = InternalTool(
     open_ai_tool=OpenAiToolConfig(
         type="function",
         function=OpenAiToolFunction(
-            name=SKILL_READER_TOOL_NAME_PREFIX,
+            name=INTERNAL_SKILLS_READ_SKILL_TOOL_NAME,
             description="Read the full content of an agent skill. Use this tool when you need to get detailed instructions about a specific skill that is available to you.",
             parameters=OpenAiToolFunctionParameters(
                 type=JsonTypeEnum.object,
@@ -47,4 +46,4 @@ SKILL_READER_TOOL_CONFIG = InternalTool(
     ),
 )
 
-SKILL_READER_TOOL_NAME = SKILL_READER_TOOL_CONFIG.open_ai_tool.function.name
+SKILL_READER_TOOL_NAME = INTERNAL_SKILLS_READ_SKILL_TOOL_NAME

--- a/src/quickapp/timestamp_tooling/_tool_configs.py
+++ b/src/quickapp/timestamp_tooling/_tool_configs.py
@@ -1,3 +1,4 @@
+from quickapp.common.tool_names import INTERNAL_TIMEAWARENESS_CURRENT_TIMESTAMP_TOOL_NAME
 from quickapp.config.tools.base import (
     ConfigurableSchemaSimpleType,
     JsonTypeEnum,
@@ -13,7 +14,7 @@ SYNTHETIC_TIMESTAMP_CALL_PREFIX = "call_synthetic_timestamp_"
 CURRENT_TIMESTAMP_TOOL_CONFIG = InternalTool(
     open_ai_tool=OpenAiToolConfig(
         function=OpenAiToolFunction(
-            name="internal_timeawareness_current_timestamp",
+            name=INTERNAL_TIMEAWARENESS_CURRENT_TIMESTAMP_TOOL_NAME,
             description="Returns the current date and time. Optionally converts to a specific timezone.",
             parameters=OpenAiToolFunctionParameters(
                 type=JsonTypeEnum.object,
@@ -30,4 +31,4 @@ CURRENT_TIMESTAMP_TOOL_CONFIG = InternalTool(
 )
 
 # Tool name as sent to the LLM (sanitized, no hash)
-CURRENT_TIMESTAMP_TOOL_NAME = CURRENT_TIMESTAMP_TOOL_CONFIG.open_ai_tool.function.name
+CURRENT_TIMESTAMP_TOOL_NAME = INTERNAL_TIMEAWARENESS_CURRENT_TIMESTAMP_TOOL_NAME

--- a/src/tests/unit_tests/agent_tests/test_orchestrator_capabilities.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator_capabilities.py
@@ -29,9 +29,7 @@ def test_deployment_id_and_input_attachment_types_exposed():
     [
         ("application/pdf", True),
         ("image/png", True),
-        ("image/jpeg", True),
         ("text/csv", False),
-        ("application/zip", False),
     ],
 )
 def test_orchestrator_accepts_mime_type_matches_input_attachment_types(mime: str, expected: bool):

--- a/src/tests/unit_tests/agent_tests/test_orchestrator_capabilities.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator_capabilities.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import pytest
+
+from quickapp.agent.orchestrator_capabilities import OrchestratorCapabilities
+
+
+def _deployment(
+    deployment_id: str = "gpt-4",
+    input_attachment_types: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(id=deployment_id, input_attachment_types=input_attachment_types)
+
+
+def test_deployment_id_and_input_attachment_types_exposed():
+    caps = OrchestratorCapabilities(
+        deployment=_deployment(  # type: ignore[arg-type]
+            deployment_id="gpt-4",
+            input_attachment_types=["application/pdf", "image/*"],
+        )
+    )
+
+    assert caps.deployment_id == "gpt-4"
+    assert caps.input_attachment_types == ["application/pdf", "image/*"]
+
+
+@pytest.mark.parametrize(
+    "mime, expected",
+    [
+        ("application/pdf", True),
+        ("image/png", True),
+        ("image/jpeg", True),
+        ("text/csv", False),
+        ("application/zip", False),
+    ],
+)
+def test_orchestrator_accepts_mime_type_matches_input_attachment_types(mime: str, expected: bool):
+    caps = OrchestratorCapabilities(
+        deployment=_deployment(  # type: ignore[arg-type]
+            input_attachment_types=["application/pdf", "image/*"],
+        )
+    )
+
+    assert caps.orchestrator_accepts_mime_type(mime) is expected
+
+
+def test_orchestrator_accepts_mime_type_returns_false_when_input_attachment_types_is_none():
+    caps = OrchestratorCapabilities(
+        deployment=_deployment(input_attachment_types=None),  # type: ignore[arg-type]
+    )
+
+    assert caps.orchestrator_accepts_mime_type("application/pdf") is False
+    assert caps.orchestrator_accepts_mime_type("image/png") is False

--- a/src/tests/unit_tests/agent_tests/test_orchestrator_deployment_initializer.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator_deployment_initializer.py
@@ -5,12 +5,7 @@ import pytest
 
 from quickapp.agent._orchestrator_deployment_initializer import _OrchestratorDeploymentInitializer
 from quickapp.agent.orchestrator_capabilities import OrchestratorCapabilities
-
-
-def _make_app_config(deployment_id: str = "gpt-4") -> MagicMock:
-    app_config = MagicMock()
-    app_config.orchestrator.deployment.deployment_id = deployment_id
-    return app_config
+from quickapp.common.exceptions import OrchestratorInitializationException
 
 
 def _make_deployment(
@@ -21,21 +16,26 @@ def _make_deployment(
 
 
 def _make_initializer(
+    *,
     deployment_id: str = "gpt-4",
-    cache_return_value: object = None,
+    fetch_metadata: AsyncMock | None = None,
 ) -> tuple[_OrchestratorDeploymentInitializer, AsyncMock, AsyncMock]:
+    app_config = MagicMock()
+    app_config.orchestrator.deployment.deployment_id = deployment_id
+
+    resolver = AsyncMock()
     tool_config_service = MagicMock()
-    tool_config_service.get_deployment_metadata = AsyncMock()
+    tool_config_service.get_deployment_metadata = resolver
 
     cache = MagicMock()
-    cache.get = AsyncMock(return_value=cache_return_value)
+    cache.fetch_metadata = fetch_metadata or AsyncMock()
 
     initializer = _OrchestratorDeploymentInitializer(
-        app_config=_make_app_config(deployment_id),
+        app_config=app_config,
         tool_config_service=tool_config_service,
         orchestrator_deployment_cache=cache,
     )
-    return initializer, tool_config_service.get_deployment_metadata, cache.get
+    return initializer, resolver, cache.fetch_metadata
 
 
 @pytest.mark.asyncio
@@ -44,8 +44,8 @@ async def test_initialize_populates_capabilities_from_cache():
         deployment_id="gpt-4",
         input_attachment_types=["application/pdf"],
     )
-    initializer, _resolver, _cache_get = _make_initializer(
-        deployment_id="gpt-4", cache_return_value=deployment
+    initializer, _resolver, _fetch_metadata = _make_initializer(
+        fetch_metadata=AsyncMock(return_value=deployment),
     )
 
     await initializer.initialize()
@@ -56,31 +56,34 @@ async def test_initialize_populates_capabilities_from_cache():
 
 
 @pytest.mark.asyncio
-async def test_initialize_raises_when_cache_returns_none():
-    initializer, _resolver, _cache_get = _make_initializer(cache_return_value=None)
+async def test_initialize_propagates_orchestrator_initialization_exception_from_cache():
+    initializer, _resolver, _fetch_metadata = _make_initializer(
+        fetch_metadata=AsyncMock(
+            side_effect=OrchestratorInitializationException(
+                message="No deployment metadata", deployment_id="gpt-4"
+            )
+        ),
+    )
 
-    with pytest.raises(RuntimeError, match="returned no model"):
+    with pytest.raises(OrchestratorInitializationException, match="No deployment metadata"):
         await initializer.initialize()
 
 
 def test_capabilities_property_raises_before_initialize():
-    initializer, _resolver, _cache_get = _make_initializer()
+    initializer, _resolver, _fetch_metadata = _make_initializer()
 
     with pytest.raises(RuntimeError, match="accessed before"):
         _ = initializer.capabilities
 
 
 @pytest.mark.asyncio
-async def test_cache_key_and_resolver_passed_to_cache_get():
+async def test_resolver_and_deployment_id_passed_to_fetch_metadata():
     deployment = _make_deployment(deployment_id="my-app")
-    initializer, resolver, cache_get = _make_initializer(
-        deployment_id="my-app", cache_return_value=deployment
+    initializer, resolver, fetch_metadata = _make_initializer(
+        deployment_id="my-app",
+        fetch_metadata=AsyncMock(return_value=deployment),
     )
 
     await initializer.initialize()
 
-    cache_get.assert_awaited_once_with(
-        "orchestrator_deployment_my-app",
-        resolver,
-        "my-app",
-    )
+    fetch_metadata.assert_awaited_once_with(resolver, "my-app")

--- a/src/tests/unit_tests/agent_tests/test_orchestrator_deployment_initializer.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator_deployment_initializer.py
@@ -1,0 +1,86 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from quickapp.agent._orchestrator_deployment_initializer import _OrchestratorDeploymentInitializer
+from quickapp.agent.orchestrator_capabilities import OrchestratorCapabilities
+
+
+def _make_app_config(deployment_id: str = "gpt-4") -> MagicMock:
+    app_config = MagicMock()
+    app_config.orchestrator.deployment.deployment_id = deployment_id
+    return app_config
+
+
+def _make_deployment(
+    deployment_id: str = "gpt-4",
+    input_attachment_types: list[str] | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(id=deployment_id, input_attachment_types=input_attachment_types)
+
+
+def _make_initializer(
+    deployment_id: str = "gpt-4",
+    cache_return_value: object = None,
+) -> tuple[_OrchestratorDeploymentInitializer, AsyncMock, AsyncMock]:
+    tool_config_service = MagicMock()
+    tool_config_service.get_deployment_metadata = AsyncMock()
+
+    cache = MagicMock()
+    cache.get = AsyncMock(return_value=cache_return_value)
+
+    initializer = _OrchestratorDeploymentInitializer(
+        app_config=_make_app_config(deployment_id),
+        tool_config_service=tool_config_service,
+        orchestrator_deployment_cache=cache,
+    )
+    return initializer, tool_config_service.get_deployment_metadata, cache.get
+
+
+@pytest.mark.asyncio
+async def test_initialize_populates_capabilities_from_cache():
+    deployment = _make_deployment(
+        deployment_id="gpt-4",
+        input_attachment_types=["application/pdf"],
+    )
+    initializer, _resolver, _cache_get = _make_initializer(
+        deployment_id="gpt-4", cache_return_value=deployment
+    )
+
+    await initializer.initialize()
+
+    assert isinstance(initializer.capabilities, OrchestratorCapabilities)
+    assert initializer.capabilities.deployment_id == "gpt-4"
+    assert initializer.capabilities.input_attachment_types == ["application/pdf"]
+
+
+@pytest.mark.asyncio
+async def test_initialize_raises_when_cache_returns_none():
+    initializer, _resolver, _cache_get = _make_initializer(cache_return_value=None)
+
+    with pytest.raises(RuntimeError, match="returned no model"):
+        await initializer.initialize()
+
+
+def test_capabilities_property_raises_before_initialize():
+    initializer, _resolver, _cache_get = _make_initializer()
+
+    with pytest.raises(RuntimeError, match="accessed before"):
+        _ = initializer.capabilities
+
+
+@pytest.mark.asyncio
+async def test_cache_key_and_resolver_passed_to_cache_get():
+    deployment = _make_deployment(deployment_id="my-app")
+    initializer, resolver, cache_get = _make_initializer(
+        deployment_id="my-app", cache_return_value=deployment
+    )
+
+    await initializer.initialize()
+
+    cache_get.assert_awaited_once_with(
+        "orchestrator_deployment_my-app",
+        resolver,
+        "my-app",
+    )

--- a/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_tool_config_service.py
@@ -151,6 +151,46 @@ class TestGetBasicToolConfig:
         assert "lang" in result.open_ai_tool.function.parameters.properties
 
 
+class TestGetDeploymentMetadata:
+    @pytest.mark.asyncio
+    async def test_returns_deployment_model(self):
+        dep = _make_deployment_model(deployment_id="gpt-4")
+        dial_client = _make_async_dial(deployment_model=dep)
+        svc = _make_service(dial_client)
+
+        result = await svc.get_deployment_metadata("gpt-4")
+
+        assert result is dep
+        dial_client.deployments.get.assert_awaited_once_with("gpt-4")
+        dial_client.application.get.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_application_on_404(self):
+        app = _make_deployment_model(deployment_id="my-app")
+        dial_client = _make_async_dial(
+            deployments_get_side_effect=_make_dial_exception(404),
+            application_model=app,
+        )
+        svc = _make_service(dial_client)
+
+        result = await svc.get_deployment_metadata("my-app")
+
+        assert result is app
+        dial_client.application.get.assert_awaited_once_with("my-app")
+
+    @pytest.mark.asyncio
+    async def test_non_404_dial_exception_propagates(self):
+        dial_client = _make_async_dial(
+            deployments_get_side_effect=_make_dial_exception(500),
+        )
+        svc = _make_service(dial_client)
+
+        with pytest.raises(DialException):
+            await svc.get_deployment_metadata("broken-dep")
+
+        dial_client.application.get.assert_not_called()
+
+
 class TestGetBasicToolsetConfig:
     @pytest.mark.asyncio
     async def test_returns_toolset_info(self):


### PR DESCRIPTION
### Applicable issues

- fixes #303

### Description of changes

Foundational infrastructure for capability-aware orchestrator features, e.g. #228. No consumer ships here — those follow in subsequent PRs.

**What lands:**
- `OrchestratorCapabilities` — request-scoped holder for the orchestrator deployment's DialCore metadata (`deployment_id`, `input_attachment_types`, `orchestrator_accepts_mime_type`).
- `OrchestratorDeploymentCacheService` — singleton cache, intentionally separate from `DialDeploymentToolCacheService` so neither path can starve the other on TTL renewal.
- `_OrchestratorDeploymentInitializer` — `CompletionInitializer` that prefetches deployment metadata once per chat completion (cache hit on repeats within TTL).
- DI wiring in `AgentModule`.

**Bundled refactors (no behaviour change):**
- `common/tool_names.py` registry for canonical internal-tool function names; existing `*_TOOL_NAME` aliases re-export.
- `common/utils.posix_path_last_segment` replaces `os.path.basename` at three DIAL-URL call sites in the Python interpreter so handling is OS-rule-independent.
- Drops stale `from __future__ import annotations` from `common/chat_completion_stream/*`.
- Locks `ToolConfigCoreService.get_deployment_metadata` contract with unit tests before new consumers land.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Changes are tested on review environment

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
