### PR TITLE
feat: support tool_choice parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,7 +146,7 @@ integration_test: install_integration
 	$(MAKE) stop_test_server
 
 integration_test_run:
-	ENABLE_PREVIEW_FEATURES=true $(POETRY) run pytest --model=${MODEL} -m "integration" $(ARGS)
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run pytest --model=${MODEL} --junitxml=reports/tests-integration-${MODEL_SHORT_NAME}.xml -m "integration" $(ARGS)
 
 e2e_test: install_integration
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run pytest -n $(or ${WORKERS},logical) --no-cache --junitxml=reports/tests-e2e.xml -m "e2e" $(ARGS)

--- a/docs/designs/enforce_tool_call.md
+++ b/docs/designs/enforce_tool_call.md
@@ -1,0 +1,290 @@
+# Design: Enforce Tool Call
+
+- **Status:** Draft
+- **Dependencies:**
+  - None
+
+## Problem Statement
+
+QuickApps does not expose the `tool_choice` parameter to clients. When a client sends a chat completion
+request to QuickApps, there is no way to instruct the orchestrator LLM to call a tool on the current
+iteration. The underlying DIAL Core API supports `tool_choice` (`"none"`, `"auto"`, `"required"`, or a
+named function object), but is not used by QuickApps.
+
+## Design Goals
+
+- **Propagate `tool_choice` from the incoming request to the orchestrator LLM call.** QuickApps accepts
+  the parameter and forwards it unchanged - no re-interpretation or filtering.
+- **Apply `tool_choice` only on the first orchestrator iteration.** After the first LLM call, the
+  orchestrator must revert to its natural behavior (`"auto"`) so subsequent agentic iterations can
+  freely decide whether to call tools or produce a final response. Without this, `"required"` would
+  trap the agent in an infinite tool-call loop.
+- **Follow the existing `response_format` propagation pattern.** Extract from request, store in
+  request-scoped context, provide via DI, consume in `_ChatCompletionConfigBuilder`.
+
+---
+
+## Use Cases
+
+### UC-1: Client forces a specific tool call
+
+**Trigger:** Client sends `"tool_choice": {"type": "function", "function": {"name": "web_search"}}`
+in the chat completion request.
+
+**Behavior:** On the first orchestrator iteration, the LLM is forced to call `web_search`. On
+subsequent iterations the constraint is lifted and the LLM may respond freely.
+
+**Outcome:** The agent always begins by searching the web, then synthesizes the results into a
+final response.
+
+### UC-2: Client requires any tool call
+
+**Trigger:** Client sends `"tool_choice": "required"`.
+
+**Behavior:** The first iteration forces the LLM to call at least one tool (model picks which).
+Subsequent iterations revert to `"auto"`.
+
+**Outcome:** The agent is guaranteed to use a tool before answering, but retains freedom on tool
+selection and on subsequent iterations.
+
+### UC-3: Client suppresses tool calls
+
+**Trigger:** Client sends `"tool_choice": "none"`.
+
+**Behavior:** On the first iteration, the LLM is told not to call any tool and must produce a text
+response. The orchestrator loop terminates after one iteration (no tool calls detected).
+
+**Outcome:** The agent responds directly without invoking tools, even if tools are available.
+
+### UC-4: Client requires tool call but no tools are configured
+
+**Trigger:** Client sends `"tool_choice": "required"` to an app with an empty `tool_sets` array.
+
+**Behavior:** QuickApps rejects the request with HTTP 400 before calling the orchestrator LLM.
+
+**Outcome:** Client receives a clear error message: "Cannot enforce tool_choice: no tools are
+available. Configure at least one tool set or use tool_choice='auto'."
+
+### UC-5: Default behavior (no `tool_choice`)
+
+**Trigger:** Client omits `tool_choice` from the request.
+
+**Behavior:** No `tool_choice` field is included in the orchestrator payload on any iteration.
+The LLM uses its own default (typically `"auto"` when tools are present).
+
+**Outcome:** Identical to current behavior — no regression.
+
+---
+
+## Design
+
+### 1. DI type — `TOOL_CHOICE`
+
+A new annotated type in `common/_di_types.py`:
+
+```python
+from aidial_sdk.chat_completion.request import ToolChoice
+
+TOOL_CHOICE = Annotated[ToolChoice | str | None, "TOOL_CHOICE"]
+```
+
+`str` is used rather than the SDK's narrower `Literal["auto", "none", "required"]` to avoid
+coupling to the SDK's literal set — future values pass through without code changes.
+
+### 2. Request context — extraction and storage
+
+`_RequestContext` gains a `tool_choice` property (same pattern as `response_format`).
+
+`_RequestContextSetup.setup_context()` extracts it from the incoming `Request`:
+
+```python
+if isinstance(request, Request) and request.tool_choice is not None:
+    context.tool_choice = request.tool_choice
+```
+
+No validation is needed beyond what the SDK already provides — the `Request` model validates
+the union type via Pydantic.
+
+### 3. DI provider — `AppModule`
+
+`AppModule` adds a request-scoped provider:
+
+```python
+@provider
+def __provide_tool_choice(self, context: _RequestContext) -> TOOL_CHOICE:
+    return context.tool_choice
+```
+
+### 4. First-iteration-only semantics — `_ToolChoiceHolder`
+
+`_ChatCompletionConfigBuilder` is NoScope (recreated each iteration), so it cannot track state
+across iterations. To ensure `tool_choice` is applied only on the first iteration, a request-scoped
+`_ToolChoiceHolder` class is introduced in `agent/_tool_choice_holder.py`.
+
+```python
+class _ToolChoiceHolder:
+    def __init__(self, tool_choice: TOOL_CHOICE) -> None:
+        self._value: ToolChoice | str | None = tool_choice
+        self._consumed: bool = False
+
+    def consume(self) -> ToolChoice | str | None:
+        if self._consumed:
+            return None
+        self._consumed = True
+        return self._value
+```
+
+The holder is registered with `request_scope` in `AgentModule.configure()`. Because it is
+request-scoped, it persists across all orchestrator iterations within a single request. The
+`consume()` method returns the value on the first call and `None` on all subsequent calls,
+giving first-iteration-only semantics without modifying the orchestrator or builder interfaces.
+
+### 5. Consumption — `_ChatCompletionConfigBuilder`
+
+The builder receives `_ToolChoiceHolder` via constructor injection (not `TOOL_CHOICE` directly).
+On `build()`, it calls `consume()` and includes the result in the payload if non-None:
+
+```python
+tool_choice = self.__tool_choice_holder.consume()
+if tool_choice is not None:
+    requires_tool = tool_choice == "required" or (
+        hasattr(tool_choice, "type") and tool_choice.type == "function"
+    )
+    if requires_tool and not self.__tools:
+        raise InvalidRequestError(...)
+
+    if hasattr(tool_choice, "model_dump"):
+        payload["tool_choice"] = tool_choice.model_dump(exclude_none=True, mode="json")
+    else:
+        payload["tool_choice"] = tool_choice
+```
+
+### 6. Validation — `tool_choice` vs available tools
+
+When `tool_choice` demands a tool call (`"required"` or a named function object) but no tools are
+available, QuickApps rejects the request with an `InvalidRequestError` (HTTP 400) rather than
+forwarding an impossible constraint to the orchestrator LLM.
+
+This covers:
+- `"required"` with an empty tool set → 400
+- `{"type": "function", "function": {"name": "x"}}` with an empty tool set → 400
+- `"auto"` or `"none"` with no tools → passes through (no constraint to enforce)
+
+The validation runs inside `_ChatCompletionConfigBuilder.build()` on the first iteration only
+(since `consume()` returns `None` on subsequent iterations).
+
+---
+
+## Out of Scope
+
+- **App-config-level `tool_choice`.** A static `tool_choice` field on `OrchestratorConfig` (set by
+  the app builder, applied on every request regardless of client input). This is a reasonable
+  future extension but conflates two concerns (client-controlled vs builder-controlled). If needed
+  later, it can layer as a default that the client overrides.
+- **Per-iteration `tool_choice` control.** Allowing the client to specify different `tool_choice`
+  values for different iterations. This would require a fundamentally different API shape.
+- **Named function validation.** When `tool_choice` names a specific function, QuickApps does not
+  validate that the function exists in the current tool set. The orchestrator LLM (or DIAL Core)
+  will return an error if the function is unknown — propagating that error is sufficient.
+
+---
+
+## Configuration / Usage Examples
+
+**Client request with `tool_choice`:**
+
+```json
+{
+  "messages": [{"role": "user", "content": "What's the weather in London?"}],
+  "tool_choice": "required"
+}
+```
+
+**Client request forcing a named tool:**
+
+```json
+{
+  "messages": [{"role": "user", "content": "Search for recent AI papers"}],
+  "tool_choice": {"type": "function", "function": {"name": "web_search"}}
+}
+```
+
+**Effect on orchestrator payload (first iteration only):**
+
+```json
+{
+  "model": "gpt-4o",
+  "messages": [...],
+  "tools": [...],
+  "tool_choice": "required",
+  "stream": true
+}
+```
+
+**Second iteration payload (tool_choice absent):**
+
+```json
+{
+  "model": "gpt-4o",
+  "messages": [...],
+  "tools": [...],
+  "stream": true
+}
+```
+
+---
+
+## Migration
+
+No breaking changes. `tool_choice` is optional and defaults to `None`.
+
+## Summary of Changes
+
+### New
+
+| Component | What |
+|---|---|
+| `common/_di_types.py` | `TOOL_CHOICE` annotated type |
+| `agent/_tool_choice_holder.py` | `_ToolChoiceHolder` — request-scoped consume-once holder |
+| `application/_request_context.py` | `tool_choice` property on `_RequestContext` |
+| `application/_request_context_setup.py` | Extraction from `Request.tool_choice` |
+| `application/app_module.py` | `__provide_tool_choice` provider |
+
+### Modified
+
+| Component | What |
+|---|---|
+| `agent/_chat_completion_config_builder.py` | Inject `_ToolChoiceHolder`, consume and include in payload |
+| `agent/agent_module.py` | Bind `_ToolChoiceHolder` with `request_scope` |
+
+---
+
+## Test Plan
+
+**Unit — `_ChatCompletionConfigBuilder`:**
+- `tool_choice=None` → payload has no `tool_choice` key.
+- `tool_choice="required"` + first build → payload contains `"tool_choice": "required"`.
+- `tool_choice="required"` + second build → payload has no `tool_choice` key (consumed).
+- `tool_choice=ToolChoice(type="function", function=...)` → payload contains serialized object on first build.
+- `tool_choice="none"` → payload contains `"tool_choice": "none"` on first build.
+
+**Unit — `_ToolChoiceHolder`:**
+- `consume()` returns value on first call.
+- `consume()` returns `None` on subsequent calls.
+- `None` input → always returns `None`.
+
+**Unit — validation:**
+- `tool_choice="required"` + empty tools list → `InvalidRequestError`.
+- `tool_choice=ToolChoice(function name)` + empty tools list → `InvalidRequestError`.
+- `tool_choice="none"` + empty tools list → no error.
+- `tool_choice="auto"` + empty tools list → no error.
+- `tool_choice="required"` + non-empty tools list → no error.
+
+**Unit — `_RequestContextSetup`:**
+- Request with `tool_choice` → stored in context.
+- Request without `tool_choice` → context value is `None`.
+
+**Integration — agent loop:**
+- `tool_choice="required"` forces a tool call on iteration 1; iteration 2 proceeds without constraint.
+- `tool_choice="none"` produces a direct text response, loop terminates after one iteration.
+- `tool_choice={"type": "function", "function": {"name": "..."}}` forces the named tool on iteration 1.

--- a/src/quickapp/common/__init__.py
+++ b/src/quickapp/common/__init__.py
@@ -7,6 +7,7 @@ from ._di_types import (
     ForwardedHeaders,
     ORCHESTRATOR_AZURE_CLIENT,
     RESPONSE_FORMAT,
+    TOOL_CHOICE,
 )
 from quickapp.common.base_initializer import BaseInitializer, InitializerType
 from .tool_call_result import ToolCallResult

--- a/src/quickapp/common/_di_types.py
+++ b/src/quickapp/common/_di_types.py
@@ -1,12 +1,14 @@
 from typing import Annotated
 
 from aidial_sdk.chat_completion import ResponseFormat
+from aidial_sdk.chat_completion.request import ToolChoice
 from openai.lib.azure import AsyncAzureOpenAI
 from pydantic import SecretStr
 
 DIAL_API_KEY = Annotated[SecretStr, "DIAL_API_KEY"]
 DIAL_BEARER = Annotated[SecretStr | None, "DIAL_BEARER"]
 RESPONSE_FORMAT = Annotated[ResponseFormat | None, "RESPONSE_FORMAT"]
+TOOL_CHOICE = Annotated[ToolChoice | str | None, "TOOL_CHOICE"]
 ForwardedHeaders = Annotated[dict[str, str] | None, "ForwardedHeaders"]
 CLIENT_CHANNEL_ID = Annotated[str | None, "CLIENT_CHANNEL_ID"]
 CLIENT_CHANNEL_HEADER = "X-DIAL-CLIENT-CHANNEL-ID"

--- a/src/quickapp/core/agent/_chat_completion_config_builder.py
+++ b/src/quickapp/core/agent/_chat_completion_config_builder.py
@@ -66,23 +66,7 @@ class _ChatCompletionConfigBuilder:
                     type(self.__response_format),
                 )
 
-        tool_choice = self.__tool_choice_holder.consume()
-        if tool_choice is not None:
-            requires_tool = tool_choice == "required" or (
-                hasattr(tool_choice, "type") and tool_choice.type == "function"
-            )
-            if requires_tool and not self.__tools:
-                raise InvalidRequestError(
-                    message="tool_choice requires at least one tool to be configured",
-                    display_message=(
-                        "Cannot enforce tool_choice: no tools are available. "
-                        "Configure at least one tool set or use tool_choice='auto'."
-                    ),
-                )
-            if hasattr(tool_choice, "model_dump"):
-                payload["tool_choice"] = tool_choice.model_dump(exclude_none=True, mode="json")
-            else:
-                payload["tool_choice"] = tool_choice
+        self._apply_tool_choice(payload)
 
         if self.__presentation_settings.show_usage_statistics:
             payload["stream_options"] = {"include_usage": True}
@@ -96,6 +80,26 @@ class _ChatCompletionConfigBuilder:
                 "Chat completion config: %s", json.dumps(chat_completion_config, ensure_ascii=False)
             )
         return chat_completion_config
+
+    def _apply_tool_choice(self, payload: dict[str, Any]) -> None:
+        tool_choice = self.__tool_choice_holder.consume()
+        if tool_choice is None:
+            return
+        requires_tool = tool_choice == "required" or (
+            hasattr(tool_choice, "type") and tool_choice.type == "function"
+        )
+        if requires_tool and not self.__tools:
+            raise InvalidRequestError(
+                message="tool_choice requires at least one tool to be configured",
+                display_message=(
+                    "Cannot enforce tool_choice: no tools are available. "
+                    "Configure at least one tool set or use tool_choice='auto'."
+                ),
+            )
+        if hasattr(tool_choice, "model_dump"):
+            payload["tool_choice"] = tool_choice.model_dump(exclude_none=True, mode="json")
+        else:
+            payload["tool_choice"] = tool_choice
 
     def _prepare_messages(self, messages: list[Message]) -> list[dict[str, Any]]:
         transformed_messages = messages

--- a/src/quickapp/core/agent/_chat_completion_config_builder.py
+++ b/src/quickapp/core/agent/_chat_completion_config_builder.py
@@ -3,6 +3,7 @@ import logging
 from typing import Any
 
 from aidial_sdk.chat_completion.request import Message
+from aidial_sdk.exceptions import InvalidRequestError
 from injector import inject
 
 from quickapp.common import RESPONSE_FORMAT, ForwardedHeaders
@@ -10,6 +11,7 @@ from quickapp.common.abstract.base_transformer import PreInvocationTransformer
 from quickapp.common.presentation_settings import PresentationSettings
 from quickapp.config.agent_settings import AgentSettings
 from quickapp.config.application import ApplicationConfig
+from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
 from quickapp.core.agent.message_logger import format_openai_message_pipe_tree
 from quickapp.core.agent.models import STATE_KEY_ORCHESTRATOR, OpenAiToolConfigDict
 
@@ -23,6 +25,7 @@ class _ChatCompletionConfigBuilder:
         config: ApplicationConfig,
         tools: list[OpenAiToolConfigDict],
         response_format: RESPONSE_FORMAT,
+        tool_choice_holder: _ToolChoiceHolder,
         pre_invocation_transformers: list[PreInvocationTransformer],
         presentation_settings: PresentationSettings,
         forwarded_headers: ForwardedHeaders,
@@ -31,6 +34,7 @@ class _ChatCompletionConfigBuilder:
         self.__config: ApplicationConfig = config
         self.__tools: list[OpenAiToolConfigDict] = tools
         self.__response_format = response_format
+        self.__tool_choice_holder = tool_choice_holder
         self.__pre_invocation_transformers = pre_invocation_transformers
         self.__presentation_settings = presentation_settings
         self.__forwarded_headers = forwarded_headers
@@ -61,6 +65,24 @@ class _ChatCompletionConfigBuilder:
                     "Unsupported response format type: %s. The response format will not be applied.",
                     type(self.__response_format),
                 )
+
+        tool_choice = self.__tool_choice_holder.consume()
+        if tool_choice is not None:
+            requires_tool = tool_choice == "required" or (
+                hasattr(tool_choice, "type") and tool_choice.type == "function"
+            )
+            if requires_tool and not self.__tools:
+                raise InvalidRequestError(
+                    message="tool_choice requires at least one tool to be configured",
+                    display_message=(
+                        "Cannot enforce tool_choice: no tools are available. "
+                        "Configure at least one tool set or use tool_choice='auto'."
+                    ),
+                )
+            if hasattr(tool_choice, "model_dump"):
+                payload["tool_choice"] = tool_choice.model_dump(exclude_none=True, mode="json")
+            else:
+                payload["tool_choice"] = tool_choice
 
         if self.__presentation_settings.show_usage_statistics:
             payload["stream_options"] = {"include_usage": True}

--- a/src/quickapp/core/agent/_tool_choice_holder.py
+++ b/src/quickapp/core/agent/_tool_choice_holder.py
@@ -1,0 +1,20 @@
+from aidial_sdk.chat_completion.request import ToolChoice
+from injector import inject
+
+from quickapp.common import TOOL_CHOICE
+
+
+@inject
+class _ToolChoiceHolder:
+    """Request-scoped holder that returns tool_choice on the first consume() call."""
+
+    def __init__(self, tool_choice: TOOL_CHOICE) -> None:
+        self._value: ToolChoice | str | None = tool_choice
+        self._consumed: bool = False
+
+    def consume(self) -> ToolChoice | str | None:
+        """Consume tool_choice on the first consume() call."""
+        if self._consumed:
+            return None
+        self._consumed = True
+        return self._value

--- a/src/quickapp/core/agent/agent_module.py
+++ b/src/quickapp/core/agent/agent_module.py
@@ -48,6 +48,7 @@ from quickapp.core.agent._orchestrator_deployment_initializer import (
     _OrchestratorStaticToolsContext,
 )
 from quickapp.core.agent._prompt_providers import ConfigBasedPromptProvider
+from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
 from quickapp.core.agent.assistant_invoker import AssistantInvoker
 from quickapp.core.agent.models import OpenAiToolConfigDict
 from quickapp.core.agent.orchestrator import Orchestrator
@@ -77,6 +78,7 @@ class AgentModule(Module):
     def configure(self, binder: Binder) -> None:
         # FIXME: mypy warning:
         binder.bind(Orchestrator, to=Orchestrator)  # type: ignore[type-abstract]
+        binder.bind(_ToolChoiceHolder, to=_ToolChoiceHolder, scope=request_scope)
         binder.bind(StateHolder, to=StateHolder, scope=request_scope)
         binder.bind(
             DeferredStageCloseRegistry,

--- a/src/quickapp/core/application/_request_context.py
+++ b/src/quickapp/core/application/_request_context.py
@@ -1,4 +1,5 @@
 from aidial_sdk.chat_completion import Choice, ResponseFormat
+from aidial_sdk.chat_completion.request import ToolChoice
 from aidial_sdk.exceptions import InvalidRequestError
 
 from quickapp.common import CLIENT_CHANNEL_ID, DIAL_API_KEY, DIAL_BEARER, ForwardedHeaders
@@ -46,6 +47,7 @@ class _RequestContext(MessagesMixin):
     _response_format: ResponseFormat | None = None
     _forwarded_headers: ForwardedHeaders | None = None
     _client_channel_id: CLIENT_CHANNEL_ID = None
+    _tool_choice: ToolChoice | str | None = None
 
     @property
     def bearer(self) -> DIAL_BEARER:
@@ -127,3 +129,13 @@ class _RequestContext(MessagesMixin):
         if self._client_channel_id is not None:
             raise RuntimeError("Client channel ID is already set")
         self._client_channel_id = value
+
+    @property
+    def tool_choice(self) -> ToolChoice | str | None:
+        return self._tool_choice
+
+    @tool_choice.setter
+    def tool_choice(self, value: ToolChoice | str | None) -> None:
+        if self._tool_choice is not None:
+            raise RuntimeError("Tool choice is already set")
+        self._tool_choice = value

--- a/src/quickapp/core/application/_request_context.py
+++ b/src/quickapp/core/application/_request_context.py
@@ -1,8 +1,13 @@
 from aidial_sdk.chat_completion import Choice, ResponseFormat
-from aidial_sdk.chat_completion.request import ToolChoice
 from aidial_sdk.exceptions import InvalidRequestError
 
-from quickapp.common import CLIENT_CHANNEL_ID, DIAL_API_KEY, DIAL_BEARER, ForwardedHeaders
+from quickapp.common import (
+    CLIENT_CHANNEL_ID,
+    DIAL_API_KEY,
+    DIAL_BEARER,
+    TOOL_CHOICE,
+    ForwardedHeaders,
+)
 from quickapp.common.messages_mixin import MessagesMixin
 from quickapp.config.application import ApplicationConfig
 
@@ -47,7 +52,7 @@ class _RequestContext(MessagesMixin):
     _response_format: ResponseFormat | None = None
     _forwarded_headers: ForwardedHeaders | None = None
     _client_channel_id: CLIENT_CHANNEL_ID = None
-    _tool_choice: ToolChoice | str | None = None
+    _tool_choice: TOOL_CHOICE = None
 
     @property
     def bearer(self) -> DIAL_BEARER:
@@ -131,11 +136,11 @@ class _RequestContext(MessagesMixin):
         self._client_channel_id = value
 
     @property
-    def tool_choice(self) -> ToolChoice | str | None:
+    def tool_choice(self) -> TOOL_CHOICE:
         return self._tool_choice
 
     @tool_choice.setter
-    def tool_choice(self, value: ToolChoice | str | None) -> None:
+    def tool_choice(self, value: TOOL_CHOICE) -> None:
         if self._tool_choice is not None:
             raise RuntimeError("Tool choice is already set")
         self._tool_choice = value

--- a/src/quickapp/core/application/_request_context_setup.py
+++ b/src/quickapp/core/application/_request_context_setup.py
@@ -68,6 +68,9 @@ class _RequestContextSetup:
         if isinstance(request, Request) and request.response_format:
             context.response_format = request.response_format
 
+        if isinstance(request, Request) and request.tool_choice is not None:
+            context.tool_choice = request.tool_choice
+
     async def setup_messages(self, messages: list[Message]) -> None:
         """Populate ``context.messages`` from the raw request messages and
         run the transformer chain over them. Called after initializers so

--- a/src/quickapp/core/application/app_module.py
+++ b/src/quickapp/core/application/app_module.py
@@ -9,6 +9,7 @@ from quickapp.common import (
     DIAL_API_KEY,
     DIAL_BEARER,
     RESPONSE_FORMAT,
+    TOOL_CHOICE,
     ForwardedHeaders,
 )
 from quickapp.common.dial_settings import DialSettings
@@ -78,6 +79,10 @@ class AppModule(Module):
     @provider
     def __provide_response_format(self, context: _RequestContext) -> RESPONSE_FORMAT:
         return context.response_format
+
+    @provider
+    def __provide_tool_choice(self, context: _RequestContext) -> TOOL_CHOICE:
+        return context.tool_choice
 
     @provider
     def __provide_forwarded_headers(self, context: _RequestContext) -> ForwardedHeaders:

--- a/src/tests/integration_tests/test_runner/e2e_runner.py
+++ b/src/tests/integration_tests/test_runner/e2e_runner.py
@@ -199,6 +199,11 @@ class TestRunner:
                 request_payload["response_format"] = test_case.response_format
                 logger.debug(f"Using response_format: {test_case.response_format}")
 
+            # Add tool_choice if specified in test case
+            if test_case.tool_choice is not None:
+                request_payload["tool_choice"] = test_case.tool_choice
+                logger.debug(f"Using tool_choice: {test_case.tool_choice}")
+
             response = client.post(
                 TestConfig.API_ENDPOINTS['CHAT_COMPLETIONS'],
                 headers=headers,

--- a/src/tests/integration_tests/test_runner/models.py
+++ b/src/tests/integration_tests/test_runner/models.py
@@ -196,6 +196,7 @@ class TstCase:
         description: str,
         similarity_threshold: float = SimilarityThreshold.DEFAULT.value,
         response_format: dict[str, Any] | None = None,
+        tool_choice: str | dict[str, Any] | None = None,
     ):
         self.name = name
         self.description = description
@@ -204,6 +205,7 @@ class TstCase:
         self.similarity_threshold = similarity_threshold
         self.py_interpreter_session_flow = False
         self.response_format = response_format
+        self.tool_choice = tool_choice
 
     def add_user_message(
         self,

--- a/src/tests/integration_tests/test_tool_choice.py
+++ b/src/tests/integration_tests/test_tool_choice.py
@@ -1,0 +1,75 @@
+import pytest
+
+from tests.integration_tests.test_runner.config import SimilarityThreshold
+from tests.integration_tests.test_runner.e2e_runner import e2e_test
+from tests.integration_tests.test_runner.models import ToolCall, TstCase
+from tests.integration_tests.test_runner.utils.tool_names import ToolNames
+
+
+@pytest.mark.integration
+@e2e_test(
+    config_file_set="integration",
+    no_cache=True,
+    test_case=TstCase(
+        "tool_choice_required",
+        "tool_choice=required forces a calculator tool call on the first iteration",
+        similarity_threshold=SimilarityThreshold.LENIENT.value,
+        tool_choice="required",
+    ).add_user_message(
+        user_message="Write Python code to calculate the factorial of 10 and print the result",
+        tool_calls=[
+            ToolCall(ToolNames.PYTHON_CODE_INTERPRETER.value, min_calls=1, max_calls=3),
+        ],
+    ),
+)
+def test_tool_choice_required(client):
+    pass
+
+
+@pytest.mark.integration
+@e2e_test(
+    config_file_set="integration",
+    no_cache=True,
+    test_case=TstCase(
+        "tool_choice_none",
+        "tool_choice=none prevents tool calls even for calculation requests",
+        similarity_threshold=SimilarityThreshold.LENIENT.value,
+        tool_choice="none",
+    ).add_user_message(
+        user_message="Use the python interpreter to calculate 2 + 2",
+        tool_calls=[],
+        answer=[
+            "4",
+            "2 + 2 = 4",
+            "The answer is 4",
+            "I can't run the code interpreter in this message, but the result of 2 + 2 is 4.",
+            "I can't run the Python interpreter in this turn. The result is 2 + 2 = 4.",
+        ],
+    ),
+)
+def test_tool_choice_none(client):
+    pass
+
+
+@pytest.mark.integration
+@e2e_test(
+    config_file_set="integration",
+    no_cache=True,
+    test_case=TstCase(
+        "tool_choice_function",
+        "tool_choice with specific function name forces the calculator tool",
+        similarity_threshold=SimilarityThreshold.LENIENT.value,
+        tool_choice={
+            "type": "function",
+            "function": {"name": ToolNames.PYTHON_CODE_INTERPRETER.value},
+        },
+    ).add_user_message(
+        user_message="What is the square root of 144?",
+        tool_calls=[
+            ToolCall(ToolNames.PYTHON_CODE_INTERPRETER.value, min_calls=1, max_calls=3),
+        ],
+        answer=["12", "square root of 144 is 12", "√144 = 12"],
+    ),
+)
+def test_tool_choice_specific_function(client):
+    pass

--- a/src/tests/unit_tests/agent_tests/test_assistant_invoker.py
+++ b/src/tests/unit_tests/agent_tests/test_assistant_invoker.py
@@ -10,6 +10,7 @@ from quickapp.common.stage_close_registry import DeferredStageCloseRegistry
 from quickapp.config.agent_settings import AgentSettings
 from quickapp.core.agent import AssistantInvoker
 from quickapp.core.agent._chat_completion_config_builder import _ChatCompletionConfigBuilder
+from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
 
 
 def _presentation_settings(show_usage: bool):
@@ -59,11 +60,13 @@ def _make_config_builder(
     show_usage: bool = False,
     forwarded_headers=None,
     response_format=None,
+    tool_choice=None,
 ) -> _ChatCompletionConfigBuilder:
     return _ChatCompletionConfigBuilder(
         config=config or DummyConfig(),
         tools=tools or [{"name": "t1"}],
         response_format=response_format,
+        tool_choice_holder=_ToolChoiceHolder(tool_choice=tool_choice),
         pre_invocation_transformers=[mock_filter],
         presentation_settings=_presentation_settings(show_usage),
         forwarded_headers=forwarded_headers,

--- a/src/tests/unit_tests/agent_tests/test_tool_choice_config_builder.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_choice_config_builder.py
@@ -1,0 +1,102 @@
+from unittest.mock import MagicMock
+
+import pytest
+from aidial_sdk.chat_completion.request import FunctionChoice, ToolChoice
+from aidial_sdk.exceptions import InvalidRequestError
+
+from quickapp.core.agent._chat_completion_config_builder import _ChatCompletionConfigBuilder
+from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
+
+
+def _make_builder(
+    tools=None,
+    tool_choice=None,
+) -> _ChatCompletionConfigBuilder:
+    config = MagicMock()
+    config.orchestrator.deployment.parameters.model_dump.return_value = {}
+    config.orchestrator.deployment.deployment_id = "test-model"
+    holder = _ToolChoiceHolder(tool_choice=tool_choice)
+    return _ChatCompletionConfigBuilder(
+        config=config,
+        tools=tools if tools is not None else [],
+        response_format=None,
+        tool_choice_holder=holder,
+        pre_invocation_transformers=[],
+        presentation_settings=MagicMock(show_usage_statistics=False),
+        forwarded_headers=None,
+        agent_settings=MagicMock(chat_message_log_length=100),
+    )
+
+
+class TestToolChoiceInPayload:
+    def test_tool_choice_none_not_in_payload(self):
+        builder = _make_builder(tool_choice=None)
+        result = builder.build([])
+        assert "tool_choice" not in result
+
+    def test_tool_choice_auto_included(self):
+        builder = _make_builder(tool_choice="auto")
+        result = builder.build([])
+        assert result["tool_choice"] == "auto"
+
+    def test_tool_choice_none_literal_included(self):
+        builder = _make_builder(tool_choice="none")
+        result = builder.build([])
+        assert result["tool_choice"] == "none"
+
+    def test_tool_choice_required_with_tools(self):
+        tools = [{"type": "function", "function": {"name": "search", "parameters": {}}}]
+        builder = _make_builder(tools=tools, tool_choice="required")
+        result = builder.build([])
+        assert result["tool_choice"] == "required"
+
+    def test_tool_choice_function_object_serialized(self):
+        tools = [{"type": "function", "function": {"name": "web_search", "parameters": {}}}]
+        tc = ToolChoice(type="function", function=FunctionChoice(name="web_search"))
+        builder = _make_builder(tools=tools, tool_choice=tc)
+        result = builder.build([])
+        assert result["tool_choice"] == {"type": "function", "function": {"name": "web_search"}}
+
+    def test_tool_choice_consumed_only_on_first_build(self):
+        tools = [{"type": "function", "function": {"name": "f", "parameters": {}}}]
+        holder = _ToolChoiceHolder(tool_choice="required")
+        config = MagicMock()
+        config.orchestrator.deployment.parameters.model_dump.side_effect = lambda **kwargs: {}
+        config.orchestrator.deployment.deployment_id = "model"
+        builder = _ChatCompletionConfigBuilder(
+            config=config,
+            tools=tools,
+            response_format=None,
+            tool_choice_holder=holder,
+            pre_invocation_transformers=[],
+            presentation_settings=MagicMock(show_usage_statistics=False),
+            forwarded_headers=None,
+            agent_settings=MagicMock(chat_message_log_length=100),
+        )
+        first = builder.build([])
+        assert first["tool_choice"] == "required"
+        second = builder.build([])
+        assert "tool_choice" not in second
+
+
+class TestToolChoiceValidation:
+    def test_required_without_tools_raises(self):
+        builder = _make_builder(tools=[], tool_choice="required")
+        with pytest.raises(InvalidRequestError):
+            builder.build([])
+
+    def test_function_object_without_tools_raises(self):
+        tc = ToolChoice(type="function", function=FunctionChoice(name="my_fn"))
+        builder = _make_builder(tools=[], tool_choice=tc)
+        with pytest.raises(InvalidRequestError):
+            builder.build([])
+
+    def test_auto_without_tools_no_error(self):
+        builder = _make_builder(tools=[], tool_choice="auto")
+        result = builder.build([])
+        assert result["tool_choice"] == "auto"
+
+    def test_none_literal_without_tools_no_error(self):
+        builder = _make_builder(tools=[], tool_choice="none")
+        result = builder.build([])
+        assert result["tool_choice"] == "none"

--- a/src/tests/unit_tests/agent_tests/test_tool_choice_holder.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_choice_holder.py
@@ -1,0 +1,18 @@
+from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
+
+
+class TestToolChoiceHolder:
+    def test_consume_returns_value_on_first_call(self):
+        holder = _ToolChoiceHolder(tool_choice="required")
+        assert holder.consume() == "required"
+
+    def test_consume_returns_none_on_subsequent_calls(self):
+        holder = _ToolChoiceHolder(tool_choice="required")
+        holder.consume()
+        assert holder.consume() is None
+        assert holder.consume() is None
+
+    def test_consume_with_none_input_returns_none_always(self):
+        holder = _ToolChoiceHolder(tool_choice=None)
+        assert holder.consume() is None
+        assert holder.consume() is None

--- a/src/tests/unit_tests/application_tests/test_request_context_setup.py
+++ b/src/tests/unit_tests/application_tests/test_request_context_setup.py
@@ -38,6 +38,7 @@ def _make_chat_request(headers: dict | None = None) -> MagicMock:
     request.bearer_token = "test-bearer"
     request.messages = []
     request.response_format = None
+    request.tool_choice = None
     request.headers = headers or {}
     request.request_dial_application_properties = AsyncMock(return_value={})
     return request


### PR DESCRIPTION
### Applicable issues

#182

### Description of changes

Extends chat completion API with parameter `tool_choice`, similar to one in Core API [tool_choice](https://dialx.ai/dial_api#operation/sendChatCompletionRequest:~:text=functions%20are%20supported.-,tool_choice,-string%20or%20ChatCompletionNamedToolChoice).

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Design documented is updated/created and approved by the team (if applicable)
- [ ] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [x] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
