### PR TITLE
chore: add .worktreeinclude for claude code

### DIFF
--- a/.worktreeinclude
+++ b/.worktreeinclude
@@ -1,0 +1,7 @@
+.env
+.idea
+.venv
+docker_compose_files/core/data/
+docker_compose_files/core/configuration/generated/
+docker_compose_files/core/admin-export/out.json
+docker_compose_files/core/logs/


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

Git worktrees start from a clean checkout and therefore omit any gitignored files. Several of those files are required for a worktree to be usable for local development with Claude Code — environment config, IDE settings, the local DIAL Core data/configuration, and logs — so a fresh worktree is missing pieces needed to run the app.

This adds a `.worktreeinclude` manifest listing the gitignored paths Claude Code should copy into a new worktree so it is immediately functional:

- `.env`, `.idea`, `.venv`
- `docker_compose_files/core/data/`
- `docker_compose_files/core/configuration/generated/`
- `docker_compose_files/core/admin-export/out.json`
- `docker_compose_files/core/logs/`

Tooling/config only — no application behavior changes.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Design documented is updated/created and approved by the team (if applicable)
- [ ] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
