### PR TITLE
fix: render agent skill stage content as code block #320

### DIFF
--- a/src/quickapp/skills/_skill_reader_stage_wrapper.py
+++ b/src/quickapp/skills/_skill_reader_stage_wrapper.py
@@ -11,7 +11,7 @@ class _SkillReaderStageWrapper(TimedStageWrapper):
     def _get_formatted_parameters(self, parameters: dict[str, Any]) -> str:
         """Format the parameters for display in the stage."""
         if skill_name := parameters.get("skill_name"):
-            return f"Skill: {skill_name}"
+            return f"Skill: {skill_name}\n\n"
         return ""
 
     def _build_debug_info_from_exception(self, exception: Exception) -> str:

--- a/src/quickapp/skills/_skill_reader_stage_wrapper.py
+++ b/src/quickapp/skills/_skill_reader_stage_wrapper.py
@@ -9,9 +9,6 @@ from quickapp.common import TimedStageWrapper, ToolCallResult
 class _SkillReaderStageWrapper(TimedStageWrapper):
 
     def _get_formatted_parameters(self, parameters: dict[str, Any]) -> str:
-        """Format the parameters for display in the stage."""
-        if skill_name := parameters.get("skill_name"):
-            return f"Skill: {skill_name}\n\n"
         return ""
 
     def _build_debug_info_from_exception(self, exception: Exception) -> str:

--- a/src/quickapp/skills/_skill_reader_stage_wrapper.py
+++ b/src/quickapp/skills/_skill_reader_stage_wrapper.py
@@ -15,9 +15,7 @@ class _SkillReaderStageWrapper(TimedStageWrapper):
         return ""
 
     def _build_debug_info_from_exception(self, exception: Exception) -> str:
-        """Build debug information from an exception."""
-        return f"### Error:\n{exception}\n"
+        return f"Error:\n```\n{exception}\n```\n"
 
     def _build_debug_info_from_result(self, result: ToolCallResult) -> str:
-        """Build debug information from the result."""
-        return f"### Skill Content:\n{result.content}\n"
+        return f"Skill Content:\n```\n{result.content}\n```\n"

--- a/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
+++ b/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
@@ -25,13 +25,8 @@ def wrapper(mock_stage):
     )
 
 
-def test_get_formatted_parameters_ends_with_blank_line(wrapper):
-    output = wrapper._get_formatted_parameters({"skill_name": "demo-skill"})
-
-    assert output == "Skill: demo-skill\n\n"
-
-
-def test_get_formatted_parameters_returns_empty_when_no_skill_name(wrapper):
+def test_get_formatted_parameters_returns_empty(wrapper):
+    assert wrapper._get_formatted_parameters({"skill_name": "demo-skill"}) == ""
     assert wrapper._get_formatted_parameters({}) == ""
 
 

--- a/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
+++ b/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
@@ -25,6 +25,16 @@ def wrapper(mock_stage):
     )
 
 
+def test_get_formatted_parameters_ends_with_blank_line(wrapper):
+    output = wrapper._get_formatted_parameters({"skill_name": "demo-skill"})
+
+    assert output == "Skill: demo-skill\n\n"
+
+
+def test_get_formatted_parameters_returns_empty_when_no_skill_name(wrapper):
+    assert wrapper._get_formatted_parameters({}) == ""
+
+
 def test_build_debug_info_from_result_wraps_content_in_code_fence(wrapper):
     skill_content = "# Heading\n## Subheading\nbody text"
     result = ToolCallResult(content=skill_content, content_type="text/markdown")

--- a/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
+++ b/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
@@ -1,0 +1,42 @@
+from unittest.mock import MagicMock
+
+import pytest
+from aidial_sdk.chat_completion import Stage
+
+from quickapp.common import ToolCallResult
+
+# noinspection PyProtectedMember
+from quickapp.skills._skill_reader_stage_wrapper import _SkillReaderStageWrapper
+
+
+@pytest.fixture
+def mock_stage():
+    stage = MagicMock(spec=Stage)
+    stage.__enter__.return_value = stage
+    return stage
+
+
+@pytest.fixture
+def wrapper(mock_stage):
+    return _SkillReaderStageWrapper(
+        stage=mock_stage,
+        tool_config=None,
+        stage_name="Reading Skill: ",
+    )
+
+
+def test_build_debug_info_from_result_wraps_content_in_code_fence(wrapper):
+    skill_content = "# Heading\n## Subheading\nbody text"
+    result = ToolCallResult(content=skill_content, content_type="text/markdown")
+
+    output = wrapper._build_debug_info_from_result(result)
+
+    assert output == f"Skill Content:\n```\n{skill_content}\n```\n"
+
+
+def test_build_debug_info_from_exception_wraps_message_in_code_fence(wrapper):
+    exception = ValueError("skill not found")
+
+    output = wrapper._build_debug_info_from_exception(exception)
+
+    assert output == "Error:\n```\nskill not found\n```\n"


### PR DESCRIPTION
### Applicable issues

- fixes #320

### Description of changes

When an Agent skill stage was expanded, embedded markdown in the skill body (its own `#`/`##` headings) rendered as oversized bold text, and the redundant "Skill: <name>" parameters chunk ran on the same line as the "Skill Content:" label.

- Wrap the skill payload and exception text in fenced code blocks so the body is shown verbatim.
- Drop the `### Error:` / `### Skill Content:` H3 prefixes (now plain-text labels).
- Stop emitting the parameters chunk — the skill name is already in the stage title (`Reading Skill: <name>`).

That's how stage looks after the changes:
<img width="1478" height="597" alt="image" src="https://github.com/user-attachments/assets/5e7bb37a-c6ba-4d76-875a-15143d0b6181" />


### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.