### PR TITLE
feat: wrap file tool stage content in code blocks and order params

### DIFF
--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -1480,8 +1480,14 @@
             }
           ],
           "default": null,
-          "description": "The format of the parameter value. If present then the value will be wrapped in ```{format} {parameter value}```.",
+          "description": "Controls whether the value is wrapped in a fenced code block (so it is shown verbatim, not rendered as markdown). None: render raw. Empty string: plain code block with no language. Non-empty: code block with that language (e.g. 'json'). The fence auto-sizes to survive backtick runs in the value.",
           "title": "Format"
+        },
+        "order": {
+          "default": 0,
+          "description": "Sort position of the parameter in the stage content. Lower values come first; equal values keep their original order. Use a positive value to push long parameters to the end.",
+          "title": "Order",
+          "type": "integer"
         }
       },
       "title": "FormattedParameterConfig",

--- a/docs/generated-internal-tools.json
+++ b/docs/generated-internal-tools.json
@@ -26,7 +26,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -55,7 +56,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -75,17 +77,36 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
         "description": "Relative path under the agent's home dir (e.g. 'reports/summary.md'). Absolute files/... URLs are rejected."
       },
       "old_string": {
+        "display": {
+          "stage": {
+            "ignore": false,
+            "ignore_parameter_name": false,
+            "show_value_in_stage_title": false,
+            "format": "",
+            "order": 1
+          }
+        },
         "type": "string",
         "description": "Exact substring to replace. Must occur exactly once. Include surrounding context to disambiguate."
       },
       "new_string": {
+        "display": {
+          "stage": {
+            "ignore": false,
+            "ignore_parameter_name": false,
+            "show_value_in_stage_title": false,
+            "format": "",
+            "order": 1
+          }
+        },
         "type": "string",
         "description": "Replacement text. May be empty to delete the match."
       }
@@ -109,7 +130,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -133,7 +155,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -157,7 +180,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -186,7 +210,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -216,7 +241,8 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
@@ -261,13 +287,23 @@
           "stage": {
             "ignore": false,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",
         "description": "Relative path under the agent's home dir. Forward slashes for nesting. Rejected: leading '/', '..' segments, '../' substring, empty segments, absolute 'files/...' URLs."
       },
       "content": {
+        "display": {
+          "stage": {
+            "ignore": false,
+            "ignore_parameter_name": false,
+            "show_value_in_stage_title": false,
+            "format": "",
+            "order": 1
+          }
+        },
         "type": "string",
         "description": "UTF-8 text content of the file."
       },
@@ -294,7 +330,8 @@
           "stage": {
             "ignore": true,
             "ignore_parameter_name": false,
-            "show_value_in_stage_title": true
+            "show_value_in_stage_title": true,
+            "order": 0
           }
         },
         "type": "string",

--- a/src/quickapp/common/base_stage_wrapper.py
+++ b/src/quickapp/common/base_stage_wrapper.py
@@ -1,3 +1,4 @@
+import re
 from abc import ABC, abstractmethod
 from types import TracebackType
 from typing import Any, cast
@@ -129,10 +130,18 @@ class BaseStageWrapper(ABC):
             else param_value
         )
 
-        if display_config.format:
-            result_value = f"\n```{display_config.format}\n{result_value}\n\n```"
+        if display_config.format is not None:
+            fence = self._code_fence(str(result_value))
+            result_value = f"\n{fence}{display_config.format}\n{result_value}\n{fence}\n"
 
         return str(result_value)
+
+    @staticmethod
+    def _code_fence(value: str) -> str:
+        # Open the fence with one more backtick than the longest backtick run in the
+        # value (minimum 3) so embedded code fences cannot close the wrapper early.
+        longest = max((len(match) for match in re.findall(r"`+", value)), default=0)
+        return "`" * max(3, longest + 1)
 
     def add_result(self, result: ToolCallResult) -> None:
         debug_info = self._build_debug_info_from_result(result)

--- a/src/quickapp/config/tools/display/paramenter.py
+++ b/src/quickapp/config/tools/display/paramenter.py
@@ -59,7 +59,20 @@ class FormattedParameterConfig(BaseModel):
     )
     format: str | None = Field(
         default=None,
-        description="The format of the parameter value. If present then the value will be wrapped in ```{format} {parameter value}```.",
+        description=(
+            "Controls whether the value is wrapped in a fenced code block (so it is "
+            "shown verbatim, not rendered as markdown). None: render raw. Empty string: "
+            "plain code block with no language. Non-empty: code block with that language "
+            "(e.g. 'json'). The fence auto-sizes to survive backtick runs in the value."
+        ),
+    )
+    order: int = Field(
+        default=0,
+        description=(
+            "Sort position of the parameter in the stage content. Lower values come "
+            "first; equal values keep their original order. Use a positive value to "
+            "push long parameters to the end."
+        ),
     )
 
 

--- a/src/quickapp/dial_files_tooling/_stage_wrapper.py
+++ b/src/quickapp/dial_files_tooling/_stage_wrapper.py
@@ -17,7 +17,7 @@ class _FileStageWrapper(TimedStageWrapper):
 
     def _get_formatted_parameters(self, parameters: dict[str, Any]) -> str:
         stage_params = "> #### Request:\n\r"
-        for param_name, param_value in parameters.items():
+        for param_name, param_value in self._order_parameters(parameters).items():
             if display_config := self._parameters_config_map.get(param_name):
                 if not display_config.ignore:
                     stage_params += self._get_parameter_name(param_name, display_config)
@@ -28,6 +28,15 @@ class _FileStageWrapper(TimedStageWrapper):
             else:
                 stage_params += f"***{param_name}:*** {param_value}\n\r"
         return stage_params
+
+    def _order_parameters(self, parameters: dict[str, Any]) -> dict[str, Any]:
+        # Sort by the configured `order` (default 0). sorted() is stable, so params
+        # sharing an order keep their original position.
+        def _order(param_name: str) -> int:
+            display_config = self._parameters_config_map.get(param_name)
+            return display_config.order if display_config else 0
+
+        return dict(sorted(parameters.items(), key=lambda item: _order(item[0])))
 
     def _build_debug_info_from_exception(self, exception: Exception) -> str:
         return f"### Exception:\n\r{exception}\n\r"

--- a/src/quickapp/dial_files_tooling/_tool_configs.py
+++ b/src/quickapp/dial_files_tooling/_tool_configs.py
@@ -28,6 +28,12 @@ _PATH_IN_TITLE = ParameterDisplayConfig(
     stage=FormattedParameterConfig(show_value_in_stage_title=True)
 )
 
+# Long, free-form text values: wrap in a verbatim code block (so markdown is not
+# rendered) and push them to the end of the stage parameter list.
+_FILE_CONTENT_DISPLAY_CONFIG = ParameterDisplayConfig(
+    stage=FormattedParameterConfig(format="", order=1)
+)
+
 
 LIST_FILES_TOOL_CONFIG = InternalTool(
     open_ai_tool=OpenAiToolConfig(
@@ -245,6 +251,7 @@ WRITE_FILE_TOOL_CONFIG = InternalTool(
                     "content": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.string,
                         description="UTF-8 text content of the file.",
+                        display=_FILE_CONTENT_DISPLAY_CONFIG,
                     ),
                     "content_type": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.string,
@@ -295,10 +302,12 @@ EDIT_FILE_TOOL_CONFIG = InternalTool(
                             "Exact substring to replace. Must occur exactly once. "
                             "Include surrounding context to disambiguate."
                         ),
+                        display=_FILE_CONTENT_DISPLAY_CONFIG,
                     ),
                     "new_string": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.string,
                         description="Replacement text. May be empty to delete the match.",
+                        display=_FILE_CONTENT_DISPLAY_CONFIG,
                     ),
                 },
                 required=["path", "old_string", "new_string"],

--- a/src/tests/unit_tests/dial_files_tooling/test_file_stage_wrapper.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_file_stage_wrapper.py
@@ -1,0 +1,79 @@
+from unittest.mock import MagicMock
+
+import pytest
+from aidial_sdk.chat_completion import Stage
+
+# noinspection PyProtectedMember
+from quickapp.dial_files_tooling._stage_wrapper import _FileStageWrapper
+from quickapp.dial_files_tooling._tool_configs import EDIT_FILE_TOOL_CONFIG, WRITE_FILE_TOOL_CONFIG
+
+
+@pytest.fixture
+def mock_stage():
+    stage = MagicMock(spec=Stage)
+    stage.__enter__.return_value = stage
+    stage.append_content = MagicMock()
+    stage.append_name = MagicMock()
+    return stage
+
+
+def _write_wrapper(mock_stage) -> _FileStageWrapper:
+    return _FileStageWrapper(
+        stage=mock_stage, tool_config=WRITE_FILE_TOOL_CONFIG, stage_name="Write file"
+    )
+
+
+def _edit_wrapper(mock_stage) -> _FileStageWrapper:
+    return _FileStageWrapper(
+        stage=mock_stage, tool_config=EDIT_FILE_TOOL_CONFIG, stage_name="Edit file"
+    )
+
+
+def test_content_wrapped_in_code_block(mock_stage):
+    wrapper = _write_wrapper(mock_stage)
+
+    rendered = wrapper._get_formatted_parameters(
+        {"path": "report.md", "content": "# Heading\n\nSome **bold** text."}
+    )
+
+    # The markdown content appears verbatim inside a fenced code block, so the
+    # heading/bold markup is not rendered by the UI.
+    assert "```\n# Heading\n\nSome **bold** text.\n```" in rendered
+
+
+def test_fence_grows_for_embedded_code_block(mock_stage):
+    wrapper = _write_wrapper(mock_stage)
+
+    content = "Intro\n\n```python\nprint('hi')\n```\n\nOutro"
+    rendered = wrapper._get_formatted_parameters({"path": "report.md", "content": content})
+
+    # The inner fence is 3 backticks, so the wrapper must open with 4 to avoid
+    # closing early. The whole content (including the inner fence) stays intact.
+    assert "````\n" + content + "\n````" in rendered
+    assert "```python" in rendered
+
+
+def test_long_param_rendered_last(mock_stage):
+    wrapper = _write_wrapper(mock_stage)
+
+    # Input lists the long `content` before the short `path`.
+    rendered = wrapper._get_formatted_parameters(
+        {"content": "body", "path": "report.md", "content_type": "text/markdown"}
+    )
+
+    # Short params (path, content_type) come before the long content block.
+    assert rendered.index("path:") < rendered.index("content:")
+    assert rendered.index("content_type:") < rendered.index("content:")
+
+
+def test_edit_strings_wrapped_in_code_blocks(mock_stage):
+    wrapper = _edit_wrapper(mock_stage)
+
+    rendered = wrapper._get_formatted_parameters(
+        {"path": "a.md", "old_string": "**old**", "new_string": "**new**"}
+    )
+
+    assert "```\n**old**\n```" in rendered
+    assert "```\n**new**\n```" in rendered
+    # path is short and rendered before the long replacement strings.
+    assert rendered.index("path:") < rendered.index("old_string:")


### PR DESCRIPTION
### Applicable issues

- fixes #353

### Description of changes

File tool stages rendered the `content` parameter as **live markdown**, so writing a markdown file showed a rendered document (headings, TOC, links) instead of the literal text the agent wrote.

- **Verbatim code blocks** — reuse the existing `format` field on `FormattedParameterConfig` to wrap a value in a fenced code block. `format` is now three-state: `None` renders raw, `""` produces a plain code block (no language), and a non-empty string sets the language (e.g. `json`). The fence **auto-sizes** to one backtick longer than the longest backtick run in the value, so embedded code fences inside the content (e.g. a ` ```python ` block) cannot close the wrapper early.
- **Parameter ordering** — added an `order` field to `FormattedParameterConfig`; stage parameters are sorted by it (stable, default `0`), so long values like file `content` render after short ones like `path`.
- Configured write/edit file content params (`content`, `old_string`, `new_string`) to render as plain code blocks, last.

Added unit tests covering verbatim wrapping, fence growth for embedded code blocks, and parameter ordering.

### Screenshots
<img width="2168" height="1401" alt="image" src="https://github.com/user-attachments/assets/163940d3-b1ab-4edc-9533-64b94abb868d" />


### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
