### PR TITLE
fix: propagate DIAL schema extensions to legacy alias properties #311

### DIFF
--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -789,6 +789,7 @@
         "name": {
           "deprecated": true,
           "description": "DEPRECATED. Legacy alias for `deployment_id`.",
+          "dial:resource": true,
           "type": "string"
         }
       },
@@ -1128,6 +1129,7 @@
         "dial_id": {
           "deprecated": true,
           "description": "DEPRECATED. Legacy alias for `deployment_id`.",
+          "dial:resource": true,
           "type": "string"
         }
       },

--- a/src/quickapp/common/base_config.py
+++ b/src/quickapp/common/base_config.py
@@ -14,6 +14,16 @@ _DIAL_ID_PREFIX = "https://mydial.epam.com/custom_application_schemas/"
 
 _PREVIEW_MARKER = "x-preview"
 
+# Field-level schema keys carried over from a canonical field to its LegacyAlias.
+# DIAL Core's schema-driven tooling (e.g. resource discovery / auto-share) keys
+# off these markers; an alias must mirror them or manifests stored under the
+# legacy key become invisible to those collectors.
+_LEGACY_ALIAS_PROPAGATED_KEYS: tuple[str, ...] = (
+    DialJSONSchemaExtensions.RESOURCE,
+    DialJSONSchemaExtensions.FILE,
+    "format",
+)
+
 
 def _collect_defs_references(schema: Any) -> set[str]:
     """Return the set of $defs keys referenced in *schema*."""
@@ -271,11 +281,16 @@ class LegacyAliasModel(BaseModel):
         required = json_schema.get("required") or []
         any_of = json_schema.setdefault("anyOf", [])
         for canonical, legacy in cls._legacy_alias_pairs:
-            properties[legacy.name] = {
+            canonical_schema = properties.get(canonical, {})
+            alias_schema: dict[str, Any] = {
                 "type": "string",
                 "description": legacy.description or f"DEPRECATED. Legacy alias for `{canonical}`.",
                 "deprecated": True,
             }
+            for key in _LEGACY_ALIAS_PROPAGATED_KEYS:
+                if key in canonical_schema:
+                    alias_schema[key] = canonical_schema[key]
+            properties[legacy.name] = alias_schema
             if canonical in required:
                 required.remove(canonical)
             any_of.extend([{"required": [canonical]}, {"required": [legacy.name]}])

--- a/src/tests/unit_tests/config_tests/test_legacy_aliases.py
+++ b/src/tests/unit_tests/config_tests/test_legacy_aliases.py
@@ -3,15 +3,27 @@ Pin the legacy-alias behavior introduced when `DialDeploymentConfig.name` was
 renamed to `deployment_id` and `DialMCPToolSet.dial_id` was renamed to
 `deployment_id`.
 
-The aliases must keep working at two layers:
+The aliases must keep working at three layers:
 - Pydantic runtime validation (so existing manifests still load).
 - The published JSON schema (so DIAL Core's config validator still accepts
   manifests using the legacy keys).
+- DIAL field-level schema markers (`dial:resource`, `dial:file`, `format`)
+  must mirror onto the alias so schema-driven tooling that keys off those
+  markers (e.g. resource discovery / auto-share) still sees manifests stored
+  under the legacy key.
 """
+
+from typing import Annotated
 
 import pytest
 from pydantic import ValidationError
 
+from quickapp.common.base_config import (
+    DialFileConfigField,
+    DialResourceConfigField,
+    LegacyAlias,
+    LegacyAliasModel,
+)
 from quickapp.common.dial_schema import DialJSONSchemaExtensions
 from quickapp.config.dial_deployment import DialDeploymentConfig
 from quickapp.config.toolsets.dial_mcp import DialMCPToolSet
@@ -39,6 +51,7 @@ class TestDialDeploymentConfigLegacyAlias:
 
         assert "name" in properties
         assert properties["name"].get("deprecated") is True
+        assert properties["name"].get(DialJSONSchemaExtensions.RESOURCE) is True
 
     def test_schema_uses_anyOf_for_required(self):
         schema = DialDeploymentConfig.model_json_schema()
@@ -71,9 +84,48 @@ class TestDialMCPToolSetLegacyAlias:
 
         assert "dial_id" in properties
         assert properties["dial_id"].get("deprecated") is True
+        assert properties["dial_id"].get(DialJSONSchemaExtensions.RESOURCE) is True
 
     def test_schema_uses_anyOf_for_required(self):
         schema = DialMCPToolSet.model_json_schema()
         assert "deployment_id" not in schema.get("required", [])
         assert {"required": ["deployment_id"]} in schema["anyOf"]
         assert {"required": ["dial_id"]} in schema["anyOf"]
+
+
+class TestLegacyAliasModelMarkerPropagation:
+    """Pin the propagation rule directly against `LegacyAliasModel`, independent
+    of any specific production consumer — guards future uses of the helper."""
+
+    def test_file_marker_and_format_propagate_to_alias(self):
+        class _FileModel(LegacyAliasModel):
+            file_url: Annotated[
+                str,
+                DialFileConfigField(description="A DIAL file URL."),
+                LegacyAlias("file"),
+            ]
+
+        schema = _FileModel.model_json_schema()
+        properties = schema["properties"]
+
+        assert properties["file_url"].get(DialJSONSchemaExtensions.FILE) is True
+        assert properties["file_url"].get("format") == "dial-file-encoded"
+
+        assert properties["file"].get("deprecated") is True
+        assert properties["file"].get(DialJSONSchemaExtensions.FILE) is True
+        assert properties["file"].get("format") == "dial-file-encoded"
+
+    def test_resource_marker_propagates_to_alias(self):
+        class _ResourceModel(LegacyAliasModel):
+            deployment_id: Annotated[
+                str,
+                DialResourceConfigField(description="A DIAL resource id."),
+                LegacyAlias("old_name"),
+            ]
+
+        schema = _ResourceModel.model_json_schema()
+        properties = schema["properties"]
+
+        assert properties["deployment_id"].get(DialJSONSchemaExtensions.RESOURCE) is True
+        assert properties["old_name"].get("deprecated") is True
+        assert properties["old_name"].get(DialJSONSchemaExtensions.RESOURCE) is True


### PR DESCRIPTION
### Applicable issues

- fixes #311

### Description of changes

A renamed field's legacy alias was published as a bare deprecated string, dropping the DIAL field-level markers (`dial:resource`, `dial:file`, `format`) the canonical carries. DIAL Core's schema-driven auto-share keys off those markers, so manifests stored under the legacy key validated but their resources were no longer attached to the per-request key — surfacing as `403 Forbidden`.

The alias now mirrors the canonical's DIAL markers, only adding `deprecated: true`. Contained to `LegacyAliasModel`; runtime validation behavior unchanged.

### Checklist

- [X] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
