### PR TITLE
fix: file-tools 404 handling, path leakage, and overwrite semantics

### DIFF
--- a/docs/generated-internal-tools.json
+++ b/docs/generated-internal-tools.json
@@ -38,7 +38,7 @@
       },
       "overwrite": {
         "type": "boolean",
-        "description": "If true, replace an existing destination. Default: false."
+        "description": "Default and strongly preferred: false. Leave false unless a previous copy failed because the destination exists AND the user has explicitly approved replacing it. Never set true on your own."
       }
     },
     "required": [
@@ -141,7 +141,7 @@
       },
       "overwrite": {
         "type": "boolean",
-        "description": "If true, replace an existing destination. Default: false."
+        "description": "Default and strongly preferred: false. Leave false unless a previous move failed because the destination exists AND the user has explicitly approved replacing it. Never set true on your own."
       }
     },
     "required": [
@@ -214,7 +214,7 @@
   },
   {
     "name": "internal_file_write",
-    "description": "Create or overwrite a UTF-8 text file under the agent's home dir. Relative path only (absolute files/... URLs are rejected). Nested paths allowed; '..' rejected. Default content_type is text/plain. overwrite=False fails on collision; overwrite=True replaces with ETag guard.",
+    "description": "Create a UTF-8 text file under the agent's home dir. Relative path only (absolute files/... URLs are rejected). Nested paths allowed; '..' rejected. Default content_type is text/plain. Always call with overwrite=false first. If it reports the file already exists, ask the user whether to replace it and only retry with overwrite=true once they approve — never set overwrite=true on your own.",
     "properties": {
       "path": {
         "display": {
@@ -237,7 +237,7 @@
       },
       "overwrite": {
         "type": "boolean",
-        "description": "If true, replace an existing file. Default: false."
+        "description": "Default and strongly preferred: false. Leave false unless a previous write failed because the file exists AND the user has explicitly approved replacing it. When true, the file is created if missing or replaced if it exists."
       }
     },
     "required": [

--- a/src/quickapp/dial_core_services/dial_file_service.py
+++ b/src/quickapp/dial_core_services/dial_file_service.py
@@ -1,10 +1,10 @@
 import logging
 from collections import deque
 from pathlib import PurePosixPath
-from typing import Literal
+from typing import Literal, NoReturn
 
 from aidial_client import AsyncDial
-from aidial_client._exception import ResourceNotFoundError
+from aidial_client._exception import DialException, ResourceNotFoundError
 from aidial_client.types.metadata import FileItem, FileMetadata
 from injector import inject
 from pydantic import BaseModel, ConfigDict
@@ -41,6 +41,32 @@ class DialFileService:
     async def my_appdata_home(self) -> PurePosixPath | None:
         return await self.__dial_client.my_appdata_home()
 
+    @staticmethod
+    def _reraise_404_as_not_found(exc: DialException) -> NoReturn:
+        """Normalize a 404 to ResourceNotFoundError.
+
+        The aidial_client `metadata` resource (used directly by `list_folder` and
+        indirectly by `files.get_metadata`) registers no `on_http_error` handler, so a 404
+        surfaces as a base `DialException`, not `ResourceNotFoundError`. Re-raise it as
+        `ResourceNotFoundError` so callers' not-found handling works uniformly.
+        """
+        if exc.status_code == 404 and not isinstance(exc, ResourceNotFoundError):
+            raise ResourceNotFoundError(message=exc.message) from exc
+        raise exc
+
+    async def _get_metadata(self, url: str) -> FileMetadata:
+        """Fetch file or folder metadata, normalizing a 404 to ResourceNotFoundError.
+
+        Calls metadata.get with the URL verbatim (rather than files.get_metadata, which
+        runs it through get_api_path) so a trailing slash is preserved — DIAL Core
+        distinguishes a folder (trailing '/', returns .items) from a file. Callers always
+        pass pre-resolved relative 'files/...' URLs, so get_api_path normalization is moot.
+        """
+        try:
+            return await self.__dial_client.metadata.get("files", url)
+        except DialException as e:
+            self._reraise_404_as_not_found(e)
+
     async def download_file(self, file_url: str) -> tuple[bytes, FileMetadata | None]:
         logger.debug(f"File url to download url:{file_url}")
         file_data = self.__state_holder.get_file_data(url=file_url)
@@ -48,7 +74,7 @@ class DialFileService:
             return file_data, self.__state_holder.get_file_metadata(file_url)
         try:
             logger.debug(f"Downloading file:{file_url}")
-            metadata = await self.__dial_client.files.get_metadata(file_url)
+            metadata = await self._get_metadata(file_url)
             size = metadata.content_length or 0
             if size > self.__content_size_limit:
                 raise ValueError(
@@ -89,7 +115,7 @@ class DialFileService:
             uploaded_url = await self._upload_text(url, content, content_type, if_none_match="*")
         else:
             try:
-                metadata = await self.__dial_client.files.get_metadata(url)
+                metadata = await self._get_metadata(url)
                 etag: str | None = metadata.etag
             except ResourceNotFoundError:
                 etag = None
@@ -138,7 +164,7 @@ class DialFileService:
         queue: deque[tuple[str, int]] = deque([(folder_url, 1)])
         while queue:
             current_url, depth = queue.popleft()
-            metadata = await self.__dial_client.metadata.get("files", current_url)
+            metadata = await self._get_metadata(current_url)
             if metadata.node_type != "FOLDER":
                 raise ValueError(f"not a folder: {current_url}")
             items: list[FileItem] = metadata.items or []

--- a/src/quickapp/dial_core_services/dial_file_service.py
+++ b/src/quickapp/dial_core_services/dial_file_service.py
@@ -101,30 +101,20 @@ class DialFileService:
         Behaviour:
           * `if_match` given: upload with `If-Match` (caller-driven concurrency
             check, used by the edit tool which already has the etag).
-          * `overwrite=False`: upload with `If-None-Match: *` (fail if the file
-            exists).
-          * `overwrite=True`: fetch current metadata; if the file exists, upload
-            with `If-Match: <etag>`; otherwise upload with `If-None-Match: *`.
+          * `overwrite=False`: upload with `If-None-Match: *` (create only — fail
+            if the file already exists).
+          * `overwrite=True`: upload unconditionally (create or replace). No
+            metadata round-trip, so a not-yet-existing file is simply created.
 
-        Raises `EtagMismatchError` on `If-None-Match`/`If-Match` failure; other
+        Raises `EtagMismatchError` on an `If-None-Match`/`If-Match` failure; other
         DIAL errors propagate unchanged. Cache is invalidated on success.
         """
         if if_match is not None:
             uploaded_url = await self._upload_text(url, content, content_type, if_match=if_match)
-        elif not overwrite:
-            uploaded_url = await self._upload_text(url, content, content_type, if_none_match="*")
+        elif overwrite:
+            uploaded_url = await self._upload_text(url, content, content_type)
         else:
-            try:
-                metadata = await self._get_metadata(url)
-                etag: str | None = metadata.etag
-            except ResourceNotFoundError:
-                etag = None
-            if etag is None:
-                uploaded_url = await self._upload_text(
-                    url, content, content_type, if_none_match="*"
-                )
-            else:
-                uploaded_url = await self._upload_text(url, content, content_type, if_match=etag)
+            uploaded_url = await self._upload_text(url, content, content_type, if_none_match="*")
         self.invalidate_cache(url)
         return uploaded_url
 

--- a/src/quickapp/dial_files_tooling/_base_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_base_file_tool.py
@@ -2,7 +2,7 @@ import logging
 from abc import ABC
 from typing import Any
 
-from aidial_client._exception import DialException
+from aidial_client._exception import DialException, ResourceNotFoundError
 from aidial_client.types.metadata import FileMetadata
 from injector import AssistedBuilder, inject
 
@@ -50,6 +50,10 @@ class _DialFileTool(StagedBaseTool, ABC):
     ) -> tuple[str, FileMetadata | None]:
         try:
             data, metadata = await self._dial_file_service.download_file(file_url)
+        except ResourceNotFoundError as e:
+            raise InvalidToolCallParameterException(
+                "path", f"file not found: {display_path}"
+            ) from e
         except DialException as e:
             self._check_permission_denied(e, display_path)
             raise InvalidToolCallParameterException("path", f"File download failed: {e}") from e

--- a/src/quickapp/dial_files_tooling/_copy_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_copy_file_tool.py
@@ -38,7 +38,7 @@ class _CopyFileTool(_DialFileTool):
                 f"destination already exists: {dest_display}; pass overwrite=True to replace",
             ) from e
         except DialException as e:
-            self._check_permission_denied(e, source_url, parameter_name="source")
+            self._check_permission_denied(e, source, parameter_name="source")
             raise
 
         result = ToolCallResult(content=f"Copied to: {dest_display}", content_type="text/plain")

--- a/src/quickapp/dial_files_tooling/_copy_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_copy_file_tool.py
@@ -35,7 +35,8 @@ class _CopyFileTool(_DialFileTool):
         except EtagMismatchError as e:
             raise InvalidToolCallParameterException(
                 "destination",
-                f"destination already exists: {dest_display}; pass overwrite=True to replace",
+                f"destination already exists: {dest_display}. Ask the user whether to "
+                "replace it; only if they approve, retry with overwrite=True.",
             ) from e
         except DialException as e:
             self._check_permission_denied(e, source, parameter_name="source")

--- a/src/quickapp/dial_files_tooling/_list_files_tool.py
+++ b/src/quickapp/dial_files_tooling/_list_files_tool.py
@@ -51,19 +51,37 @@ class _ListFilesTool(_DialFileTool):
         if max_depth < 1 or max_depth > _MAX_DEPTH:
             raise InvalidToolCallParameterException("max_depth", f"must be in [1, {_MAX_DEPTH}]")
 
-        if not path.endswith("/"):
-            path = path + "/"
+        # Root-of-home references ('', '.', './', '/') list the agent home directory itself.
+        # They bypass _resolve_appdata_url, whose validation rejects a leading '/' and would
+        # mangle './' into 'files/.../.'.
+        if path.strip() in ("", ".", "./", "/"):
+            folder_url = await self._resolve_home_dir()
+        else:
+            if not path.endswith("/"):
+                path = path + "/"
+            folder_url = await self._resolve_appdata_url(path)
 
-        folder_url = await self._resolve_appdata_url(path)
+        try:
+            home = await self._resolve_home_dir()
+        except InvalidToolCallParameterException:
+            home = None
+        is_home_root = folder_url == home
 
         try:
             entries = await self._dial_file_service.list_folder(folder_url, max_depth=max_depth)
         except ResourceNotFoundError as e:
-            raise InvalidToolCallParameterException(
-                "path", f"folder not found: {folder_url}"
-            ) from e
+            # A 404 on the agent home root means "nothing written yet" → empty listing.
+            # A 404 on a user-specified subfolder is a genuine not-found.
+            if is_home_root:
+                entries = []
+            else:
+                display = await self._to_display_path(folder_url)
+                raise InvalidToolCallParameterException(
+                    "path", f"folder not found: {display}"
+                ) from e
         except ValueError as e:
-            raise InvalidToolCallParameterException("path", f"not a folder: {folder_url}") from e
+            display = await self._to_display_path(folder_url)
+            raise InvalidToolCallParameterException("path", f"not a folder: {display}") from e
         except DialException as e:
             self._check_permission_denied(e, path)
             raise

--- a/src/quickapp/dial_files_tooling/_list_files_tool.py
+++ b/src/quickapp/dial_files_tooling/_list_files_tool.py
@@ -51,28 +51,14 @@ class _ListFilesTool(_DialFileTool):
         if max_depth < 1 or max_depth > _MAX_DEPTH:
             raise InvalidToolCallParameterException("max_depth", f"must be in [1, {_MAX_DEPTH}]")
 
-        # Root-of-home references ('', '.', './', '/') list the agent home directory itself.
-        # They bypass _resolve_appdata_url, whose validation rejects a leading '/' and would
-        # mangle './' into 'files/.../.'.
-        if path.strip() in ("", ".", "./", "/"):
-            folder_url = await self._resolve_home_dir()
-        else:
-            if not path.endswith("/"):
-                path = path + "/"
-            folder_url = await self._resolve_appdata_url(path)
-
-        try:
-            home = await self._resolve_home_dir()
-        except InvalidToolCallParameterException:
-            home = None
-        is_home_root = folder_url == home
+        folder_url = await self._resolve_folder_url(path)
 
         try:
             entries = await self._dial_file_service.list_folder(folder_url, max_depth=max_depth)
         except ResourceNotFoundError as e:
             # A 404 on the agent home root means "nothing written yet" → empty listing.
             # A 404 on a user-specified subfolder is a genuine not-found.
-            if is_home_root:
+            if self._is_root_reference(path):
                 entries = []
             else:
                 display = await self._to_display_path(folder_url)
@@ -93,3 +79,21 @@ class _ListFilesTool(_DialFileTool):
         if stage_wrapper:
             stage_wrapper.add_result(result)
         return result
+
+    @staticmethod
+    def _is_root_reference(path: str) -> bool:
+        """Whether the path denotes the agent home directory itself ('', '.', './', '/')."""
+        return path.strip() in ("", ".", "./", "/")
+
+    async def _resolve_folder_url(self, path: str) -> str:
+        """Resolve a folder path to a 'files/...' URL ending in '/'.
+
+        Root-of-home references resolve to the home directory directly, bypassing
+        _resolve_appdata_url, whose validation rejects a leading '/' and would mangle
+        './' into 'files/.../.'.
+        """
+        if self._is_root_reference(path):
+            return await self._resolve_home_dir()
+        if not path.endswith("/"):
+            path = path + "/"
+        return await self._resolve_appdata_url(path)

--- a/src/quickapp/dial_files_tooling/_move_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_move_file_tool.py
@@ -39,7 +39,7 @@ class _MoveFileTool(_DialFileTool):
                 f"destination already exists: {dest_display}; pass overwrite=True to replace",
             ) from e
         except DialException as e:
-            self._check_permission_denied(e, source_url, parameter_name="source")
+            self._check_permission_denied(e, source, parameter_name="source")
             raise
 
         result = ToolCallResult(content=f"Moved to: {dest_display}", content_type="text/plain")

--- a/src/quickapp/dial_files_tooling/_move_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_move_file_tool.py
@@ -36,7 +36,8 @@ class _MoveFileTool(_DialFileTool):
         except EtagMismatchError as e:
             raise InvalidToolCallParameterException(
                 "destination",
-                f"destination already exists: {dest_display}; pass overwrite=True to replace",
+                f"destination already exists: {dest_display}. Ask the user whether to "
+                "replace it; only if they approve, retry with overwrite=True.",
             ) from e
         except DialException as e:
             self._check_permission_denied(e, source, parameter_name="source")

--- a/src/quickapp/dial_files_tooling/_tool_configs.py
+++ b/src/quickapp/dial_files_tooling/_tool_configs.py
@@ -140,10 +140,12 @@ WRITE_FILE_TOOL_CONFIG = InternalTool(
         function=OpenAiToolFunction(
             name=f"{TOOL_NAME_PREFIX}write",
             description=(
-                "Create or overwrite a UTF-8 text file under the agent's home dir. "
+                "Create a UTF-8 text file under the agent's home dir. "
                 "Relative path only (absolute files/... URLs are rejected). "
                 "Nested paths allowed; '..' rejected. Default content_type is text/plain. "
-                "overwrite=False fails on collision; overwrite=True replaces with ETag guard."
+                "Always call with overwrite=false first. If it reports the file already "
+                "exists, ask the user whether to replace it and only retry with "
+                "overwrite=true once they approve — never set overwrite=true on your own."
             ),
             parameters=OpenAiToolFunctionParameters(
                 type=JsonTypeEnum.object,
@@ -170,7 +172,12 @@ WRITE_FILE_TOOL_CONFIG = InternalTool(
                     ),
                     "overwrite": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.boolean,
-                        description="If true, replace an existing file. Default: false.",
+                        description=(
+                            "Default and strongly preferred: false. Leave false unless a "
+                            "previous write failed because the file exists AND the user has "
+                            "explicitly approved replacing it. When true, the file is created "
+                            "if missing or replaced if it exists."
+                        ),
                     ),
                 },
                 required=["path", "content"],
@@ -271,7 +278,11 @@ COPY_FILE_TOOL_CONFIG = InternalTool(
                     ),
                     "overwrite": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.boolean,
-                        description="If true, replace an existing destination. Default: false.",
+                        description=(
+                            "Default and strongly preferred: false. Leave false unless a "
+                            "previous copy failed because the destination exists AND the user "
+                            "has explicitly approved replacing it. Never set true on your own."
+                        ),
                     ),
                 },
                 required=["source", "destination"],
@@ -310,7 +321,11 @@ MOVE_FILE_TOOL_CONFIG = InternalTool(
                     ),
                     "overwrite": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.boolean,
-                        description="If true, replace an existing destination. Default: false.",
+                        description=(
+                            "Default and strongly preferred: false. Leave false unless a "
+                            "previous move failed because the destination exists AND the user "
+                            "has explicitly approved replacing it. Never set true on your own."
+                        ),
                     ),
                 },
                 required=["source", "destination"],

--- a/src/quickapp/dial_files_tooling/_write_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_write_file_tool.py
@@ -35,13 +35,10 @@ class _WriteFileTool(_DialFileTool):
                 overwrite=overwrite,
             )
         except EtagMismatchError as e:
-            if overwrite:
-                raise InvalidToolCallParameterException(
-                    "path", "file changed concurrently; re-read and retry"
-                ) from e
             raise InvalidToolCallParameterException(
                 "path",
-                f"file already exists: {display_path}; pass overwrite=True to replace",
+                f"file already exists: {display_path}. Ask the user whether to replace it; "
+                "only if they approve, retry with overwrite=True.",
             ) from e
         except DialException as e:
             self._check_permission_denied(e, display_path)

--- a/src/tests/unit_tests/dial_core_services_tests/test_dial_file_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_dial_file_service.py
@@ -183,20 +183,20 @@ class TestWriteFile:
         assert result == "files/b/generated-files/notes.md"
 
     @pytest.mark.asyncio
-    async def test_overwrite_creates_when_missing_via_base_404(self):
-        # overwrite=True fetches current metadata; a missing file 404s as a base
-        # DialException (via metadata.get). It must be treated as "not there yet"
-        # and uploaded with If-None-Match: *, not error out.
+    async def test_overwrite_uploads_unconditionally(self):
+        # overwrite=True is a deliberate create-or-replace: upload with no ETag
+        # conditions and no metadata round-trip, so a not-yet-existing file is
+        # simply created rather than erroring out.
         mock_client = _make_mock_dial_client(upload_url="files/b/new.txt")
-        mock_client.metadata.get = AsyncMock(side_effect=DialException(message="", status_code=404))
         svc = _make_service(dial_client=mock_client)
 
         result = await svc.write_file(url="files/b/new.txt", content="hello", overwrite=True)
 
         assert result == "files/b/new.txt"
+        mock_client.metadata.get.assert_not_called()
         mock_client.files.upload.assert_awaited_once()
         call_kwargs = mock_client.files.upload.call_args.kwargs
-        assert call_kwargs.get("etag_if_none_match") == "*"
+        assert call_kwargs.get("etag_if_none_match") is None
         assert call_kwargs.get("etag_if_match") is None
 
 

--- a/src/tests/unit_tests/dial_core_services_tests/test_dial_file_service.py
+++ b/src/tests/unit_tests/dial_core_services_tests/test_dial_file_service.py
@@ -1,7 +1,7 @@
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
-from aidial_client._exception import EtagMismatchError
+from aidial_client._exception import DialException, EtagMismatchError, ResourceNotFoundError
 
 from quickapp.common.state_holder import StateHolder
 from quickapp.dial_core_services.dial_file_service import DialFileService
@@ -27,9 +27,12 @@ def _make_mock_dial_client(
     mock_download_result.aget_content = AsyncMock(return_value=file_content)
 
     mock_files = MagicMock()
-    mock_files.get_metadata = AsyncMock(return_value=mock_metadata)
     mock_files.download = AsyncMock(return_value=mock_download_result)
     mock_files.upload = AsyncMock(return_value=mock_metadata)
+
+    # The service fetches file/folder metadata via metadata.get (not files.get_metadata).
+    mock_metadata_resource = MagicMock()
+    mock_metadata_resource.get = AsyncMock(return_value=mock_metadata)
 
     mock_bucket = MagicMock()
     mock_bucket.appdata = None
@@ -40,6 +43,7 @@ def _make_mock_dial_client(
 
     mock_dial_client = MagicMock()
     mock_dial_client.files = mock_files
+    mock_dial_client.metadata = mock_metadata_resource
     mock_dial_client.resource_permissions = mock_resource_permissions
     mock_dial_client.bucket = MagicMock()
     mock_dial_client.bucket.get_raw = AsyncMock(return_value=mock_bucket)
@@ -75,7 +79,7 @@ class TestDownloadFile:
 
         assert data == file_bytes
         assert metadata is not None
-        mock_dial_client.files.get_metadata.assert_awaited_once_with("files/test.txt")
+        mock_dial_client.metadata.get.assert_awaited_once_with("files", "files/test.txt")
         mock_dial_client.files.download.assert_awaited_once_with("files/test.txt")
 
     @pytest.mark.asyncio
@@ -90,7 +94,7 @@ class TestDownloadFile:
 
         assert data == b"cached content"
         assert metadata is stored_metadata
-        mock_dial_client.files.get_metadata.assert_not_called()
+        mock_dial_client.metadata.get.assert_not_called()
         mock_dial_client.files.download.assert_not_called()
 
     @pytest.mark.asyncio
@@ -113,6 +117,17 @@ class TestDownloadFile:
 
         with pytest.raises(ValueError, match="exceeds the limit of 1024"):
             await svc.download_file("files/medium.bin")
+
+    @pytest.mark.asyncio
+    async def test_base_dialexception_404_raises_resource_not_found(self):
+        # metadata.get has no on_http_error handler, so a real 404 arrives as a base
+        # DialException. It must be normalized to ResourceNotFoundError.
+        mock_client = _make_mock_dial_client()
+        mock_client.metadata.get = AsyncMock(side_effect=DialException(message="", status_code=404))
+        svc = _make_service(dial_client=mock_client)
+
+        with pytest.raises(ResourceNotFoundError):
+            await svc.download_file("files/missing.txt")
 
 
 class TestWriteFile:
@@ -167,6 +182,36 @@ class TestWriteFile:
         )
         assert result == "files/b/generated-files/notes.md"
 
+    @pytest.mark.asyncio
+    async def test_overwrite_creates_when_missing_via_base_404(self):
+        # overwrite=True fetches current metadata; a missing file 404s as a base
+        # DialException (via metadata.get). It must be treated as "not there yet"
+        # and uploaded with If-None-Match: *, not error out.
+        mock_client = _make_mock_dial_client(upload_url="files/b/new.txt")
+        mock_client.metadata.get = AsyncMock(side_effect=DialException(message="", status_code=404))
+        svc = _make_service(dial_client=mock_client)
+
+        result = await svc.write_file(url="files/b/new.txt", content="hello", overwrite=True)
+
+        assert result == "files/b/new.txt"
+        mock_client.files.upload.assert_awaited_once()
+        call_kwargs = mock_client.files.upload.call_args.kwargs
+        assert call_kwargs.get("etag_if_none_match") == "*"
+        assert call_kwargs.get("etag_if_match") is None
+
+
+class TestListFolder:
+    @pytest.mark.asyncio
+    async def test_base_dialexception_404_raises_resource_not_found(self):
+        # list_folder calls metadata.get directly; a missing folder 404s as a base
+        # DialException, which must be normalized so callers can treat it as not-found.
+        mock_client = _make_mock_dial_client()
+        mock_client.metadata.get = AsyncMock(side_effect=DialException(message="", status_code=404))
+        svc = _make_service(dial_client=mock_client)
+
+        with pytest.raises(ResourceNotFoundError):
+            await svc.list_folder("files/appbucket/")
+
 
 class TestInvalidateCache:
     @pytest.mark.asyncio
@@ -182,7 +227,7 @@ class TestInvalidateCache:
         # Now invalidate and change what the mock returns
         svc.invalidate_cache("files/b/f.txt")
         mock_client.files.download.return_value.aget_content = AsyncMock(return_value=file_bytes_v2)
-        mock_client.files.get_metadata.return_value.content_length = 100
+        mock_client.metadata.get.return_value.content_length = 100
 
         second, _ = await svc.download_file("files/b/f.txt")
         assert second == file_bytes_v2

--- a/src/tests/unit_tests/dial_files_tooling/test_copy_file_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_copy_file_tool.py
@@ -88,3 +88,6 @@ class TestCopyFile:
         with pytest.raises(InvalidToolCallParameterException) as exc:
             await tool._run_in_stage_async(stage_wrapper=None, source="a.md", destination="b.md")
         assert exc.value.parameter_name == "source"
+        # The message shows the user-facing source, not the resolved internal appdata URL.
+        assert "access denied: a.md" in exc.value.message
+        assert "appbucket" not in exc.value.message

--- a/src/tests/unit_tests/dial_files_tooling/test_copy_file_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_copy_file_tool.py
@@ -63,6 +63,7 @@ class TestCopyFile:
         with pytest.raises(InvalidToolCallParameterException) as exc:
             await tool._run_in_stage_async(stage_wrapper=None, source="a.md", destination="b.md")
         assert exc.value.parameter_name == "destination"
+        assert "Ask the user" in exc.value.message
         assert "overwrite=True" in exc.value.message
 
     @pytest.mark.asyncio

--- a/src/tests/unit_tests/dial_files_tooling/test_edit_file_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_edit_file_tool.py
@@ -1,7 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
-from aidial_client._exception import EtagMismatchError
+from aidial_client._exception import EtagMismatchError, ResourceNotFoundError
 
 from quickapp.common.exceptions import InvalidToolCallParameterException
 from quickapp.dial_files_tooling._edit_file_tool import _EditFileTool
@@ -37,6 +37,17 @@ class TestEditFile:
             stage_wrapper=None, path="r.md", old_string="bar", new_string="qux"
         )
         tool._dial_file_service.download_file.assert_awaited_once_with("files/appbucket/r.md")
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises_friendly_not_found(self):
+        tool = _make_tool()
+        tool._dial_file_service.download_file.side_effect = ResourceNotFoundError(message="404")
+        with pytest.raises(InvalidToolCallParameterException) as exc:
+            await tool._run_in_stage_async(
+                stage_wrapper=None, path="missing.md", old_string="bar", new_string="qux"
+            )
+        assert exc.value.parameter_name == "path"
+        assert "file not found" in exc.value.message
 
     @pytest.mark.asyncio
     async def test_absolute_url_rejected(self):

--- a/src/tests/unit_tests/dial_files_tooling/test_list_files_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_list_files_tool.py
@@ -61,6 +61,9 @@ class TestListFiles:
             await tool._run_in_stage_async(stage_wrapper=None, path="missing/")
         assert exc.value.parameter_name == "path"
         assert "folder not found" in exc.value.message
+        # The message shows the user-facing relative path, not the internal appdata URL.
+        assert "folder not found: missing/" in exc.value.message
+        assert "appbucket" not in exc.value.message
 
     @pytest.mark.asyncio
     async def test_not_a_folder_raises(self):
@@ -108,3 +111,34 @@ class TestListFiles:
         tool = _make_tool(entries=[])
         result = await tool._run_in_stage_async(stage_wrapper=None, path="reports/")
         assert result.content == "(empty folder)"
+
+    @pytest.mark.asyncio
+    async def test_root_path_missing_renders_empty(self):
+        # The agent home dir doesn't exist yet (nothing written) → empty listing, not an error.
+        tool = _make_tool(side_effect=ResourceNotFoundError(message="404"))
+        result = await tool._run_in_stage_async(stage_wrapper=None, path="./")
+        assert result.content == "(empty folder)"
+        tool._dial_file_service.list_folder.assert_awaited_once_with(
+            "files/appbucket/", max_depth=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_root_slash_missing_renders_empty(self):
+        tool = _make_tool(side_effect=ResourceNotFoundError(message="404"))
+        result = await tool._run_in_stage_async(stage_wrapper=None, path="/")
+        assert result.content == "(empty folder)"
+        tool._dial_file_service.list_folder.assert_awaited_once_with(
+            "files/appbucket/", max_depth=1
+        )
+
+    @pytest.mark.asyncio
+    async def test_root_path_lists_home_when_present(self):
+        entries = [
+            FolderEntry(url="files/appbucket/summary.md", is_folder=False, size=10),
+        ]
+        tool = _make_tool(entries=entries)
+        result = await tool._run_in_stage_async(stage_wrapper=None, path=".")
+        assert "summary.md" in result.content
+        tool._dial_file_service.list_folder.assert_awaited_once_with(
+            "files/appbucket/", max_depth=1
+        )

--- a/src/tests/unit_tests/dial_files_tooling/test_move_file_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_move_file_tool.py
@@ -60,6 +60,8 @@ class TestMoveFile:
         with pytest.raises(InvalidToolCallParameterException) as exc:
             await tool._run_in_stage_async(stage_wrapper=None, source="a.md", destination="b.md")
         assert exc.value.parameter_name == "destination"
+        assert "Ask the user" in exc.value.message
+        assert "overwrite=True" in exc.value.message
 
     @pytest.mark.asyncio
     async def test_source_not_found_raises(self):

--- a/src/tests/unit_tests/dial_files_tooling/test_read_file_lines_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_read_file_lines_tool.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import pytest
+from aidial_client._exception import ResourceNotFoundError
 
 from quickapp.common.exceptions import InvalidToolCallParameterException
 from quickapp.dial_files_tooling._read_file_lines_tool import _ReadFileLinesTool
@@ -69,3 +70,14 @@ class TestReadFileLines:
                 stage_wrapper=None, path="f.txt", start_line=5, end_line=2
             )
         assert exc.value.parameter_name == "end_line"
+
+    @pytest.mark.asyncio
+    async def test_missing_file_raises_friendly_not_found(self):
+        tool = _make_tool()
+        tool._dial_file_service.download_file.side_effect = ResourceNotFoundError(message="404")
+        with pytest.raises(InvalidToolCallParameterException) as exc:
+            await tool._run_in_stage_async(
+                stage_wrapper=None, path="missing.txt", start_line=0, end_line=2
+            )
+        assert exc.value.parameter_name == "path"
+        assert "file not found" in exc.value.message

--- a/src/tests/unit_tests/dial_files_tooling/test_write_file_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_write_file_tool.py
@@ -1,4 +1,4 @@
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import MagicMock
 
 import pytest
 from aidial_client._exception import EtagMismatchError
@@ -78,29 +78,20 @@ class TestWriteFile:
         assert call_kwargs["content_type"] == "text/csv"
 
     @pytest.mark.asyncio
-    async def test_overwrite_false_collision_raises(self):
+    async def test_overwrite_false_collision_asks_user(self):
         tool = _make_tool(raise_on_write=EtagMismatchError(message="exists"))
         with pytest.raises(InvalidToolCallParameterException) as exc:
             await tool._run_in_stage_async(stage_wrapper=None, path="reports/x.md", content="x")
         assert exc.value.parameter_name == "path"
+        # Guides the model to seek user approval before retrying with overwrite=True.
+        assert "Ask the user" in exc.value.message
         assert "overwrite=True" in exc.value.message
 
     @pytest.mark.asyncio
-    async def test_overwrite_true_concurrent_modification_raises(self):
-        service = make_service()
-        service.write_file = AsyncMock(side_effect=EtagMismatchError(message="412"))
-        tool = _WriteFileTool(
-            stage_wrapper_builder=MagicMock(),
-            tool_config=WRITE_FILE_TOOL_CONFIG,
-            perf_timer=MagicMock(),
-            dial_file_service=service,
-            dial_files_config=make_config(),
-        )
-        with pytest.raises(InvalidToolCallParameterException) as exc:
-            await tool._run_in_stage_async(
-                stage_wrapper=None, path="r.md", content="x", overwrite=True
-            )
-        assert "concurrently" in exc.value.message
+    async def test_overwrite_true_forwarded_to_service(self):
+        tool = _make_tool()
+        await tool._run_in_stage_async(stage_wrapper=None, path="r.md", content="x", overwrite=True)
+        assert tool._dial_file_service.write_file.call_args.kwargs["overwrite"] is True
 
     @pytest.mark.asyncio
     async def test_appdata_missing_raises(self):


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #345

### Description of changes

Fixes the DIAL file tools' handling of missing resources and tightens overwrite semantics. Four changes (one per commit):

**1. Root app path & 404 error handling (`69b4e1b`)**
- Normalize 404s at the service layer. `metadata.get` (and `files.get_metadata`, which delegates to it) register no `on_http_error` handler, so a 404 surfaced as a base `DialException` rather than `ResourceNotFoundError`. New `_reraise_404_as_not_found` + `_get_metadata` helpers normalize it, and `download_file` / `write_file` / `list_folder` all route through them.
- **List files**: root-of-home references (`''`, `.`, `./`, `/`) now list the agent home directory itself; a 404 on the home root renders `(empty folder)` (nothing written yet) instead of erroring, while a genuinely-missing subfolder still gets a friendly "folder not found". Error messages show the relative display path, not the internal appdata URL.
- **Read / Edit / Search**: a missing file now raises a friendly "file not found" instead of leaking a raw exception repr.

**2. Display only relative path (`40e1ee2`)**
- `copy` / `move` permission-denied messages now show the user-facing `source` instead of the resolved internal `files/{bucket}/…` URL.

**3. Simplify list tool (`59c587d`)**
- Extract `_is_root_reference` predicate and `_resolve_folder_url` helper; drop the defensive home-dir re-resolution. Pure refactor.

**4. Overwrite=true creates missing files; steer LLM to ask before replacing (`76de6b7`)**
- `write_file` `overwrite=true` now does a single **unconditional upload** (create if missing, replace if present), removing the metadata round-trip that previously failed when the model called `overwrite=true` on a not-yet-existing file. The now-dead "changed concurrently" branch in the write tool is removed.
- Tool and `overwrite`-param descriptions (write / copy / move) steer the LLM to default to `overwrite=false` and only retry with `overwrite=true` after a collision **and** explicit user approval. Collision messages instruct the model to ask the user first.

### Screenshots

#### Read absent file
<img width="2168" height="1401" alt="Screenshot 2026-06-04 at 18 32 35" src="https://github.com/user-attachments/assets/c7e545cd-c403-4564-8ca7-2ffcab8c8efa" />

#### List absent root dir
<img width="2168" height="1401" alt="Screenshot 2026-06-04 at 18 31 23" src="https://github.com/user-attachments/assets/440925f4-aa18-4760-b421-0519f05ee98b" />

#### Write a new file using overwrite: true
<img width="2168" height="1401" alt="Screenshot 2026-06-04 at 18 30 02" src="https://github.com/user-attachments/assets/b9bbb7af-3342-4fff-a1d8-6c05056eae36" />

#### List files in absent folder
<img width="2168" height="1401" alt="Screenshot 2026-06-04 at 18 37 57" src="https://github.com/user-attachments/assets/0272ab32-6031-471d-9be1-a7b4ae96a363" />



### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.