### PR TITLE
fix: prevent nested code fences from breaking skill/file stage rendering

### DIFF
--- a/src/quickapp/common/base_stage_wrapper.py
+++ b/src/quickapp/common/base_stage_wrapper.py
@@ -1,4 +1,3 @@
-import re
 from abc import ABC, abstractmethod
 from types import TracebackType
 from typing import Any, cast
@@ -6,6 +5,7 @@ from typing import Any, cast
 from aidial_sdk.chat_completion import Attachment, Stage
 
 from quickapp.common import ToolCallResult
+from quickapp.common.utils import fenced_code_block
 from quickapp.config.tools.base import BaseOpenAITool, BaseTool
 from quickapp.config.tools.display.paramenter import (
     FormattedParameterConfig,
@@ -131,17 +131,10 @@ class BaseStageWrapper(ABC):
         )
 
         if display_config.format is not None:
-            fence = self._code_fence(str(result_value))
-            result_value = f"\n{fence}{display_config.format}\n{result_value}\n{fence}\n"
+            block = fenced_code_block(str(result_value), display_config.format)
+            result_value = f"\n{block}\n"
 
         return str(result_value)
-
-    @staticmethod
-    def _code_fence(value: str) -> str:
-        # Open the fence with one more backtick than the longest backtick run in the
-        # value (minimum 3) so embedded code fences cannot close the wrapper early.
-        longest = max((len(match) for match in re.findall(r"`+", value)), default=0)
-        return "`" * max(3, longest + 1)
 
     def add_result(self, result: ToolCallResult) -> None:
         debug_info = self._build_debug_info_from_result(result)

--- a/src/quickapp/common/utils.py
+++ b/src/quickapp/common/utils.py
@@ -34,6 +34,20 @@ def matches_type(mime_type: str | None, allowed_mime_types: list[str] | None) ->
     return False
 
 
+def fenced_code_block(text: str, language: str = "") -> str:
+    """Wrap ``text`` in a Markdown fenced code block that survives nested fences.
+
+    Per CommonMark, a fenced block is closed by a line with at least as many
+    backticks as its opening fence. Content that itself contains ``` runs (a skill
+    body, a markdown file) would otherwise break out of a fixed triple-backtick
+    fence and corrupt the rendered stage. Open with a fence one backtick longer
+    than the longest backtick run in ``text`` (minimum three).
+    """
+    longest_run = max((len(run) for run in re.findall(r"`+", text)), default=0)
+    fence = "`" * max(3, longest_run + 1)
+    return f"{fence}{language}\n{text}\n{fence}"
+
+
 def posix_path_last_segment(path: str) -> str:
     """Return the final segment of a POSIX-style path (``/`` separators only).
 

--- a/src/quickapp/core/application/_initialization_error_handler.py
+++ b/src/quickapp/core/application/_initialization_error_handler.py
@@ -12,6 +12,7 @@ from quickapp.common.exceptions import (
     SkillInitializationException,
     ToolInitializationException,
 )
+from quickapp.common.utils import fenced_code_block
 
 logger = logging.getLogger(__name__)
 
@@ -60,17 +61,17 @@ class _InitializationErrorHandler:
             if isinstance(exc, ToolInitializationException):
                 tool_lines.append(f"- **{exc.tool_name}{exc.toolset_name}**: {exc}")
                 if exc.details:
-                    tool_lines.append(f"```\n{exc.details}\n```")
+                    tool_lines.append(fenced_code_block(exc.details))
             elif isinstance(exc, HookInitializationException):
                 hook_lines.append(f"- **{exc.tool_name}{exc.toolset_name}**: {exc}")
                 if exc.details:
-                    hook_lines.append(f"```\n{exc.details}\n```")
+                    hook_lines.append(fenced_code_block(exc.details))
             elif isinstance(exc, OffloadConfigurationException):
                 offload_lines.append(f"- {exc}")
             elif isinstance(exc, ConfigResolutionException):
                 tool_lines.append(f"- **template '{exc.template_name}'**: {exc}")
                 if exc.details:
-                    tool_lines.append(f"```\n{exc.details}\n```")
+                    tool_lines.append(fenced_code_block(exc.details))
             elif isinstance(exc, SkillCatastrophicInitializationException):
                 catastrophic_lines.append(f"- {exc.reason}")
             elif isinstance(exc, SkillInitializationException) and exc.url is not None:

--- a/src/quickapp/dial_files_tooling/_search_in_file_tool.py
+++ b/src/quickapp/dial_files_tooling/_search_in_file_tool.py
@@ -4,9 +4,10 @@ from typing import Any
 from quickapp.common.base_stage_wrapper import BaseStageWrapper
 from quickapp.common.exceptions import InvalidToolCallParameterException
 from quickapp.common.tool_call_result import ToolCallResult
+from quickapp.common.utils import fenced_code_block
 from quickapp.dial_files_tooling._base_file_tool import _MAX_DEPTH, _DialFileTool
 from quickapp.dial_files_tooling._glob import _glob_to_regex
-from quickapp.dial_files_tooling._utils import code_block, is_root_reference, relative_to
+from quickapp.dial_files_tooling._utils import is_root_reference, relative_to
 
 _OUTPUT_MODES = ("content", "files_with_matches")
 
@@ -73,7 +74,7 @@ class _SearchInFileTool(_DialFileTool):
         indices = self._matching_line_indices(lines, pattern, case_insensitive)
         if not indices:
             return "No matches found."
-        return code_block(self._format_matches(lines, indices, context_lines))
+        return fenced_code_block(self._format_matches(lines, indices, context_lines))
 
     async def _search_folder(
         self,
@@ -134,12 +135,12 @@ class _SearchInFileTool(_DialFileTool):
         if not matches:
             return "No matches found."
         if output_mode == "files_with_matches":
-            return code_block("\n".join(display for display, _, _ in matches))
+            return fenced_code_block("\n".join(display for display, _, _ in matches))
         blocks = [
             f"{display}\n{self._format_matches(lines, indices, context_lines)}"
             for display, lines, indices in matches
         ]
-        return code_block("\n\n".join(blocks))
+        return fenced_code_block("\n\n".join(blocks))
 
     @staticmethod
     def _matching_line_indices(lines: list[str], pattern: str, case_insensitive: bool) -> list[int]:

--- a/src/quickapp/dial_files_tooling/_utils.py
+++ b/src/quickapp/dial_files_tooling/_utils.py
@@ -4,6 +4,7 @@ These have no dependency on `self`/DI, so they live here rather than on the
 `_DialFileTool` base class (which holds the download/resolution behaviour).
 """
 
+from quickapp.common.utils import fenced_code_block
 from quickapp.dial_core_services.dial_file_service import FolderEntry
 
 
@@ -31,15 +32,6 @@ def format_size(size: int | None) -> str:
     return f"{size / (1024 * 1024 * 1024):.1f} GB"
 
 
-def code_block(text: str) -> str:
-    """Wrap text in a fenced code block.
-
-    The agent's tool results are rendered as markdown, which collapses single
-    newlines into spaces. Fencing preserves line breaks and column alignment.
-    """
-    return f"```\n{text}\n```"
-
-
 def render_listing(entries: list[tuple[str, FolderEntry]]) -> str:
     if not entries:
         return "(empty folder)"
@@ -50,4 +42,4 @@ def render_listing(entries: list[tuple[str, FolderEntry]]) -> str:
     for display, entry in entries:
         size_col = "-" if entry.is_folder else format_size(entry.size)
         rows.append(f"{display:<{name_w}}  {size_col}")
-    return code_block("\n".join(rows))
+    return fenced_code_block("\n".join(rows))

--- a/src/quickapp/mcp_tooling/_mcp_stage_wrapper.py
+++ b/src/quickapp/mcp_tooling/_mcp_stage_wrapper.py
@@ -7,6 +7,7 @@ from pydantic import BaseModel
 
 from quickapp.common import TimedStageWrapper, ToolCallResult
 from quickapp.common.response_formatter import ResponseFormatter
+from quickapp.common.utils import fenced_code_block
 
 logger = logging.getLogger(__name__)
 
@@ -53,16 +54,16 @@ class _MCPStageWrapper(TimedStageWrapper):
             "xml": ResponseFormatter.format_xml,
             "html": ResponseFormatter.format_html,
             "csv": ResponseFormatter.format_csv,
-            "plain": lambda x: f"```{x}\n```",
         }
 
         main_type = result.content_type.split(";")[0].split("/")[1].lower()
         try:
             formatted = formatters.get(main_type, lambda x: x)(result.content)
-            if main_type in ("csv", "plain"):
+            # csv is rendered as a Markdown table, not a fenced code block.
+            if main_type == "csv":
                 return formatted
-            else:
-                return f"```{main_type}\n{formatted}\n```"
+            language = "" if main_type == "plain" else main_type
+            return fenced_code_block(formatted, language)
         except Exception as e:
             logger.exception(str(e))
-            return f"```{main_type}\n{result.content}\n```"
+            return fenced_code_block(result.content, main_type)

--- a/src/quickapp/rest_api_tooling/_rest_api_stage_wrapper.py
+++ b/src/quickapp/rest_api_tooling/_rest_api_stage_wrapper.py
@@ -9,6 +9,7 @@ from httpx import HTTPStatusError, RequestError
 from injector import inject
 
 from quickapp.common import TimedStageWrapper, ToolCallResult
+from quickapp.common.utils import fenced_code_block
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +35,7 @@ class _RestApiStageWrapper(TimedStageWrapper):
             response_text = exception.response.text or "No response text available"
             return (
                 f"> ##### Status Code:\n{status_code}\n"
-                f"> ##### Response:\n```text\n{response_text}\n```"
+                f"> ##### Response:\n{fenced_code_block(response_text, 'text')}"
             )
 
         if isinstance(exception, RequestError):
@@ -66,10 +67,10 @@ class _RestApiStageWrapper(TimedStageWrapper):
         }
         try:
             formatted = formatters.get(main_type, lambda x: x)(result.content)
-            return formatted if 'csv' in main_type else f"```{main_type}\n{formatted}\n```"
+            return formatted if 'csv' in main_type else fenced_code_block(formatted, main_type)
         except Exception as e:
             logger.exception(e)
-            return f"```{main_type}\n{result.content}\n```"
+            return fenced_code_block(result.content, main_type)
 
     @staticmethod
     def __format_json(content: str) -> str:

--- a/src/quickapp/skills/_skill_reader_stage_wrapper.py
+++ b/src/quickapp/skills/_skill_reader_stage_wrapper.py
@@ -3,6 +3,7 @@ from typing import Any
 from injector import inject
 
 from quickapp.common import TimedStageWrapper, ToolCallResult
+from quickapp.common.utils import fenced_code_block
 
 
 @inject
@@ -12,7 +13,7 @@ class _SkillReaderStageWrapper(TimedStageWrapper):
         return ""
 
     def _build_debug_info_from_exception(self, exception: Exception) -> str:
-        return f"Error:\n```\n{exception}\n```\n"
+        return f"Error:\n{fenced_code_block(str(exception))}\n"
 
     def _build_debug_info_from_result(self, result: ToolCallResult) -> str:
-        return f"Skill Content:\n```\n{result.content}\n```\n"
+        return f"Skill Content:\n{fenced_code_block(result.content)}\n"

--- a/src/tests/unit_tests/application_tests/test_initialization_error_handler.py
+++ b/src/tests/unit_tests/application_tests/test_initialization_error_handler.py
@@ -44,6 +44,22 @@ class TestConfigResolutionExceptionRendering:
         assert "/deployment/name: must be string" in rendered
         stage.close.assert_called_once_with(Status.FAILED)
 
+    def test_details_with_embedded_fence_uses_longer_wrapping_fence(self):
+        stage = MagicMock(spec=Stage)
+        details = "trace:\n```\nboom\n```"
+        exc = ConfigResolutionException(
+            message="value is not a string",
+            template_name="dial_rag",
+            json_path="/deployment/name",
+            details=details,
+        )
+        handler = _make_handler(stage, [exc])
+
+        handler.handle_initialization_issues()
+
+        rendered = _stage_content(stage)
+        assert f"````\n{details}\n````" in rendered
+
     def test_no_exceptions_does_not_render_stage(self):
         stage = MagicMock(spec=Stage)
         handler = _make_handler(stage, [])

--- a/src/tests/unit_tests/common/test_fenced_code_block.py
+++ b/src/tests/unit_tests/common/test_fenced_code_block.py
@@ -1,0 +1,25 @@
+from quickapp.common.utils import fenced_code_block
+
+
+def test_plain_text_uses_triple_backtick_fence():
+    assert fenced_code_block("a\nb") == "```\na\nb\n```"
+
+
+def test_language_is_appended_to_opening_fence():
+    assert fenced_code_block("x", "python") == "```python\nx\n```"
+
+
+def test_nested_triple_fence_forces_four_backticks():
+    content = "intro\n```py\ncode\n```\noutro"
+    assert fenced_code_block(content) == f"````\n{content}\n````"
+
+
+def test_fence_grows_past_longest_backtick_run():
+    # Longest run is 4 backticks, so the wrapper must use 5.
+    content = "before ```` after"
+    assert fenced_code_block(content) == f"`````\n{content}\n`````"
+
+
+def test_inline_backticks_below_three_keep_triple_fence():
+    content = "use `code` and ``more`` here"
+    assert fenced_code_block(content) == f"```\n{content}\n```"

--- a/src/tests/unit_tests/dial_files_tooling/test_search_in_file_tool.py
+++ b/src/tests/unit_tests/dial_files_tooling/test_search_in_file_tool.py
@@ -4,10 +4,10 @@ import pytest
 from aidial_client._exception import ResourceNotFoundError
 
 from quickapp.common.exceptions import InvalidToolCallParameterException
+from quickapp.common.utils import fenced_code_block
 from quickapp.dial_core_services.dial_file_service import FolderEntry
 from quickapp.dial_files_tooling._search_in_file_tool import _SearchInFileTool
 from quickapp.dial_files_tooling._tool_configs import SEARCH_IN_FILE_TOOL_CONFIG
-from quickapp.dial_files_tooling._utils import code_block
 from tests.unit_tests.dial_files_tooling._helpers import make_config, make_service
 
 
@@ -79,7 +79,7 @@ class TestSearchFileMode:
     async def test_single_match(self):
         tool = _make_tool("foo\nbar\nbaz")
         result = await tool._run_in_stage_async(stage_wrapper=None, path="x", pattern="bar")
-        assert result.content == code_block("2:bar")
+        assert result.content == fenced_code_block("2:bar")
 
     @pytest.mark.asyncio
     async def test_no_matches(self):
@@ -102,7 +102,7 @@ class TestSearchFileMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="x", pattern="ERR", context_lines=1
         )
-        assert result.content == code_block("1:ERR\n2:a\n--\n4:c\n5:ERR")
+        assert result.content == fenced_code_block("1:ERR\n2:a\n--\n4:c\n5:ERR")
 
     @pytest.mark.asyncio
     async def test_context_lines_adjacent_windows_merge(self):
@@ -111,7 +111,7 @@ class TestSearchFileMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="x", pattern="ERR", context_lines=1
         )
-        assert result.content == code_block("1:a\n2:ERR\n3:b\n4:c\n5:ERR\n6:d")
+        assert result.content == fenced_code_block("1:a\n2:ERR\n3:b\n4:c\n5:ERR\n6:d")
 
     @pytest.mark.asyncio
     async def test_output_mode_in_file_mode_ignored(self):
@@ -120,7 +120,7 @@ class TestSearchFileMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="x", pattern="a", output_mode="count"
         )
-        assert result.content == code_block("1:a")
+        assert result.content == fenced_code_block("1:a")
 
     @pytest.mark.asyncio
     async def test_name_filter_in_file_mode_ignored(self):
@@ -128,7 +128,7 @@ class TestSearchFileMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="x", pattern="a", name_filter="*.md"
         )
-        assert result.content == code_block("1:a")
+        assert result.content == fenced_code_block("1:a")
 
     @pytest.mark.asyncio
     async def test_max_depth_in_file_mode_ignored(self):
@@ -136,7 +136,7 @@ class TestSearchFileMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="x", pattern="bar", max_depth=3
         )
-        assert result.content == code_block("2:bar")
+        assert result.content == fenced_code_block("2:bar")
 
 
 class TestSearchFolderMode:
@@ -152,7 +152,7 @@ class TestSearchFolderMode:
         tool._dial_file_service.list_folder.assert_awaited_once_with(
             "files/appbucket/", max_depth=10
         )
-        assert result.content == code_block("a.md\n2:ERROR here")
+        assert result.content == fenced_code_block("a.md\n2:ERROR here")
 
     @pytest.mark.asyncio
     async def test_content_mode_groups_matches_per_file(self):
@@ -165,7 +165,7 @@ class TestSearchFolderMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="reports/", pattern="ERROR"
         )
-        assert result.content == code_block("a.md\n1:ERROR one\n\nb.txt\n2:ERROR two")
+        assert result.content == fenced_code_block("a.md\n1:ERROR one\n\nb.txt\n2:ERROR two")
 
     @pytest.mark.asyncio
     async def test_files_with_matches_mode(self):
@@ -178,7 +178,7 @@ class TestSearchFolderMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="reports/", pattern="ERROR", output_mode="files_with_matches"
         )
-        assert result.content == code_block("a.md")
+        assert result.content == fenced_code_block("a.md")
 
     @pytest.mark.asyncio
     async def test_count_mode_is_rejected(self):
@@ -199,7 +199,7 @@ class TestSearchFolderMode:
         }
         tool = _make_folder_tool(entries, contents)
         result = await tool._run_in_stage_async(stage_wrapper=None, path="d/", pattern="ERROR")
-        assert result.content == code_block("b.md\n1:ERROR text")
+        assert result.content == fenced_code_block("b.md\n1:ERROR text")
 
     @pytest.mark.asyncio
     async def test_oversized_file_skipped(self):
@@ -210,7 +210,7 @@ class TestSearchFolderMode:
         }
         tool = _make_folder_tool(entries, contents)
         result = await tool._run_in_stage_async(stage_wrapper=None, path="d/", pattern="ERROR")
-        assert result.content == code_block("b.md\n1:ERROR text")
+        assert result.content == fenced_code_block("b.md\n1:ERROR text")
 
     @pytest.mark.asyncio
     async def test_name_filter_excludes_before_download(self):
@@ -223,7 +223,7 @@ class TestSearchFolderMode:
         result = await tool._run_in_stage_async(
             stage_wrapper=None, path="data/", pattern="2026-Q1", name_filter="**/*.csv"
         )
-        assert result.content == code_block("data/a.csv\n1:2026-Q1 row")
+        assert result.content == fenced_code_block("data/a.csv\n1:2026-Q1 row")
         # The .json was filtered out before any download was attempted.
         tool._dial_file_service.download_file.assert_awaited_once_with("files/appbucket/data/a.csv")
 

--- a/src/tests/unit_tests/mcp_tool_tests/test_stage_wrapper.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_stage_wrapper.py
@@ -198,6 +198,23 @@ def test_build_debug_info_from_params_and_exception(mock_stage, wrapper, params)
     mock_stage.append_content.assert_any_call(expected_exception)
 
 
+def test_plain_text_response_is_fenced_without_language(mock_stage, wrapper):
+    result = ToolCallResult(content="line1\nline2", content_type="text/plain")
+
+    output = wrapper._build_debug_info_from_result(result)
+
+    assert output == "> ##### Response:\n```\nline1\nline2\n```\n"
+
+
+def test_response_with_embedded_fence_uses_longer_wrapping_fence(mock_stage, wrapper):
+    content = "intro\n```python\nprint('hi')\n```\noutro"
+    result = ToolCallResult(content=content, content_type="text/plain")
+
+    output = wrapper._build_debug_info_from_result(result)
+
+    assert output == f"> ##### Response:\n````\n{content}\n````\n"
+
+
 def test_exception_handling_in_format_response(mock_stage, wrapper, params):
     result = ToolCallResult(
         content="{'content': 'response content'}", content_type="application/json"

--- a/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
+++ b/src/tests/unit_tests/skills_tests/test_skill_reader_stage_wrapper.py
@@ -45,3 +45,14 @@ def test_build_debug_info_from_exception_wraps_message_in_code_fence(wrapper):
     output = wrapper._build_debug_info_from_exception(exception)
 
     assert output == "Error:\n```\nskill not found\n```\n"
+
+
+def test_build_debug_info_from_result_uses_longer_fence_for_nested_fences(wrapper):
+    # A skill body that itself contains a ``` code fence must not break out of
+    # the wrapping fence, otherwise the rendered stage in the UI is corrupted.
+    skill_content = "intro\n```python\nprint('hi')\n```\noutro"
+    result = ToolCallResult(content=skill_content, content_type="text/markdown")
+
+    output = wrapper._build_debug_info_from_result(result)
+
+    assert output == f"Skill Content:\n````\n{skill_content}\n````\n"


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR -->
- fixes #

### Description of changes

Reading a skill whose body contains ` ``` ` code fences corrupted the rendered stage in the UI. The content was wrapped in a **fixed** triple-backtick fence, so (per CommonMark, where a fenced block closes on the first line with ≥ as many backticks as the opening fence) the first nested fence closed the wrapper early and everything after it spilled outside the code block. The same latent bug existed in every other stage wrapper that renders arbitrary tool/response content.

**Core fix**

- Add a shared `fenced_code_block(text, language="")` helper in `common/utils.py` that opens with a fence **one backtick longer than the longest backtick run** in the content (minimum three), so embedded fences can never break out.
- Route `_SkillReaderStageWrapper` (the reported bug — both result and error paths) through it.
- Collapse the duplicate `BaseStageWrapper._code_fence` into the shared helper.
- Remove the local `code_block` wrapper from the DIAL file tools (`dial_files_tooling/_utils.py`, `_search_in_file_tool.py`) and use `fenced_code_block` directly.

**Same bug class in other stage wrappers**

- **MCP** (`_mcp_stage_wrapper.py`) and **REST** (`_rest_api_stage_wrapper.py`) result/response paths now use the helper, so an MCP server or HTTP response returning markdown with ` ``` ` no longer breaks the stage. This also fixes a pre-existing bug where a `text/plain` MCP response placed the whole body on the opening fence line as the info string.
- REST error-response body and the initialization-error `details` blocks (`_initialization_error_handler.py`) go through the helper too.

JSON-dump sites (request params, py-interpreter result) are intentionally left unchanged: a bare ` ``` ` closing line cannot occur in single-token-per-line JSON output.

For backtick-free content the output is byte-identical to before, so existing rendering and assertions are unchanged. Regression tests added for the skill reader, the shared helper, the MCP plain-text/nested-fence path, and the init-error `details` path.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)
- [x] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [x] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.