### PR TITLE
chore: refresh quickapps-code-review checklist from recent PR comments

### DIFF
--- a/.claude/skills/quickapps-code-review/SKILL.md
+++ b/.claude/skills/quickapps-code-review/SKILL.md
@@ -54,12 +54,16 @@ Do NOT auto-apply fixes unless the user asks — surface them first.
 The single most common review comment is some form of **"why is this here?"** — apply that lens to every new file, field, parameter, import, and comment.
 
 ### 1. Necessity — "why is this here?"
+
+**This is the single most frequently left comment — most often phrased "is it used?" / "where is it used?" / "clean up".** Trace every new symbol to a real consumer before submitting.
+
 - [ ] Any new field, parameter, import, file, or comment that isn't load-bearing? Delete it.
-- [ ] **New function with no production call sites?** Grep/`findReferences` every new symbol. Delete it, inline it, or mark test-only in the name/docstring. *e.g. a helper left behind after a refactor path was removed.*
-- [ ] Sync fallback kept alongside a new async production path, used only by unit tests? Prefer async tests with a fake/stub, or document `test-only` explicitly — don't leave ambiguous dual APIs.
+- [ ] Method or function defined but never called (dead code)? Delete it — verify with LSP `findReferences`, not a guess.
+- [ ] Local variable assigned but unused, or used exactly once? Drop it or inline the expression.
+- [ ] Public method that only delegates to a private one with no added logic? Collapse them into one.
 - [ ] Unused subclass parameter required by parent interface? Mark intent explicitly (e.g. `del param`) — don't silently leave it.
 - [ ] Self-explanatory code annotated with a redundant comment? Drop the comment.
-- [ ] Redundant control flow (e.g. `else` after a branch that already returns/handles)? Drop it.
+- [ ] Redundant control flow (e.g. `else` after a branch that already returns/handles), or a check made redundant by an earlier filter/guard? Drop it.
 
 ### 2. PR scope
 - [ ] Diff contains unrelated renames, refactors, test scaffolding, or fixtures? Split into a separate PR.
@@ -68,11 +72,15 @@ The single most common review comment is some form of **"why is this here?"** �
 
 ### 3. Module boundaries / imports
 - [ ] Upward imports against the documented dependency direction (shared layers must not import from feature layers)? Fix the direction. *Example: `common/` importing from `agent/`.*
-- [ ] Reaching into a dependency's internals when its public API exposes the same symbol? Prefer the public surface — even when the internal is re-exported.
+- [ ] Reaching into a dependency's internals when its public API exposes the same symbol? Prefer the public surface — even when the internal is re-exported. *Includes importing from a third-party private package (e.g. `aidial_client._...`) when the symbol is re-exported by its public package.*
 - [ ] Sibling feature modules importing each other? Extract shared code into a shared layer.
+- [ ] Code (and its DI binding) consumed by exactly one module but parked in a shared/`common/` layer? Move it into the consuming module; only genuinely cross-cutting code belongs in shared.
+- [ ] Accessing a protected member (`_x`) of another module's class? That's a boundary leak — expose a public surface or relocate the code.
+- [ ] Imports *between modules inside the same internal package* (`_foo.py` ↔ `_bar.py`)? Use relative imports (`from ._bar import ...`) to avoid circular imports at package load.
 
 ### 4. DI / Injector
 - [ ] Service instantiated directly (`Foo()`) where another site injects it? Unify on constructor injection.
+- [ ] Value threaded through as a constructor/method parameter when it's already available via injection (e.g. request-scoped messages, config)? Inject it instead of passing it.
 - [ ] New DI binding added? It must be wired into **every** assembly point (prod entry + integration-test container).
 - [ ] Duplicate bindings of the same protocol/type? Pick one.
 - [ ] **Request-scoped type bound in a module but parameter typed `T | None = None`?** If every production call site injects it, make the parameter required — optional-only-for-tests confuses, as this project uses injector for dependencies. Use a test double via DI, not `None` defaults.
@@ -81,10 +89,11 @@ The single most common review comment is some form of **"why is this here?"** �
 - [ ] Any `os.getenv` in app code? **Reject.** Move to a `pydantic-settings` `BaseSettings`. To check if an env var was actually set, use `"field_name" in settings.model_fields_set`.
 - [ ] New `import os` solely for env access? Drop it.
 
-### 6. Naming
-- [ ] Name leaks the implementation entity rather than describing the feature? Prefer feature-oriented names.
+### 6. Naming & consistency
+- [ ] Name leaks the implementation entity rather than describing the feature? Prefer feature-oriented names. *Also: name new constructs generically when a feature request to broaden them is foreseeable (e.g. `static_tools` over a vendor-specific name).*
 - [ ] Same string appears in code, JSON config, defaults, and error messages? Lift it to a single shared constant and reference it everywhere.
 - [ ] Subclass/identifier name doesn't match the actual exposed name (after a rename)? Realign all references.
+- [ ] Re-implementing a mechanism that already exists elsewhere (a decorator, helper, or base pattern used for sibling cases)? Reuse or generalize the existing one instead of writing a bespoke variant. *Example: a one-off `nullify` over building a shared `nullify_preview_fields`.*
 
 ### 7. Design doc fidelity
 - [ ] Touched a feature with a doc under `docs/designs/`? Update the doc body to match what was actually built.
@@ -105,6 +114,8 @@ The single most common review comment is some form of **"why is this here?"** �
 
 ### 10. Decomposition
 - [ ] Method handles 2+ distinct phases? Extract each into a named method.
+- [ ] Class doing 2+ jobs or accumulating many constructor dependencies (e.g. invocation *and* config building)? Split the responsibilities into separate classes.
+- [ ] Same non-trivial logic appears in two places (even if it covers "different phases")? Either unify it or leave a comment justifying the intentional duplication.
 - [ ] Passing a collaborator into a free function that could be a method on that collaborator? Move it.
 - [ ] Nested branches that compute a boolean? Extract a one-liner.
 
@@ -133,6 +144,10 @@ The single most common review comment is some form of **"why is this here?"** �
 - [ ] **Runtime strip when preview is off?** Extend `nullify_preview_fields` (or shared preview validation) instead of bespoke `isinstance` + filter logic in `_gate_preview_fields`. Special-casing one preview type in `ApplicationConfig` will get "can you make it general, like `nullify_preview_fields`?"
 - [ ] Preview-off behaviour must log a warning when configured values are dropped — but through the shared preview path when possible, not duplicate warning strings.
 
+### 17. Exception handling
+- [ ] Broad `except Exception` that wraps/re-raises errors which a narrower handler above already raised intentionally (e.g. a 422 swallowed and re-thrown as 500)? Let the intended error propagate; catch narrowly or re-raise the original.
+- [ ] Catching `Exception` where the operation has known failure modes? Catch the specific types instead (e.g. `UnicodeDecodeError` when decoding bytes, the SDK's `ResourceNotFoundError`/`EtagMismatchError` for file ops).
+
 ## Red flags — stop and reconsider
 
 If you find yourself thinking any of these while reviewing your own change, treat it as a blocker:
@@ -140,6 +155,9 @@ If you find yourself thinking any of these while reviewing your own change, trea
 | Thought | Reaction |
 |---|---|
 | "This bit isn't strictly needed but might be useful later" | Delete it — a reviewer will ask "why is this here?" |
+| "This method/var might get used eventually" | If nothing calls it now, delete it — "is it used?" is the #1 comment. |
+| "I'll wrap `except Exception` around it to be safe" | You may be swallowing a specific error a caller relies on. Catch narrowly. |
+| "I'll put this helper in `common/` for now" | If one module uses it, it lives in that module. |
 | "I'll just sneak this rename in" | No. Separate PR. |
 | "It's just one `os.getenv`" | Move to BaseSettings. |
 | "I'll update the design doc in a follow-up" | Do it in this PR. |


### PR DESCRIPTION
### Applicable issues

- N/A — internal tooling (Claude Code skill) refresh, no product issue.

### Description of changes

Refreshes the `quickapps-code-review` self-review checklist from reviewer
feedback left on PRs merged/opened since the last refresh (#331), following
the skill's own `references/REFRESHING.md` procedure. Markdown-only change to
`.claude/skills/quickapps-code-review/SKILL.md` — no app code, schema, or docs.

Clusters of recurring feedback folded in:

- **§1 Necessity** — dead/unused code is by far the most frequent comment
  ("is it used?", "Dead method", unused var, pointless public→private wrapper).
  Added explicit checks. _(#362, #314, #309, #301, #279)_
- **§3 Module boundaries** — co-locate single-consumer code instead of `common/`;
  protected-member access is a boundary leak; relative imports inside internal
  packages; prefer public over private third-party packages. _(#279, #323, #257)_
- **§4 DI** — inject values instead of threading them as params. _(#308)_
- **§6 Naming & consistency** — reuse/generalize existing mechanisms. _(#362, #316, #301)_
- **§10 Decomposition** — split classes with too many deps / two jobs; flag
  duplicated logic. _(#308, #279)_
- **§16 Exception handling (new)** — don't let broad `except` swallow intended
  status errors; catch specific types. _(#323)_
- **Red flags** — rows for keep-just-in-case code, blanket `except`, `common/` dumping.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
