### PR TITLE
feat: custom_cert_support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Ensure shell scripts always use LF line endings, even on Windows checkouts
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN poetry install --no-interaction --no-ansi --no-cache --only main
 
 FROM python:3.13-alpine AS runtime
 
-RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat zlib musl musl-utils
+RUN apk update && apk upgrade --no-cache libcrypto3 libssl3 libexpat zlib musl musl-utils && \
+    apk add --no-cache ca-certificates
 
 WORKDIR /app
 
@@ -28,11 +29,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
 RUN adduser -u 1001 --disabled-password --gecos "" appuser
 COPY --chown=appuser --from=builder /app .
 
+COPY docker_cacert_entrypoint.sh /docker_cacert_entrypoint.sh
 RUN echo '#!/bin/sh' > /docker_entrypoint.sh && \
     echo 'set -e' >> /docker_entrypoint.sh && \
+    echo '. /docker_cacert_entrypoint.sh' >> /docker_entrypoint.sh && \
     echo '. ./.venv/bin/activate' >> /docker_entrypoint.sh && \
     echo 'exec "$@"' >> /docker_entrypoint.sh && \
-    chmod +x /docker_entrypoint.sh
+    chmod +x /docker_entrypoint.sh /docker_cacert_entrypoint.sh
 
 EXPOSE 5000
 

--- a/docker_cacert_entrypoint.sh
+++ b/docker_cacert_entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+# Sourced from docker_entrypoint.sh to configure CA certificates.
+# Set USE_SYSTEM_CA_CERTS=1 and mount custom .crt files under /certificates/
+# to merge them with the system CA bundle and export SSL_CERT_FILE.
+if [ "${USE_SYSTEM_CA_CERTS}" = "1" ]; then
+    _MERGED_CA_BUNDLE=$(mktemp)
+    cat /etc/ssl/certs/ca-certificates.crt > "${_MERGED_CA_BUNDLE}"
+    for _cert_file in /certificates/*.crt; do
+        [ -f "${_cert_file}" ] && cat "${_cert_file}" >> "${_MERGED_CA_BUNDLE}"
+    done
+    export SSL_CERT_FILE="${_MERGED_CA_BUNDLE}"
+    unset _MERGED_CA_BUNDLE _cert_file
+fi

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This folder contains technical documentation for the Quick Apps backend.
 | [File Transfer](file_transfer.md)             | How Quick Apps handles file parameters in tool calls (`file:{prefix}::` convention, preprocessing pipeline).                         |
 | [Agent Skills](skills.md)                     | How to create and manage reusable agent skills (directory layout, metadata).                                                         |
 | [Time Awareness](time_awareness.md)           | How the agent knows the current time and reasons about data freshness.                                                               |
+| [Custom CA Certificates](custom_ca_certificates.md) | How to trust a private/corporate Root CA when running behind a TLS-intercepting proxy (`USE_SYSTEM_CA_CERTS`).               |
 
 ## Preview Features
 

--- a/docs/custom_ca_certificates.md
+++ b/docs/custom_ca_certificates.md
@@ -1,0 +1,52 @@
+# Custom CA Certificates
+
+This document describes how to configure Quick Apps to trust a private or corporate Root CA
+when running behind a TLS-intercepting proxy.
+
+## Overview
+
+When Quick Apps is deployed behind a corporate HTTPS proxy that terminates TLS and re-signs
+traffic with an internal Root CA, outbound connections fail with:
+
+```
+ConnectError: SSL: CERTIFICATE_VERIFY_FAILED
+```
+
+The container ships with a standard Alpine CA bundle that does not include private CAs.
+The `USE_SYSTEM_CA_CERTS` mechanism solves this by merging a custom CA certificate into
+the bundle at container startup, before the application process starts.
+
+## Usage
+
+1. Obtain the corporate Root CA certificate in PEM format (`.crt` extension).
+2. Mount it into the container under `/certificates/`.
+3. Set `USE_SYSTEM_CA_CERTS=1`.
+
+**Docker Compose example:**
+
+```yaml
+services:
+  quickapps:
+    environment:
+      USE_SYSTEM_CA_CERTS: "1"
+    volumes:
+      - /path/to/corporate-ca.crt:/certificates/corporate-ca.crt:ro
+```
+
+Multiple certificates are supported — every `*.crt` file found under `/certificates/` is
+merged into the bundle.
+
+## How It Works
+
+The `docker_cacert_entrypoint.sh` script is sourced by the container entrypoint before the
+Python process starts. When `USE_SYSTEM_CA_CERTS=1`:
+
+1. A temporary file is created containing the Alpine system CA bundle
+   (`/etc/ssl/certs/ca-certificates.crt`).
+2. All `*.crt` files from `/certificates/` are appended to it.
+3. `SSL_CERT_FILE` is exported pointing to the merged bundle.
+
+`httpx` (the HTTP client used throughout the app) reads `SSL_CERT_FILE` automatically, so
+no application code changes are required.
+
+When `USE_SYSTEM_CA_CERTS` is not set the script is a no-op and existing behaviour is unchanged.


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #335

### Description of changes

<!-- Please explain the changes you made right below this line. -->
A new docker_cacert_entrypoint.sh script is sourced at container startup. When
  USE_SYSTEM_CA_CERTS=1, it merges the Alpine system CA bundle with any *.crt
  files mounted under /certificates/ and exports SSL_CERT_FILE pointing to the
  result. httpx (used for all outbound HTTP in the app) reads this variable
  automatically — no application code changes are needed.

  The feature is opt-in: without USE_SYSTEM_CA_CERTS=1 the script is a no-op and
  existing deployments are unaffected.

  Changes

  - docker_cacert_entrypoint.sh — new script that builds the merged CA bundle
  - Dockerfile — installs ca-certificates in the runtime stage, copies and
  sources the script via the container entrypoint
  - .gitattributes — enforces LF line endings for *.sh files to prevent CRLF
  issues on Windows checkouts
  - docs/custom_ca_certificates.md — usage and technical reference for the
  feature
  - docs/README.md — link to the new doc

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
