### PR TITLE
feat: align skill frontmatter parser with Agent Skills spec #313

### DIFF
--- a/src/quickapp/application/_initialization_error_handler.py
+++ b/src/quickapp/application/_initialization_error_handler.py
@@ -62,8 +62,11 @@ class _InitializationErrorHandler:
             elif isinstance(exc, SkillCatastrophicInitializationException):
                 catastrophic_lines.append(f"- {exc.reason}")
             elif isinstance(exc, SkillInitializationException) and exc.url is not None:
-                bucket = per_url_warning_lines if exc.severity == "warning" else per_url_error_lines
-                bucket.append(f"- **{exc.url}**: {exc.reason}")
+                line = f"- **{exc.url}**: {exc.reason}"
+                if exc.severity == "warning":
+                    per_url_warning_lines.append(line)
+                else:
+                    per_url_error_lines.append(line)
             else:
                 logger.warning(
                     "Unhandled InitializationException subclass %s; not rendered to stage",

--- a/src/quickapp/application/_initialization_error_handler.py
+++ b/src/quickapp/application/_initialization_error_handler.py
@@ -8,6 +8,7 @@ from quickapp.common.exceptions import (
     InitializationException,
     SkillCatastrophicInitializationException,
     SkillInitializationException,
+    SkillInitializationWarning,
     ToolInitializationException,
 )
 
@@ -19,6 +20,8 @@ _SKILL_SECTION = "#### Skill loading"
 _CATASTROPHIC_HEADER = (
     "> DIAL prompts as a whole could not be loaded — falling back to predefined skills only."
 )
+_PER_URL_ERRORS_HEADER = "> Errors:"
+_PER_URL_WARNINGS_HEADER = "> Warnings:"
 
 
 @inject
@@ -46,7 +49,8 @@ class _InitializationErrorHandler:
 
         tool_lines: list[str] = []
         catastrophic_lines: list[str] = []
-        per_url_lines: list[str] = []
+        per_url_error_lines: list[str] = []
+        per_url_warning_lines: list[str] = []
         for exc in exceptions:
             if isinstance(exc, ToolInitializationException):
                 tool_lines.append(f"- **{exc.tool_name}{exc.toolset_name}**: {exc}")
@@ -58,8 +62,10 @@ class _InitializationErrorHandler:
                     tool_lines.append(f"```\n{exc.details}\n```")
             elif isinstance(exc, SkillCatastrophicInitializationException):
                 catastrophic_lines.append(f"- {exc.reason}")
+            elif isinstance(exc, SkillInitializationWarning) and exc.url is not None:
+                per_url_warning_lines.append(f"- **{exc.url}**: {exc.reason}")
             elif isinstance(exc, SkillInitializationException) and exc.url is not None:
-                per_url_lines.append(f"- **{exc.url}**: {exc.reason}")
+                per_url_error_lines.append(f"- **{exc.url}**: {exc.reason}")
             else:
                 logger.warning(
                     "Unhandled InitializationException subclass %s; not rendered to stage",
@@ -69,12 +75,17 @@ class _InitializationErrorHandler:
         sections: list[list[str]] = []
         if tool_lines:
             sections.append([_TOOL_SECTION, *tool_lines])
-        if catastrophic_lines or per_url_lines:
+        if catastrophic_lines or per_url_error_lines or per_url_warning_lines:
             skill_section = [_SKILL_SECTION]
             if catastrophic_lines:
                 skill_section.append(_CATASTROPHIC_HEADER)
                 skill_section.extend(catastrophic_lines)
-            skill_section.extend(per_url_lines)
+            if per_url_error_lines:
+                skill_section.append(_PER_URL_ERRORS_HEADER)
+                skill_section.extend(per_url_error_lines)
+            if per_url_warning_lines:
+                skill_section.append(_PER_URL_WARNINGS_HEADER)
+                skill_section.extend(per_url_warning_lines)
             sections.append(skill_section)
 
         status = Status.FAILED if any(exc.is_hard for exc in exceptions) else Status.COMPLETED

--- a/src/quickapp/application/_initialization_error_handler.py
+++ b/src/quickapp/application/_initialization_error_handler.py
@@ -8,7 +8,6 @@ from quickapp.common.exceptions import (
     InitializationException,
     SkillCatastrophicInitializationException,
     SkillInitializationException,
-    SkillInitializationWarning,
     ToolInitializationException,
 )
 
@@ -62,10 +61,9 @@ class _InitializationErrorHandler:
                     tool_lines.append(f"```\n{exc.details}\n```")
             elif isinstance(exc, SkillCatastrophicInitializationException):
                 catastrophic_lines.append(f"- {exc.reason}")
-            elif isinstance(exc, SkillInitializationWarning) and exc.url is not None:
-                per_url_warning_lines.append(f"- **{exc.url}**: {exc.reason}")
             elif isinstance(exc, SkillInitializationException) and exc.url is not None:
-                per_url_error_lines.append(f"- **{exc.url}**: {exc.reason}")
+                bucket = per_url_warning_lines if exc.severity == "warning" else per_url_error_lines
+                bucket.append(f"- **{exc.url}**: {exc.reason}")
             else:
                 logger.warning(
                     "Unhandled InitializationException subclass %s; not rendered to stage",

--- a/src/quickapp/common/exceptions/__init__.py
+++ b/src/quickapp/common/exceptions/__init__.py
@@ -6,7 +6,6 @@ from .orchestrator_initialization import OrchestratorInitializationException
 from .skill_initialization import (
     SkillCatastrophicInitializationException,
     SkillInitializationException,
-    SkillInitializationWarning,
 )
 from .tool_initialization import ToolInitializationException
 from .tool_timeout import TOOL_TIMEOUT_PHRASE, ToolTimeoutError
@@ -20,7 +19,6 @@ __all__ = [
     "OrchestratorInitializationException",
     "SkillCatastrophicInitializationException",
     "SkillInitializationException",
-    "SkillInitializationWarning",
     "ToolInitializationException",
     "ToolTimeoutError",
 ]

--- a/src/quickapp/common/exceptions/__init__.py
+++ b/src/quickapp/common/exceptions/__init__.py
@@ -6,6 +6,7 @@ from .orchestrator_initialization import OrchestratorInitializationException
 from .skill_initialization import (
     SkillCatastrophicInitializationException,
     SkillInitializationException,
+    SkillInitializationWarning,
 )
 from .tool_initialization import ToolInitializationException
 from .tool_timeout import TOOL_TIMEOUT_PHRASE, ToolTimeoutError
@@ -19,6 +20,7 @@ __all__ = [
     "OrchestratorInitializationException",
     "SkillCatastrophicInitializationException",
     "SkillInitializationException",
+    "SkillInitializationWarning",
     "ToolInitializationException",
     "ToolTimeoutError",
 ]

--- a/src/quickapp/common/exceptions/skill_initialization.py
+++ b/src/quickapp/common/exceptions/skill_initialization.py
@@ -26,3 +26,10 @@ class SkillCatastrophicInitializationException(SkillInitializationException):
 
     def __init__(self, reason: str):
         super().__init__(reason, url=None)
+
+
+class SkillInitializationWarning(SkillInitializationException):
+    """Non-fatal skill loading diagnostic — e.g. a cosmetic frontmatter
+    violation. Soft like its parent; the renderer distinguishes by class
+    rather than severity flag.
+    """

--- a/src/quickapp/common/exceptions/skill_initialization.py
+++ b/src/quickapp/common/exceptions/skill_initialization.py
@@ -1,20 +1,29 @@
-from typing import ClassVar
+from typing import ClassVar, Literal
 
 from .initialization import InitializationException
 
+SkillIssueSeverity = Literal["error", "warning"]
+
 
 class SkillInitializationException(InitializationException):
-    """Per-URL skill-loading failure — fetch error, invalid frontmatter,
-    duplicate name, or predefined-vs-external name collision. Soft by default:
-    the request proceeds with whatever skills did resolve.
+    """Per-URL skill-loading issue — fetch error, invalid frontmatter,
+    duplicate name, predefined-vs-external name collision, or a non-fatal
+    parser warning. Soft by default: the request proceeds with whatever
+    skills did resolve. ``severity`` drives the renderer's section split.
     """
 
     is_hard: ClassVar[bool] = False
 
-    def __init__(self, reason: str, url: str | None = None):
+    def __init__(
+        self,
+        reason: str,
+        url: str | None = None,
+        severity: SkillIssueSeverity = "error",
+    ):
         super().__init__(reason if url is None else f"{url}: {reason}")
         self.reason = reason
         self.url = url
+        self.severity: SkillIssueSeverity = severity
 
 
 class SkillCatastrophicInitializationException(SkillInitializationException):
@@ -26,10 +35,3 @@ class SkillCatastrophicInitializationException(SkillInitializationException):
 
     def __init__(self, reason: str):
         super().__init__(reason, url=None)
-
-
-class SkillInitializationWarning(SkillInitializationException):
-    """Non-fatal skill loading diagnostic — e.g. a cosmetic frontmatter
-    violation. Soft like its parent; the renderer distinguishes by class
-    rather than severity flag.
-    """

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any
 
 from aidial_client import AsyncDial, DialException
@@ -19,6 +20,8 @@ from quickapp.predefined_tooling import PredefinedConfigResolver
 from quickapp.skills._exceptions import SkillValidationError
 from quickapp.skills._skill_metadata import SkillMetadata
 from quickapp.skills.agent_skills_provider import AgentSkillsProvider
+
+logger = logging.getLogger(__name__)
 
 CONFIG_SUPPORT_URI = "/v1/configuration-support"
 
@@ -104,7 +107,11 @@ class _Controller:
         )
 
         try:
-            metadata, _ = await fetch_and_validate_dial_prompt_skill(dial_client, config.url)
+            metadata, _, warnings = await fetch_and_validate_dial_prompt_skill(
+                dial_client, config.url
+            )
+            for warning in warnings:
+                logger.warning("Skill validation '%s': %s", config.url, warning)
             return metadata
         except DialException as e:
             if e.status_code == 401:

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -107,12 +107,10 @@ class _Controller:
         )
 
         try:
-            metadata, _, warnings = await fetch_and_validate_dial_prompt_skill(
-                dial_client, config.url
-            )
-            for warning in warnings:
+            parsed, _ = await fetch_and_validate_dial_prompt_skill(dial_client, config.url)
+            for warning in parsed.warnings:
                 logger.warning("Skill validation '%s': %s", config.url, warning)
-            return metadata
+            return parsed.metadata
         except DialException as e:
             if e.status_code == 401:
                 raise HTTPException(

--- a/src/quickapp/dial_prompt_skills/_dial_prompt_skill_resolver.py
+++ b/src/quickapp/dial_prompt_skills/_dial_prompt_skill_resolver.py
@@ -1,4 +1,5 @@
 import asyncio
+import logging
 
 from aidial_client import AsyncDial
 from injector import inject
@@ -9,6 +10,8 @@ from quickapp.config.skill import DialPromptSkillConfig
 from quickapp.skills._exceptions import SkillValidationError
 from quickapp.skills._frontmatter import parse_frontmatter
 from quickapp.skills._skill_metadata import SkillMetadata
+
+logger = logging.getLogger(__name__)
 
 
 class ResolvedDialPromptSkill(BaseModel):
@@ -41,8 +44,10 @@ async def fetch_and_validate_dial_prompt_skill(
     prompt = await client.prompts.get(url)
     if prompt.content is None or not prompt.content.strip():
         raise SkillValidationError(url, "DIAL prompt has no content")
-    metadata = parse_frontmatter(prompt.content, url)
-    return metadata, prompt.content
+    parsed = parse_frontmatter(prompt.content, url)
+    for warning in parsed.warnings:
+        logger.warning("DIAL prompt skill '%s': %s", url, warning)
+    return parsed.metadata, prompt.content
 
 
 @inject

--- a/src/quickapp/dial_prompt_skills/_dial_prompt_skill_resolver.py
+++ b/src/quickapp/dial_prompt_skills/_dial_prompt_skill_resolver.py
@@ -1,17 +1,14 @@
 import asyncio
-import logging
 
 from aidial_client import AsyncDial
 from injector import inject
 from pydantic import BaseModel, ConfigDict
 
-from quickapp.common.exceptions import SkillInitializationException
+from quickapp.common.exceptions import SkillInitializationException, SkillInitializationWarning
 from quickapp.config.skill import DialPromptSkillConfig
 from quickapp.skills._exceptions import SkillValidationError
 from quickapp.skills._frontmatter import parse_frontmatter
 from quickapp.skills._skill_metadata import SkillMetadata
-
-logger = logging.getLogger(__name__)
 
 
 class ResolvedDialPromptSkill(BaseModel):
@@ -35,19 +32,18 @@ class DialPromptSkillResolverOutput(BaseModel):
 
 async def fetch_and_validate_dial_prompt_skill(
     client: AsyncDial, url: str
-) -> tuple[SkillMetadata, str]:
+) -> tuple[SkillMetadata, str, list[str]]:
     """Fetch a DIAL prompt by URL and validate it as a skill.
 
-    Raises ``DialException`` if the fetch fails and ``SkillValidationError``
-    if the prompt is empty or its frontmatter is invalid.
+    Returns ``(metadata, content, warnings)``. Raises ``DialException`` if the
+    fetch fails and ``SkillValidationError`` if the prompt is empty or its
+    frontmatter is invalid.
     """
     prompt = await client.prompts.get(url)
     if prompt.content is None or not prompt.content.strip():
         raise SkillValidationError(url, "DIAL prompt has no content")
     parsed = parse_frontmatter(prompt.content, url)
-    for warning in parsed.warnings:
-        logger.warning("DIAL prompt skill '%s': %s", url, warning)
-    return parsed.metadata, prompt.content
+    return parsed.metadata, prompt.content, parsed.warnings
 
 
 @inject
@@ -66,8 +62,10 @@ class DialPromptSkillResolver:
         - Deduplicates by URL before fetching.
         - Fetches in parallel with ``asyncio.gather(return_exceptions=True)``.
         - Deduplicates by skill name after fetching (first configured wins).
-        - Every per-URL failure becomes a ``SkillInitializationException`` in
-          the ``exceptions`` list — per the unified initialization-issues flow.
+        - Per-URL failures become ``SkillInitializationException`` entries;
+          non-fatal parser warnings become ``SkillInitializationWarning``
+          entries. Both ride the same ``exceptions`` list to the unified
+          initialization-issues flow.
         """
         seen_urls: set[str] = set()
         unique_configs: list[DialPromptSkillConfig] = []
@@ -94,28 +92,33 @@ class DialPromptSkillResolver:
                 exceptions.append(SkillInitializationException(url=url, reason=str(result)))
                 continue
 
-            if result.metadata.name in seen_names:
+            skill, warnings = result
+            for warning in warnings:
+                exceptions.append(SkillInitializationWarning(url=url, reason=warning))
+
+            if skill.metadata.name in seen_names:
                 exceptions.append(
                     SkillInitializationException(
                         url=url,
                         reason=(
-                            f"Duplicate skill name '{result.metadata.name}';"
+                            f"Duplicate skill name '{skill.metadata.name}';"
                             " keeping first occurrence"
                         ),
                     )
                 )
                 continue
 
-            seen_names.add(result.metadata.name)
-            resolved.append(result)
+            seen_names.add(skill.metadata.name)
+            resolved.append(skill)
 
         return DialPromptSkillResolverOutput(resolved=resolved, exceptions=exceptions)
 
     async def _fetch_one(
         self,
         config: DialPromptSkillConfig,
-    ) -> ResolvedDialPromptSkill:
-        metadata, content = await fetch_and_validate_dial_prompt_skill(
+    ) -> tuple[ResolvedDialPromptSkill, list[str]]:
+        metadata, content, warnings = await fetch_and_validate_dial_prompt_skill(
             self._dial_client, config.url
         )
-        return ResolvedDialPromptSkill(url=config.url, metadata=metadata, content=content)
+        skill = ResolvedDialPromptSkill(url=config.url, metadata=metadata, content=content)
+        return skill, warnings

--- a/src/quickapp/dial_prompt_skills/_dial_prompt_skill_resolver.py
+++ b/src/quickapp/dial_prompt_skills/_dial_prompt_skill_resolver.py
@@ -2,13 +2,13 @@ import asyncio
 
 from aidial_client import AsyncDial
 from injector import inject
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, Field
 
-from quickapp.common.exceptions import SkillInitializationException, SkillInitializationWarning
+from quickapp.common.exceptions import SkillInitializationException
 from quickapp.config.skill import DialPromptSkillConfig
 from quickapp.skills._exceptions import SkillValidationError
 from quickapp.skills._frontmatter import parse_frontmatter
-from quickapp.skills._skill_metadata import SkillMetadata
+from quickapp.skills._skill_metadata import ParsedSkill, SkillMetadata
 
 
 class ResolvedDialPromptSkill(BaseModel):
@@ -19,6 +19,7 @@ class ResolvedDialPromptSkill(BaseModel):
     url: str
     metadata: SkillMetadata
     content: str
+    warnings: list[str] = Field(default_factory=list)
 
 
 class DialPromptSkillResolverOutput(BaseModel):
@@ -32,18 +33,17 @@ class DialPromptSkillResolverOutput(BaseModel):
 
 async def fetch_and_validate_dial_prompt_skill(
     client: AsyncDial, url: str
-) -> tuple[SkillMetadata, str, list[str]]:
+) -> tuple[ParsedSkill, str]:
     """Fetch a DIAL prompt by URL and validate it as a skill.
 
-    Returns ``(metadata, content, warnings)``. Raises ``DialException`` if the
-    fetch fails and ``SkillValidationError`` if the prompt is empty or its
+    Returns ``(parsed, content)``. Raises ``DialException`` if the fetch
+    fails and ``SkillValidationError`` if the prompt is empty or its
     frontmatter is invalid.
     """
     prompt = await client.prompts.get(url)
     if prompt.content is None or not prompt.content.strip():
         raise SkillValidationError(url, "DIAL prompt has no content")
-    parsed = parse_frontmatter(prompt.content, url)
-    return parsed.metadata, prompt.content, parsed.warnings
+    return parse_frontmatter(prompt.content, url), prompt.content
 
 
 @inject
@@ -62,9 +62,9 @@ class DialPromptSkillResolver:
         - Deduplicates by URL before fetching.
         - Fetches in parallel with ``asyncio.gather(return_exceptions=True)``.
         - Deduplicates by skill name after fetching (first configured wins).
-        - Per-URL failures become ``SkillInitializationException`` entries;
-          non-fatal parser warnings become ``SkillInitializationWarning``
-          entries. Both ride the same ``exceptions`` list to the unified
+        - Per-URL failures and non-fatal parser warnings both become
+          ``SkillInitializationException`` entries in the ``exceptions`` list,
+          distinguished by ``severity``. Both ride the unified
           initialization-issues flow.
         """
         seen_urls: set[str] = set()
@@ -92,33 +92,36 @@ class DialPromptSkillResolver:
                 exceptions.append(SkillInitializationException(url=url, reason=str(result)))
                 continue
 
-            skill, warnings = result
-            for warning in warnings:
-                exceptions.append(SkillInitializationWarning(url=url, reason=warning))
+            for warning in result.warnings:
+                exceptions.append(
+                    SkillInitializationException(url=url, reason=warning, severity="warning")
+                )
 
-            if skill.metadata.name in seen_names:
+            if result.metadata.name in seen_names:
                 exceptions.append(
                     SkillInitializationException(
                         url=url,
                         reason=(
-                            f"Duplicate skill name '{skill.metadata.name}';"
+                            f"Duplicate skill name '{result.metadata.name}';"
                             " keeping first occurrence"
                         ),
                     )
                 )
                 continue
 
-            seen_names.add(skill.metadata.name)
-            resolved.append(skill)
+            seen_names.add(result.metadata.name)
+            resolved.append(result)
 
         return DialPromptSkillResolverOutput(resolved=resolved, exceptions=exceptions)
 
     async def _fetch_one(
         self,
         config: DialPromptSkillConfig,
-    ) -> tuple[ResolvedDialPromptSkill, list[str]]:
-        metadata, content, warnings = await fetch_and_validate_dial_prompt_skill(
-            self._dial_client, config.url
+    ) -> ResolvedDialPromptSkill:
+        parsed, content = await fetch_and_validate_dial_prompt_skill(self._dial_client, config.url)
+        return ResolvedDialPromptSkill(
+            url=config.url,
+            metadata=parsed.metadata,
+            content=content,
+            warnings=parsed.warnings,
         )
-        skill = ResolvedDialPromptSkill(url=config.url, metadata=metadata, content=content)
-        return skill, warnings

--- a/src/quickapp/skills/_frontmatter.py
+++ b/src/quickapp/skills/_frontmatter.py
@@ -3,37 +3,44 @@ import re
 import yaml
 
 from quickapp.skills._exceptions import SkillValidationError
-from quickapp.skills._skill_metadata import SkillMetadata
+from quickapp.skills._skill_metadata import ParsedSkill, SkillMetadata
 
-_FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+_FRONTMATTER_RE = re.compile(
+    r"\A﻿?[ \t\r\n]*---[ \t\r]*\n(.*?)\n---[ \t\r]*(?:\n|\Z)",
+    re.DOTALL,
+)
 _SKILL_NAME_RE = re.compile(r"^[a-z0-9]([a-z0-9-]*[a-z0-9])?$")
+_QUOTABLE_LINE_RE = re.compile(r"^([A-Za-z_][\w-]*):[ \t]+(.+\S)[ \t]*$")
 
 
-def parse_frontmatter(content: str, source_id: str) -> SkillMetadata:
-    """Parse YAML frontmatter delimited by ``---`` and return validated SkillMetadata.
+def parse_frontmatter(content: str, source_id: str) -> ParsedSkill:
+    """Parse YAML frontmatter delimited by ``---`` and return a ``ParsedSkill``.
+
+    Follows the Agent Skills client guide's "lenient with diagnostics" model:
+    cosmetic issues are recorded as warnings and the skill is still loaded;
+    only missing required fields and irrecoverable YAML errors raise.
 
     Raises:
-        SkillValidationError: If the content is missing frontmatter or
-            fails any validation rule.
+        SkillValidationError: if the content has no frontmatter, the YAML is
+            unparseable even after a quote-retry, the YAML is not a mapping,
+            or ``name`` / ``description`` are missing or empty.
 
     Args:
         content: The full skill content string.
         source_id: Identifier for error messages (file path or prompt URL).
     """
     match = _FRONTMATTER_RE.match(content)
-
     if not match:
         raise SkillValidationError(source_id, "No YAML frontmatter found")
 
-    try:
-        parsed = yaml.safe_load(match.group(1))
-    except yaml.YAMLError as exc:
-        raise SkillValidationError(source_id, f"Failed to parse YAML frontmatter: {exc}")
+    warnings: list[str] = []
+    parsed, yaml_warning = _parse_yaml(match.group(1), source_id)
+    if yaml_warning is not None:
+        warnings.append(yaml_warning)
 
     if not isinstance(parsed, dict):
         raise SkillValidationError(source_id, "YAML frontmatter is not a dictionary")
 
-    # Normalize 'allowed-tools' hyphenated key to 'allowed_tools'
     if "allowed-tools" in parsed:
         allowed_tools_value = parsed.pop("allowed-tools")
         if isinstance(allowed_tools_value, str):
@@ -50,24 +57,22 @@ def parse_frontmatter(content: str, source_id: str) -> SkillMetadata:
         raise SkillValidationError(source_id, "Missing required fields (name/description)")
 
     if len(name) > 64:
-        raise SkillValidationError(source_id, f"Skill name exceeds 64 characters: {name}")
+        warnings.append(f"Skill name exceeds 64 characters: {name}")
 
     if "--" in name or not _SKILL_NAME_RE.match(name):
-        raise SkillValidationError(
-            source_id,
-            f"Invalid skill name format: {name}"
-            " (must be lowercase letters, numbers, hyphens;"
-            " no leading/trailing or consecutive hyphens)",
+        warnings.append(
+            f"Skill name does not match recommended format: {name}"
+            " (lowercase letters, numbers, hyphens; no leading/trailing or consecutive hyphens)"
         )
 
     if len(description) > 1024:
-        raise SkillValidationError(source_id, "Description exceeds 1024 characters")
+        warnings.append("Description exceeds 1024 characters")
 
     compatibility = parsed.get("compatibility")
     if compatibility is not None and len(compatibility) > 500:
-        raise SkillValidationError(source_id, "Compatibility exceeds 500 characters")
+        warnings.append("Compatibility exceeds 500 characters")
 
-    return SkillMetadata(
+    metadata = SkillMetadata(
         name=name,
         description=description,
         license=parsed.get("license"),
@@ -75,3 +80,44 @@ def parse_frontmatter(content: str, source_id: str) -> SkillMetadata:
         metadata=parsed.get("metadata") or None,
         allowed_tools=parsed.get("allowed_tools"),
     )
+    return ParsedSkill(metadata=metadata, warnings=warnings)
+
+
+def _parse_yaml(text: str, source_id: str) -> tuple[object, str | None]:
+    """Parse YAML, retrying once with a quote-repair if the first attempt fails.
+
+    Returns ``(parsed, warning_or_none)``. Raises ``SkillValidationError`` if
+    the YAML can't be parsed even after the repair.
+    """
+    try:
+        return yaml.safe_load(text), None
+    except yaml.YAMLError as original_exc:
+        repaired = _quote_unquoted_colons(text)
+        if repaired != text:
+            try:
+                return (
+                    yaml.safe_load(repaired),
+                    "YAML repaired by quoting value(s) with unescaped colons",
+                )
+            except yaml.YAMLError:
+                pass
+        raise SkillValidationError(source_id, f"Failed to parse YAML frontmatter: {original_exc}")
+
+
+def _quote_unquoted_colons(text: str) -> str:
+    """Wrap top-level scalar values containing unquoted colons in double quotes."""
+    out_lines: list[str] = []
+    changed = False
+    for line in text.splitlines():
+        match = _QUOTABLE_LINE_RE.match(line)
+        if match is None:
+            out_lines.append(line)
+            continue
+        key, value = match.group(1), match.group(2)
+        if value[0] in ("'", '"', "|", ">", "[", "{") or ":" not in value:
+            out_lines.append(line)
+            continue
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+        out_lines.append(f'{key}: "{escaped}"')
+        changed = True
+    return "\n".join(out_lines) if changed else text

--- a/src/quickapp/skills/_skill_metadata.py
+++ b/src/quickapp/skills/_skill_metadata.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 
 class SkillMetadata(BaseModel):
@@ -12,3 +12,10 @@ class SkillMetadata(BaseModel):
     compatibility: str | None = None
     metadata: dict[str, Any] | None = None
     allowed_tools: list[str] | None = None
+
+
+class ParsedSkill(BaseModel):
+    """Result of ``parse_frontmatter``: metadata plus non-fatal warnings."""
+
+    metadata: SkillMetadata
+    warnings: list[str] = Field(default_factory=list)

--- a/src/quickapp/skills/agent_skills_provider.py
+++ b/src/quickapp/skills/agent_skills_provider.py
@@ -37,7 +37,7 @@ class AgentSkillsProvider:
             try:
                 logger.debug(f"Loading skill `{file_stem}`")
                 content = self._provider.read_text(ContentType.SKILL, file_stem)
-                metadata = parse_frontmatter(content, file_stem)
+                parsed = parse_frontmatter(content, file_stem)
             except SkillValidationError as exc:
                 logger.warning(str(exc))
                 continue
@@ -45,13 +45,16 @@ class AgentSkillsProvider:
                 logger.error(f"Failed to parse skill `{file_stem}`: {exc}")
                 continue
 
+            metadata = parsed.metadata
+            for warning in parsed.warnings:
+                logger.warning("Skill '%s': %s", file_stem, warning)
+
             if metadata.name != file_stem:
                 logger.warning(
-                    "Skill name '%s' does not match directory name '%s'; skipping",
+                    "Skill name '%s' does not match directory name '%s'; loading anyway",
                     metadata.name,
                     file_stem,
                 )
-                continue
             skills.append(metadata)
             contents[metadata.name] = content
 

--- a/src/tests/unit_tests/application_tests/test_initialization_error_handler.py
+++ b/src/tests/unit_tests/application_tests/test_initialization_error_handler.py
@@ -4,11 +4,7 @@ from unittest.mock import MagicMock
 from aidial_sdk.chat_completion import Stage, Status
 
 from quickapp.application._initialization_error_handler import _InitializationErrorHandler
-from quickapp.common.exceptions import (
-    ConfigResolutionException,
-    SkillInitializationException,
-    SkillInitializationWarning,
-)
+from quickapp.common.exceptions import ConfigResolutionException, SkillInitializationException
 
 
 def _make_handler(stage: MagicMock, exceptions: list) -> _InitializationErrorHandler:
@@ -68,8 +64,10 @@ class TestConfigResolutionExceptionRendering:
 class TestSkillInitializationWarningRendering:
     def test_warning_renders_under_warnings_subheader_and_keeps_completed(self):
         stage = MagicMock(spec=Stage)
-        warning = SkillInitializationWarning(
-            reason="exceeds 64 characters", url="prompts/bucket/long-name"
+        warning = SkillInitializationException(
+            reason="exceeds 64 characters",
+            url="prompts/bucket/long-name",
+            severity="warning",
         )
         handler = _make_handler(stage, [warning])
 
@@ -85,7 +83,9 @@ class TestSkillInitializationWarningRendering:
     def test_error_and_warning_render_in_separate_subheaders(self):
         stage = MagicMock(spec=Stage)
         error = SkillInitializationException(reason="boom", url="prompts/bucket/broken")
-        warning = SkillInitializationWarning(reason="bad format", url="prompts/bucket/iffy")
+        warning = SkillInitializationException(
+            reason="bad format", url="prompts/bucket/iffy", severity="warning"
+        )
         handler = _make_handler(stage, [error, warning])
 
         handler.handle_initialization_issues()

--- a/src/tests/unit_tests/application_tests/test_initialization_error_handler.py
+++ b/src/tests/unit_tests/application_tests/test_initialization_error_handler.py
@@ -4,7 +4,11 @@ from unittest.mock import MagicMock
 from aidial_sdk.chat_completion import Stage, Status
 
 from quickapp.application._initialization_error_handler import _InitializationErrorHandler
-from quickapp.common.exceptions import ConfigResolutionException
+from quickapp.common.exceptions import (
+    ConfigResolutionException,
+    SkillInitializationException,
+    SkillInitializationWarning,
+)
 
 
 def _make_handler(stage: MagicMock, exceptions: list) -> _InitializationErrorHandler:
@@ -59,3 +63,38 @@ class TestConfigResolutionExceptionRendering:
         )
         handler.handle_initialization_issues()
         stage.open.assert_not_called()
+
+
+class TestSkillInitializationWarningRendering:
+    def test_warning_renders_under_warnings_subheader_and_keeps_completed(self):
+        stage = MagicMock(spec=Stage)
+        warning = SkillInitializationWarning(
+            reason="exceeds 64 characters", url="prompts/bucket/long-name"
+        )
+        handler = _make_handler(stage, [warning])
+
+        handler.handle_initialization_issues()
+
+        rendered = _stage_content(stage)
+        assert "Warnings:" in rendered
+        assert "prompts/bucket/long-name" in rendered
+        assert "exceeds 64 characters" in rendered
+        assert "Errors:" not in rendered
+        stage.close.assert_called_once_with(Status.COMPLETED)
+
+    def test_error_and_warning_render_in_separate_subheaders(self):
+        stage = MagicMock(spec=Stage)
+        error = SkillInitializationException(reason="boom", url="prompts/bucket/broken")
+        warning = SkillInitializationWarning(reason="bad format", url="prompts/bucket/iffy")
+        handler = _make_handler(stage, [error, warning])
+
+        handler.handle_initialization_issues()
+
+        rendered = _stage_content(stage)
+        assert "Errors:" in rendered
+        assert "Warnings:" in rendered
+        assert rendered.index("Errors:") < rendered.index("Warnings:")
+        assert "prompts/bucket/broken" in rendered
+        assert "prompts/bucket/iffy" in rendered
+        # Both entries have is_hard=False — status stays COMPLETED.
+        stage.close.assert_called_once_with(Status.COMPLETED)

--- a/src/tests/unit_tests/configuration_support_tests/test_controller_skills.py
+++ b/src/tests/unit_tests/configuration_support_tests/test_controller_skills.py
@@ -210,3 +210,27 @@ class TestValidateSkill:
             )
 
         assert response.status_code == 422
+
+    @pytest.mark.asyncio
+    @patch("quickapp.configuration_support._controller.AsyncDial")
+    async def test_long_name_returns_200(self, mock_dial_cls):
+        """A name >64 chars no longer rejects the skill — it returns 200 with metadata."""
+        long_name = "a" * 65
+        prompt = MagicMock()
+        prompt.content = f"---\nname: {long_name}\ndescription: desc\n---\nBody\n"
+        mock_client = MagicMock()
+        mock_client.prompts = MagicMock()
+        mock_client.prompts.get = AsyncMock(return_value=prompt)
+        mock_dial_cls.return_value = mock_client
+
+        app = _make_app(_make_controller())
+
+        async with AsyncClient(transport=ASGITransport(app=app), base_url=BASE_URL) as client:
+            response = await client.post(
+                VALIDATE_URL,
+                json={"type": "dial-prompt", "url": "prompts/bucket/long-name"},
+                headers={"api-key": "test-key"},
+            )
+
+        assert response.status_code == 200
+        assert response.json()["name"] == long_name

--- a/src/tests/unit_tests/dial_prompt_skills_tests/test_dial_prompt_skill_resolver.py
+++ b/src/tests/unit_tests/dial_prompt_skills_tests/test_dial_prompt_skill_resolver.py
@@ -2,7 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from quickapp.common.exceptions import SkillInitializationException, SkillInitializationWarning
+from quickapp.common.exceptions import SkillInitializationException
 from quickapp.config.skill import DialPromptSkillConfig
 from quickapp.dial_prompt_skills._dial_prompt_skill_resolver import DialPromptSkillResolver
 
@@ -179,7 +179,8 @@ class TestDialPromptSkillResolver:
         assert output.resolved[0].metadata.name == long_name
         assert len(output.exceptions) == 1
         warning = output.exceptions[0]
-        assert isinstance(warning, SkillInitializationWarning)
+        assert isinstance(warning, SkillInitializationException)
+        assert warning.severity == "warning"
         assert warning.url == "prompts/bucket/long"
         assert "exceeds 64 characters" in warning.reason
 
@@ -194,7 +195,7 @@ class TestDialPromptSkillResolver:
         output = await resolver.resolve([_make_config("prompts/bucket/iffy")])
 
         assert len(output.resolved) == 1
-        warnings = [e for e in output.exceptions if isinstance(e, SkillInitializationWarning)]
+        warnings = [e for e in output.exceptions if e.severity == "warning"]
         assert len(warnings) == 2
         reasons = " | ".join(w.reason for w in warnings)
         assert "exceeds 64 characters" in reasons
@@ -220,13 +221,8 @@ class TestDialPromptSkillResolver:
 
         assert len(output.resolved) == 1
         assert output.resolved[0].url == "prompts/bucket/ok"
-        warnings = [e for e in output.exceptions if isinstance(e, SkillInitializationWarning)]
-        errors = [
-            e
-            for e in output.exceptions
-            if isinstance(e, SkillInitializationException)
-            and not isinstance(e, SkillInitializationWarning)
-        ]
+        warnings = [e for e in output.exceptions if e.severity == "warning"]
+        errors = [e for e in output.exceptions if e.severity == "error"]
         assert len(warnings) == 1
         assert warnings[0].url == "prompts/bucket/ok"
         assert len(errors) == 1

--- a/src/tests/unit_tests/dial_prompt_skills_tests/test_dial_prompt_skill_resolver.py
+++ b/src/tests/unit_tests/dial_prompt_skills_tests/test_dial_prompt_skill_resolver.py
@@ -2,6 +2,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
+from quickapp.common.exceptions import SkillInitializationException, SkillInitializationWarning
 from quickapp.config.skill import DialPromptSkillConfig
 from quickapp.dial_prompt_skills._dial_prompt_skill_resolver import DialPromptSkillResolver
 
@@ -166,17 +167,70 @@ class TestDialPromptSkillResolver:
 
     @pytest.mark.asyncio
     async def test_long_name_resolves_with_warning(self):
-        """A name >64 chars used to be a per-URL failure; now it resolves."""
+        """A name >64 chars resolves and emits a SkillInitializationWarning."""
         long_name = "a" * 65
         content = f"---\nname: {long_name}\ndescription: desc\n---\nBody\n"
         prompt = _make_prompt(content=content)
         resolver = _make_resolver(prompts_get_return=prompt)
 
-        output = await resolver.resolve([_make_config()])
+        output = await resolver.resolve([_make_config("prompts/bucket/long")])
 
         assert len(output.resolved) == 1
         assert output.resolved[0].metadata.name == long_name
-        assert output.exceptions == []
+        assert len(output.exceptions) == 1
+        warning = output.exceptions[0]
+        assert isinstance(warning, SkillInitializationWarning)
+        assert warning.url == "prompts/bucket/long"
+        assert "exceeds 64 characters" in warning.reason
+
+    @pytest.mark.asyncio
+    async def test_multiple_warnings_per_skill(self):
+        """A skill with both a length and a format violation emits two warnings."""
+        bad_name = "-" + "a" * 64  # 65 chars, leading hyphen → both warnings fire
+        content = f"---\nname: {bad_name}\ndescription: desc\n---\nBody\n"
+        prompt = _make_prompt(content=content)
+        resolver = _make_resolver(prompts_get_return=prompt)
+
+        output = await resolver.resolve([_make_config("prompts/bucket/iffy")])
+
+        assert len(output.resolved) == 1
+        warnings = [e for e in output.exceptions if isinstance(e, SkillInitializationWarning)]
+        assert len(warnings) == 2
+        reasons = " | ".join(w.reason for w in warnings)
+        assert "exceeds 64 characters" in reasons
+        assert "does not match recommended format" in reasons
+
+    @pytest.mark.asyncio
+    async def test_warning_and_failure_coexist(self):
+        """One URL resolves with a warning; another fails — both reported."""
+        long_name = "a" * 65
+        ok_with_warning = _make_prompt(
+            content=f"---\nname: {long_name}\ndescription: desc\n---\nBody\n"
+        )
+        broken = _make_prompt(content="no frontmatter here")
+
+        dial_client = MagicMock()
+        dial_client.prompts = MagicMock()
+        dial_client.prompts.get = AsyncMock(side_effect=[ok_with_warning, broken])
+        resolver = DialPromptSkillResolver(dial_client=dial_client)
+
+        output = await resolver.resolve(
+            [_make_config("prompts/bucket/ok"), _make_config("prompts/bucket/broken")]
+        )
+
+        assert len(output.resolved) == 1
+        assert output.resolved[0].url == "prompts/bucket/ok"
+        warnings = [e for e in output.exceptions if isinstance(e, SkillInitializationWarning)]
+        errors = [
+            e
+            for e in output.exceptions
+            if isinstance(e, SkillInitializationException)
+            and not isinstance(e, SkillInitializationWarning)
+        ]
+        assert len(warnings) == 1
+        assert warnings[0].url == "prompts/bucket/ok"
+        assert len(errors) == 1
+        assert errors[0].url == "prompts/bucket/broken"
 
     @pytest.mark.asyncio
     async def test_bom_prefixed_content_resolves(self):

--- a/src/tests/unit_tests/dial_prompt_skills_tests/test_dial_prompt_skill_resolver.py
+++ b/src/tests/unit_tests/dial_prompt_skills_tests/test_dial_prompt_skill_resolver.py
@@ -163,3 +163,43 @@ class TestDialPromptSkillResolver:
         output = await resolver.resolve([])
         assert output.resolved == []
         assert output.exceptions == []
+
+    @pytest.mark.asyncio
+    async def test_long_name_resolves_with_warning(self):
+        """A name >64 chars used to be a per-URL failure; now it resolves."""
+        long_name = "a" * 65
+        content = f"---\nname: {long_name}\ndescription: desc\n---\nBody\n"
+        prompt = _make_prompt(content=content)
+        resolver = _make_resolver(prompts_get_return=prompt)
+
+        output = await resolver.resolve([_make_config()])
+
+        assert len(output.resolved) == 1
+        assert output.resolved[0].metadata.name == long_name
+        assert output.exceptions == []
+
+    @pytest.mark.asyncio
+    async def test_bom_prefixed_content_resolves(self):
+        """Content stored with a leading BOM (common after copy/paste) now parses."""
+        content = "﻿" + VALID_SKILL_CONTENT
+        prompt = _make_prompt(content=content)
+        resolver = _make_resolver(prompts_get_return=prompt)
+
+        output = await resolver.resolve([_make_config()])
+
+        assert len(output.resolved) == 1
+        assert output.resolved[0].metadata.name == "my-skill"
+        assert output.exceptions == []
+
+    @pytest.mark.asyncio
+    async def test_closing_fence_at_eof_resolves(self):
+        """Content with no trailing newline after the closing fence now parses."""
+        content = "---\nname: my-skill\ndescription: desc\n---"
+        prompt = _make_prompt(content=content)
+        resolver = _make_resolver(prompts_get_return=prompt)
+
+        output = await resolver.resolve([_make_config()])
+
+        assert len(output.resolved) == 1
+        assert output.resolved[0].metadata.name == "my-skill"
+        assert output.exceptions == []

--- a/src/tests/unit_tests/skills_tests/test_agent_skills_provider.py
+++ b/src/tests/unit_tests/skills_tests/test_agent_skills_provider.py
@@ -8,7 +8,7 @@ from quickapp.config.predefined_content_provider import (
 )
 from quickapp.skills._exceptions import SkillValidationError
 from quickapp.skills._frontmatter import parse_frontmatter
-from quickapp.skills._skill_metadata import SkillMetadata
+from quickapp.skills._skill_metadata import ParsedSkill, SkillMetadata
 from quickapp.skills._xml import generate_skills_xml
 from quickapp.skills.agent_skills_provider import AgentSkillsProvider
 
@@ -36,13 +36,16 @@ class TestParseFrontmatter:
             "Body content\n"
         )
         result = parse_frontmatter(content, "my-skill")
-        assert isinstance(result, SkillMetadata)
-        assert result.name == "my-skill"
-        assert result.description == "A test skill"
-        assert result.license == "MIT"
-        assert result.compatibility == ">=1.0"
-        assert result.metadata == {"version": "1.0"}
-        assert result.allowed_tools == ["tool_a", "tool_b"]
+        assert isinstance(result, ParsedSkill)
+        assert result.warnings == []
+        meta = result.metadata
+        assert isinstance(meta, SkillMetadata)
+        assert meta.name == "my-skill"
+        assert meta.description == "A test skill"
+        assert meta.license == "MIT"
+        assert meta.compatibility == ">=1.0"
+        assert meta.metadata == {"version": "1.0"}
+        assert meta.allowed_tools == ["tool_a", "tool_b"]
 
     def test_missing_name_raises(self):
         content = "---\ndescription: A skill without name\n---\nBody\n"
@@ -54,26 +57,30 @@ class TestParseFrontmatter:
         with pytest.raises(SkillValidationError):
             parse_frontmatter(content, "test")
 
-    def test_name_exceeds_64_chars_raises(self):
+    def test_name_exceeds_64_chars_warns(self):
         long_name = "a" * 65
         content = f"---\nname: {long_name}\ndescription: desc\n---\nBody\n"
-        with pytest.raises(SkillValidationError):
-            parse_frontmatter(content, "test")
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == long_name
+        assert any("exceeds 64 characters" in w for w in result.warnings)
 
-    def test_consecutive_hyphens_raises(self):
+    def test_consecutive_hyphens_warns(self):
         content = "---\nname: my--skill\ndescription: desc\n---\nBody\n"
-        with pytest.raises(SkillValidationError):
-            parse_frontmatter(content, "test")
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my--skill"
+        assert any("does not match recommended format" in w for w in result.warnings)
 
-    def test_leading_hyphen_raises(self):
+    def test_leading_hyphen_warns(self):
         content = "---\nname: -my-skill\ndescription: desc\n---\nBody\n"
-        with pytest.raises(SkillValidationError):
-            parse_frontmatter(content, "test")
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "-my-skill"
+        assert any("does not match recommended format" in w for w in result.warnings)
 
-    def test_trailing_hyphen_raises(self):
+    def test_trailing_hyphen_warns(self):
         content = "---\nname: my-skill-\ndescription: desc\n---\nBody\n"
-        with pytest.raises(SkillValidationError):
-            parse_frontmatter(content, "test")
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my-skill-"
+        assert any("does not match recommended format" in w for w in result.warnings)
 
     def test_invalid_yaml_raises(self):
         content = "---\n: [invalid yaml\n---\nBody\n"
@@ -88,7 +95,7 @@ class TestParseFrontmatter:
     def test_allowed_tools_as_string_normalized_to_list(self):
         content = "---\nname: my-skill\ndescription: desc\nallowed-tools: tool1 tool2\n---\nBody\n"
         result = parse_frontmatter(content, "test")
-        assert result.allowed_tools == ["tool1", "tool2"]
+        assert result.metadata.allowed_tools == ["tool1", "tool2"]
 
     def test_allowed_tools_as_list_kept(self):
         content = (
@@ -96,21 +103,23 @@ class TestParseFrontmatter:
             "allowed-tools:\n  - tool1\n  - tool2\n---\nBody\n"
         )
         result = parse_frontmatter(content, "test")
-        assert result.allowed_tools == ["tool1", "tool2"]
+        assert result.metadata.allowed_tools == ["tool1", "tool2"]
 
-    def test_description_exceeds_1024_chars_raises(self):
+    def test_description_exceeds_1024_chars_warns(self):
         long_desc = "x" * 1025
         content = f"---\nname: my-skill\ndescription: {long_desc}\n---\nBody\n"
-        with pytest.raises(SkillValidationError):
-            parse_frontmatter(content, "test")
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.description == long_desc
+        assert any("Description exceeds 1024" in w for w in result.warnings)
 
-    def test_compatibility_exceeds_500_chars_raises(self):
+    def test_compatibility_exceeds_500_chars_warns(self):
         long_compat = "x" * 501
         content = (
             f"---\nname: my-skill\ndescription: desc\n" f"compatibility: {long_compat}\n---\nBody\n"
         )
-        with pytest.raises(SkillValidationError, match="Compatibility exceeds 500"):
-            parse_frontmatter(content, "test")
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.compatibility == long_compat
+        assert any("Compatibility exceeds 500" in w for w in result.warnings)
 
     def test_no_frontmatter_raises(self):
         content = "Just some text without frontmatter"
@@ -123,6 +132,54 @@ class TestParseFrontmatter:
             parse_frontmatter(content, "my-source")
         assert exc_info.value.source_id == "my-source"
         assert "No YAML frontmatter found" in exc_info.value.reason
+
+    # ---- lenient regex cases --------------------------------------------
+
+    def test_bom_prefixed_parses(self):
+        content = "﻿---\nname: my-skill\ndescription: desc\n---\nBody\n"
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my-skill"
+
+    def test_leading_whitespace_parses(self):
+        content = "   \n---\nname: my-skill\ndescription: desc\n---\nBody\n"
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my-skill"
+
+    def test_leading_blank_line_parses(self):
+        content = "\n---\nname: my-skill\ndescription: desc\n---\nBody\n"
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my-skill"
+
+    def test_closing_fence_at_eof_parses(self):
+        content = "---\nname: my-skill\ndescription: desc\n---"
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my-skill"
+
+    def test_crlf_line_endings_parse(self):
+        content = "---\r\nname: my-skill\r\ndescription: desc\r\n---\r\nBody\r\n"
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.name == "my-skill"
+
+    # ---- YAML quote-retry ----------------------------------------------
+
+    def test_unquoted_colon_in_description_recovered(self):
+        content = (
+            "---\n"
+            "name: my-skill\n"
+            "description: Use when: the user asks about PDFs\n"
+            "---\n"
+            "Body\n"
+        )
+        result = parse_frontmatter(content, "test")
+        assert result.metadata.description == "Use when: the user asks about PDFs"
+        assert any("YAML repaired" in w for w in result.warnings)
+
+    def test_unrecoverable_yaml_still_raises(self):
+        # `description: With: colon` triggers the quote-repair, but `: [broken`
+        # is still broken after the repair — the second parse fails too.
+        content = "---\nname: x\ndescription: With: colon\n: [broken\n---\nBody\n"
+        with pytest.raises(SkillValidationError, match="Failed to parse YAML frontmatter"):
+            parse_frontmatter(content, "test")
 
 
 # ---------------------------------------------------------------------------
@@ -188,7 +245,7 @@ class TestAgentSkillsProviderIntegration:
         skills = asp.get_all_skills()
         assert any(s.name == "my-valid-skill" for s in skills)
 
-    def test_name_mismatch_skips_skill(self, tmp_path: Path):
+    def test_name_mismatch_loads_anyway(self, tmp_path: Path):
         skill_dir = tmp_path / "skills" / "dir-name"
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(
@@ -200,8 +257,7 @@ class TestAgentSkillsProviderIntegration:
         asp = AgentSkillsProvider(provider)
 
         skill_names = [s.name for s in asp.get_all_skills()]
-        assert "different-name" not in skill_names
-        assert "dir-name" not in skill_names
+        assert "different-name" in skill_names
 
     def test_mixed_valid_invalid_skills(self, tmp_path: Path):
         # Valid skill


### PR DESCRIPTION
### Applicable issues

- fixes #313

### Description of changes

Aligns `parse_frontmatter` with the cross-client [Agent Skills client guide](https://agentskills.io/client-implementation/adding-skills-support#step-2-parse-skill-md-files)'s "lenient with diagnostics" model. The parser is the shared entry point for the predefined-skills loader (`AgentSkillsProvider`) and the DIAL prompt resolver, so both paths benefit.

- **Loose frontmatter regex**: tolerates BOM, leading whitespace/blank line, closing fence at end-of-file, and CRLF — the variants that get introduced when SKILL.md content round-trips through DIAL prompt storage or a web textarea.
- **Cosmetic checks → warnings**: oversize `name` / `description` / `compatibility` and non-conforming `name` format are recorded in `ParsedSkill.warnings` and logged; the skill still loads. Predefined skills whose `name` doesn't match the parent directory load instead of being silently skipped.
- **YAML quote-retry**: `description: Use when: the user asks` and similar unquoted-colon authoring mistakes are auto-repaired before the parser gives up.
- **Hard failures kept**: no frontmatter, missing `name` / `description`, and YAML still unparseable after the retry.

No schema change.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.