### PR TITLE
chore: prefix Claude Code skills with quickapps-

### DIFF
--- a/.claude/skills/quickapps-code-review/SKILL.md
+++ b/.claude/skills/quickapps-code-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: code-review
+name: quickapps-code-review
 description: Use before creating a PR or claiming a change is ready (or on explicit user invocation). Self-reviews the current diff against the patterns this team's reviewers consistently flag.
 allowed-tools: Read Grep Glob LSP Bash(git diff:*) Bash(git log:*) Bash(git show:*) Bash(git status:*) Bash(git rev-parse:*) Bash(date:*) Bash(gh pr view:*) Bash(gh pr diff:*) Bash(gh pr list:*) Write(docs/reviews/*) Bash(mkdir -p docs/reviews)
 argument-hint: "[pr|uncommitted]"
@@ -10,7 +10,7 @@ context: fork
 agent: general-purpose
 ---
 
-# code-review
+# quickapps-code-review
 
 Self-review the current diff against the recurring feedback this team's reviewers actually leave. Catches it before they do.
 
@@ -166,7 +166,7 @@ Every finding is a checkbox — the author ticks them off as fixes land.
 This checklist drifts as conventions evolve. At the start of every review run, check freshness:
 
 ```bash
-git log -1 --since='7 days ago' --format=%h -- .claude/skills/code-review/SKILL.md
+git log -1 --since='7 days ago' --format=%h -- .claude/skills/quickapps-code-review/SKILL.md
 ```
 
 - **Non-empty output** → fresh. Skip; don't load `references/REFRESHING.md`.

--- a/.claude/skills/quickapps-code-review/references/REFRESHING.md
+++ b/.claude/skills/quickapps-code-review/references/REFRESHING.md
@@ -1,4 +1,4 @@
-# Refreshing the code-review checklist
+# Refreshing the quickapps-code-review checklist
 
 Procedure for refreshing the `SKILL.md` checklist from recent review comments. Invoked from `SKILL.md` when its staleness check exceeds the threshold.
 

--- a/.claude/skills/quickapps-design-review/SKILL.md
+++ b/.claude/skills/quickapps-design-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: design-review
+name: quickapps-design-review
 description: Use when the user asks to review, critique, validate, or approve a design doc under docs/designs/. Appends a Review Notes block; on explicit approval, strips notes and flips Status to Approved.
 context: fork
 agent: general-purpose
@@ -76,7 +76,7 @@ Append to the **end** of the target doc, separated from the existing content by 
 
 ## Review Notes — Round N
 
-- **Reviewer:** Claude (design-review skill)
+- **Reviewer:** Claude (quickapps-design-review skill)
 - **Date:** YYYY-MM-DD
 
 ### Verdict


### PR DESCRIPTION
## Summary

- Renames `.claude/skills/code-review/` → `quickapps-code-review/` and `.claude/skills/design-review/` → `quickapps-design-review/` so the project's Claude Code skills are clearly namespaced and don't collide with generically-named skills installed elsewhere.
- Updates internal self-references inside each `SKILL.md` (frontmatter `name:`, headers, path used in the freshness check, "design-review skill" mention) and the title of `references/REFRESHING.md`.

## Test plan

- [x] In a fresh Claude Code session, confirm the renamed skills appear as `quickapps-code-review` and `quickapps-design-review` in the available-skills list.
- [x] Invoke `quickapps-code-review` and `quickapps-design-review` and verify they behave the same as before.