### PR TITLE
chore: revise CODEOWNERS with per-module ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,30 @@
-* @ypldan
-/.github/ @MykhailoRyzhman
+* @andrii-novikov @ypldan
+
+# Infra / CI configuration ownership.
+/.github/ @dspashynskyi @nepalevov
+
+src/quickapp/agent_hooks/ @korotaav48
+src/quickapp/orchestrator_attachment_strategies/ @VinShurik
+src/quickapp/usage_statistics/ @VinShurik
+src/quickapp/configuration_support/ @VinShurik
+src/quickapp/starters/ @korotaav48 @ypldan
+
+# --- Tooling: tool-integration layer (MCP/REST/DIAL/internal/etc) ---
+src/quickapp/predefined_tooling/ @VinShurik
+src/quickapp/mcp_tooling/ @korotaav48
+src/quickapp/internal_tooling/ @VinShurik
+src/quickapp/timestamp_tooling/ @andrii-novikov @ypldan
+src/quickapp/dial_deployment_tooling/ @VinShurik @ypldan
+src/quickapp/dial_app_tooling/ @VinShurik @ypldan
+src/quickapp/rest_api_tooling/ @korotaav48 @ypldan
+src/quickapp/dial_files_tooling/ @andrii-novikov
+
+# --- File services & DIAL infra ---
+src/quickapp/dial_core_services/ @VinShurik
+src/quickapp/attachment_processing/ @VinShurik
+src/quickapp/file_transfer/ @korotaav48
+src/quickapp/shared/external_fetch/ @andrii-novikov @ypldan
+
+# --- Skills: skill loading/runtime + DIAL prompt-skill resolution ---
+src/quickapp/skills/ @korotaav48
+src/quickapp/dial_prompt_skills/ @korotaav48 @ypldan

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,11 +20,11 @@ src/quickapp/rest_api_tooling/ @korotaav48 @ypldan
 src/quickapp/dial_files_tooling/ @andrii-novikov
 
 # --- File services & DIAL infra ---
-src/quickapp/dial_core_services/ @VinShurik
+src/quickapp/dial_core_services/ @VinShurik @korotaav48
 src/quickapp/attachment_processing/ @VinShurik
 src/quickapp/file_transfer/ @korotaav48
 src/quickapp/shared/external_fetch/ @andrii-novikov @ypldan
 
 # --- Skills: skill loading/runtime + DIAL prompt-skill resolution ---
 src/quickapp/skills/ @korotaav48
-src/quickapp/dial_prompt_skills/ @korotaav48 @ypldan
+src/quickapp/dial_prompt_skills/ @korotaav48 @VinShurik @ypldan


### PR DESCRIPTION
### Applicable issues

- N/A

### Description of changes

The `CODEOWNERS` file previously routed every review to a single global owner (`* @ypldan`). This revision distributes review ownership per module across the team, so PRs auto-request the reviewers who actually work on the touched area.

Ownership was derived from an analysis of each module's contribution history (commit counts, line churn, recency) combined with the `src/quickapp/` module structure:

- **Global fallback:** `@andrii-novikov` added as the catch-all owner alongside `@ypldan`.
- **Per-module owners** assigned across orchestration core, config / app-builder support, the tooling integration layer, file services, and skills.
- **Sole specialist:** `dial_files_tooling/` → `@andrii-novikov`.
- **Infra / CI** (`/.github`) owned by its maintainers.

Ordering follows CODEOWNERS last-match-wins semantics: the global `*` rule is first, with the more specific path rules below it. No code or behavior change — this updates ownership metadata only.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
