### PR TITLE
chore: use project-local tmp dir in create-pr skill

### DIFF
--- a/.claude/skills/quickapps-create-pr/SKILL.md
+++ b/.claude/skills/quickapps-create-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: quickapps-create-pr
 description: Use when the user asks to "create a PR", "open a pull request", "raise a PR", "ship this", or "/quickapps-create-pr" in this repo. Drives the project's end-to-end PR flow — feature branch, conventional-commit title/body, the pre-PR format+lint gate, push, and `gh pr create --base development` with the repo's PR template filled in.
-allowed-tools: Read Grep Glob LSP Write(/tmp/*) Bash(git status:*) Bash(git diff:*) Bash(git log:*) Bash(git rev-parse:*) Bash(git branch:*) Bash(git checkout:*) Bash(git switch:*) Bash(git stash:*) Bash(git add:*) Bash(git commit:*) Bash(git push:*) Bash(gh pr create:*) Bash(gh pr view:*) Bash(gh pr list:*) Bash(make format:*) Bash(make lint:*) Bash(make test:*) Bash(date:*)
+allowed-tools: Read Grep Glob LSP Write(./tmp/*) Bash(git status:*) Bash(git diff:*) Bash(git log:*) Bash(git rev-parse:*) Bash(git branch:*) Bash(git checkout:*) Bash(git switch:*) Bash(git stash:*) Bash(git add:*) Bash(git commit:*) Bash(git push:*) Bash(gh pr create:*) Bash(gh pr view:*) Bash(gh pr list:*) Bash(make format:*) Bash(make lint:*) Bash(make test:*) Bash(date:*) Bash(mkdir:*)
 argument-hint: "[issue-number]"
 arguments: issue
 model: opus
@@ -121,11 +121,11 @@ git push -u origin <branch>
 - **Keep every checklist point** from the template — do not delete rows. Tick `[x]` only the ones you've actually verified, leave the rest `[ ]`. `Title follows Conventional Commits` is safe to tick; **leave `Integration tests pass` and `Changes are tested on review environment` unticked** unless they really ran (they're CI/reviewer responsibilities, and Step 2 doesn't run them locally). If a config/schema model changed, the schema-compat row is load-bearing — address it.
 - Keep the license confirmation line at the bottom.
 
-Write the filled body with the **Write** tool to `/tmp/quickapp_pr_body.md` (not a shell heredoc).
+Write the filled body with the **Write** tool to `./tmp/quickapp_pr_body.md` — a project-local, gitignored scratch dir (`mkdir -p ./tmp` first if it doesn't exist yet) — not the global `/tmp` and not a shell heredoc.
 
 ### 6. Open the PR
 
-With the body already written to `/tmp/quickapp_pr_body.md` (Step 5):
+With the body already written to `./tmp/quickapp_pr_body.md` (Step 5):
 
 ```bash
 gh pr create \
@@ -133,7 +133,7 @@ gh pr create \
   --head <branch> \
   --assignee @me \
   --title "<type>: <subject>" \
-  --body-file /tmp/quickapp_pr_body.md
+  --body-file ./tmp/quickapp_pr_body.md
 ```
 
 `--base development` is non-negotiable — this repo's default base is `development`, never `main`/`master`.

--- a/.claude/skills/quickapps-create-pr/SKILL.md
+++ b/.claude/skills/quickapps-create-pr/SKILL.md
@@ -119,6 +119,7 @@ git push -u origin <branch>
 - Fill `### Applicable issues` with `fixes #<issue>` (or leave `fixes #` if none).
 - Fill `### Description of changes` with the **why** first (problem/motivation), then the key implementation points — expand on the commit body. Add screenshots for user-visible / stage-rendering changes.
 - **Keep every checklist point** from the template — do not delete rows. Tick `[x]` only the ones you've actually verified, leave the rest `[ ]`. `Title follows Conventional Commits` is safe to tick; **leave `Integration tests pass` and `Changes are tested on review environment` unticked** unless they really ran (they're CI/reviewer responsibilities, and Step 2 doesn't run them locally). If a config/schema model changed, the schema-compat row is load-bearing — address it.
+- **If a checklist point doesn't apply to this PR** (e.g. "Design documented..." on a pure refactor with no design doc), don't delete the row and don't just leave it unticked — cross it out with `~~...~~` so the reviewer can tell "not applicable" apart from "not done". Leave a short parenthetical reason, e.g. `- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for this change)`.
 - Keep the license confirmation line at the bottom.
 
 Write the filled body with the **Write** tool to `./tmp/quickapp_pr_body.md` — a project-local, gitignored scratch dir (`mkdir -p ./tmp` first if it doesn't exist yet) — not the global `/tmp` and not a shell heredoc.
@@ -175,5 +176,5 @@ Print the PR URL `gh` returns. Give the user a 3-line summary: branch, title, an
 - **Empty `fixes #`** left when an issue exists — pass `$issue` or infer it.
 - **Body that only says *what*** — reviewers want the *why*. Lead with motivation.
 - **Unstaged schema/cache regen** from `make format`/`make dump_app_schema` — always commit regenerated artifacts.
-- **Deleting checklist rows** — keep every point from `.github/pull_request_template.md`; tick the ones you verified, leave the rest unchecked. Don't remove rows.
+- **Deleting checklist rows** — keep every point from `.github/pull_request_template.md`; tick the ones you verified, leave the rest unchecked, and cross out (`~~...~~`) the ones that don't apply with a short reason. Don't remove rows.
 - **Reproducing the PR template from memory** — read `.github/pull_request_template.md` each time; it's the source of truth and it changes.


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #

### Description of changes

<!-- Please explain the changes you made right below this line. -->
Two follow-up fixes to the `quickapps-create-pr` skill's PR-body handling:

1. The skill wrote the PR body to the global `/tmp/quickapp_pr_body.md`, outside the project tree. Point it at `./tmp/quickapp_pr_body.md` instead — the project root already gitignores `/tmp/`, so it's a safe, self-contained scratch location without leaving the worktree.
   - `allowed-tools` frontmatter: `Write(/tmp/*)` → `Write(./tmp/*)`, and added `Bash(mkdir:*)` so the skill can create the dir if missing.
   - Step 5/6 instructions and the `gh pr create --body-file` example now reference `./tmp/quickapp_pr_body.md`.
2. A checklist row left unticked reads the same to a reviewer whether it's "not applicable" or "not done yet". The skill now instructs crossing out (`~~...~~`) rows that don't apply, with a short reason, instead of just leaving them unticked or deleting them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for this skill-only change)
- ~~[ ] Documentation is updated/created (if applicable)~~
- ~~[ ] Changes are tested on review environment~~
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~
- ~~[ ] Integration tests pass~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
