### PR TITLE
feat: promote dial files tools to GA, gate offload behind preview

### DIFF
--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -1083,8 +1083,16 @@
           "type": "string"
         },
         "tool_call_result_offload": {
-          "$ref": "#/$defs/ToolCallResultOffloadConfig",
-          "description": "Offload oversized tool-call responses to a file, read back on demand via the read_lines / search file tools. Toggled by its `enabled` flag, whose default is governed by TOOL_CALL_RESULT_OFFLOAD__ENABLED_BY_DEFAULT. Requires read_lines and search to be exposed via enabled_tools."
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ToolCallResultOffloadConfig"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "description": "Offload oversized tool-call responses to a file, read back on demand via the read_lines / search file tools. Toggled by its `enabled` flag, whose default is governed by TOOL_CALL_RESULT_OFFLOAD__ENABLED_BY_DEFAULT. Requires read_lines and search to be exposed via enabled_tools.",
+          "x-preview": true
         },
         "max_files_scanned": {
           "default": 50,
@@ -1335,8 +1343,7 @@
             }
           ],
           "default": null,
-          "description": "Built-in DIAL files tools (list / read / search / write / edit / delete / copy / move).",
-          "x-preview": true
+          "description": "Built-in DIAL files tools (list / read / search / write / edit / delete / copy / move)."
         }
       },
       "title": "Features",

--- a/src/quickapp/config/application.py
+++ b/src/quickapp/config/application.py
@@ -186,7 +186,7 @@ class Features(BaseModel):
         default_factory=StageDisplayConfig,
         description="Controls which stage levels are rendered to the user.",
     )
-    dial_files: DialFilesConfig | None = PreviewField(  # type: ignore[assignment]
+    dial_files: DialFilesConfig | None = Field(
         default=None,
         description="Built-in DIAL files tools (list / read / search / write / edit / delete / copy / move).",
     )

--- a/src/quickapp/config/dial_files.py
+++ b/src/quickapp/config/dial_files.py
@@ -3,6 +3,8 @@ from typing import Literal
 from pydantic import BaseModel, Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from quickapp.common.base_config import PreviewField
+
 DialFilesToolName = Literal[
     "list",
     "read_lines",
@@ -77,7 +79,7 @@ class DialFilesConfig(BaseModel):
             "and '..' segments are rejected. Example: 'workspace/'."
         ),
     )
-    tool_call_result_offload: ToolCallResultOffloadConfig = Field(
+    tool_call_result_offload: ToolCallResultOffloadConfig | None = PreviewField(  # type: ignore[assignment]
         default_factory=ToolCallResultOffloadConfig,
         description=(
             "Offload oversized tool-call responses to a file, read back on demand via the "

--- a/src/quickapp/dial_files_tooling/dial_files_tooling_module.py
+++ b/src/quickapp/dial_files_tooling/dial_files_tooling_module.py
@@ -7,7 +7,6 @@ from injector import AssistedBuilder, Binder, Module, multiprovider, provider
 from quickapp.common import StagedBaseTool
 from quickapp.common.abstract.tool_call_result_processor import ToolCallResultProcessor
 from quickapp.common.exceptions import InitializationException, OffloadConfigurationException
-from quickapp.common.preview import preview_module
 from quickapp.common.tool_names import (
     INTERNAL_FILE_READ_LINES_TOOL_NAME,
     INTERNAL_FILE_SEARCH_TOOL_NAME,
@@ -43,7 +42,6 @@ from quickapp.dial_files_tooling._write_file_tool import _WriteFileTool
 logger = logging.getLogger(__name__)
 
 
-@preview_module
 class DialFilesToolingModule(Module):
 
     def configure(self, binder: Binder) -> None:
@@ -145,8 +143,7 @@ class DialFilesToolingModule(Module):
                 enabled=False, size_threshold=0, excluded_tools=frozenset()
             )
         offload = cfg.tool_call_result_offload
-        if not offload.enabled:
-            # Operator explicitly turned offload off: stay inline, no warning.
+        if offload is None or not offload.enabled:
             return ResolvedOffloadConfig(
                 enabled=False, size_threshold=0, excluded_tools=frozenset()
             )


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

File tools (`list`, `read_lines`, `search`, `find`, `write`, `edit`, `delete`, `copy`, `move`) are production-ready and no longer require `ENABLE_PREVIEW_FEATURES=true`.

**Changes:**
- Remove `@preview_module` from `DialFilesToolingModule` — the module now registers in every environment regardless of the preview flag.
- Promote `Features.dial_files` from `PreviewField` to a regular `Field` — the config is no longer nullified when preview features are off.

The tool-call-result offload sub-feature remains behind the preview flag (it is still experimental):
- `DialFilesConfig.tool_call_result_offload` is now typed `ToolCallResultOffloadConfig | None` with `PreviewField`, so it is nullified when preview is off.
- `_provide_offload_config` gains a `None` guard before reading `.enabled`, returning a disabled `ResolvedOffloadConfig` when the field is absent.

Schema regenerated: `x-preview` removed from `dial_files`, added to `tool_call_result_offload`.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
