### PR TITLE
feat: agent awareness of subagents conversation mode

### DIFF
--- a/docs/designs/subagents_conversation_mode.md
+++ b/docs/designs/subagents_conversation_mode.md
@@ -1,0 +1,217 @@
+# Design: Subagent Conversation Mode and Awareness
+
+- **Status:** Implemented
+
+## Problem Statement
+
+When the orchestrator LLM calls a deployment tool (subagent), it has no way to know whether the subagent is stateless (each call is independent) or maintains conversation history. The operator may configure `propagate_history=True` or `conversation_mode=stateful`, which causes the backend to reconstruct and prepend prior `[user, assistant]` exchanges on each call — but the LLM is unaware of this. This creates two distinct problems.
+
+### 1. Redundant context injection
+
+The LLM's universal fallback assumption is that every tool call is stateless. So when it calls a history-aware subagent for the second time — say, to provide an employee ID that the subagent asked for — it re-summarizes the entire prior exchange into `query`:
+
+> "Previously you asked me to assign badge 'Happy 5th Anniversary' to John Smith and requested an EmployeeID. The ID is 123456, please proceed."
+
+But because `conversation_mode=stateful`, the backend has already reconstructed and prepended the prior `[user, assistant]` exchange. The subagent now receives the prior context twice: once in the prepended history, once in the new `query`. This causes confusion, wasted tokens, and potentially incorrect behavior.
+
+The LLM should instead send only the **delta** — the new information that wasn't in the prior exchange:
+
+> "123456"
+
+### 2. No conversation thread isolation across multiple subagent instances
+
+`_extract_tool_history` currently identifies prior exchanges by **tool name only**. When the LLM calls the same tool multiple times in parallel — for example, spinning up two independent research subagents — all prior calls to that tool name pool into a single history. The LLM receives back clarifying questions from both subagents mixed together in tool results, with no way to route its follow-up answers to the correct instance.
+
+A `session_id` argument lets the LLM tag each call with a thread identifier, enabling `_extract_tool_history` to filter by `(tool_name, session_id)` rather than `tool_name` alone.
+
+---
+
+## Design Goals
+
+- The LLM must be aware, per tool, whether the subagent has conversation history — so it sends only the delta on follow-up calls.
+- `conversation_mode` (operator config) is the authoritative switch for whether the backend propagates history. The LLM does not set this; it is fixed at app-authoring time.
+- `session_id` isolates conversation threads when the same tool is invoked multiple times in a session.
+- Preserve full backward-compatibility: existing `propagate_history=True` manifests and `stateless` (default) tools are unchanged.
+
+---
+
+## Use Cases
+
+### UC-1: Single stateful subagent — multi-step task
+
+**Trigger:** User asks the orchestrator: "Assign badge 'Happy 5th Anniversary' to John Smith."
+
+**Behavior:** Orchestrator calls `assign_badge` with `query: "Assign badge … to John Smith"` and `session_id: "badge-task-1"`. Subagent responds: "Please provide EmployeeID." Orchestrator calls `get_employee_id` → gets `123456`. Now the LLM knows `assign_badge` is history-aware (from the tool description), so it calls `assign_badge` again with `query: "123456"` and `session_id: "badge-task-1"`. The backend prepends the prior exchange for that session, and the subagent receives the full thread and completes the task.
+
+**Outcome:** The second call's `query` contains only the delta. The subagent receives the correct full context without duplication.
+
+### UC-2: Multiple parallel research subagents
+
+**Trigger:** User asks the orchestrator to research two separate topics simultaneously. The orchestrator calls `research_tool` twice in parallel: first with `session_id: "research-climate"`, second with `session_id: "research-energy"`.
+
+**Behavior:** Both subagents return clarifying questions. On follow-up, the orchestrator calls each with the same `session_id` used to start that thread. `_extract_tool_history` isolates each session's history by `(tool_name, session_id)`.
+
+**Outcome:** Each subagent receives only its own prior exchanges, not the other's. The orchestrator can correctly route answers.
+
+### UC-3: Stateless tool — no change
+
+**Trigger:** An operator configures a tool without `conversation_mode` (default) or with `conversation_mode: "stateless"`.
+
+**Behavior:** No `session_id` parameter is injected into the schema. No description suffix is added. `_extract_tool_history` is never called.
+
+**Outcome:** Identical to today's behavior. No migration required.
+
+---
+
+## Proposed Design
+
+### `conversation_mode` — two values
+
+```
+stateless   (default) — each call is independent; no history or state is propagated
+stateful    — backend reconstructs [user, assistant] pairs from the parent's messages and
+              prepends them on each call via _extract_tool_history; subagent's
+              TOOL_EXECUTION_HISTORY state is threaded back automatically
+```
+
+The admin configuring the manifest picks the mode based on what they know about the target DIAL app: `stateful` if it needs prior history sent to it; `stateless` if it handles continuity itself or has no memory.
+
+**Location:** `ConversationMode` enum in `src/quickapp/config/tools/deployment.py`, field on `ContentPropagation`.
+
+`propagate_history=True` remains and continues to trigger the same extraction path — it is not deprecated.
+
+---
+
+### LLM awareness via `enrich_openai_tool_schema`
+
+**What:** For tools with `conversation_mode=stateful`, append a suffix to `function.description` informing the LLM of stateful semantics and delta-only expectations, and inject a `session_id` parameter into the tool schema.
+
+**Where:** `StagedBaseTool.enrich_openai_tool_schema(open_ai_tool)` — no-op base method, overridden in `BaseDeploymentTool`. Wired into `AgentModule.provide_openai_tools` after `_append_default_props`, before serialization. The ordering is intentional: `_append_default_props` only touches `properties` (adds `query` and `attachment_urls`), never `description`, so `enrich_openai_tool_schema` always appends to the original description rather than to something `_append_default_props` may have written.
+
+**Description suffix (informative draft — exact wording TBD):**
+
+> "This tool is a stateful subagent: it maintains conversation history across calls within the same session. On each follow-up call, the backend automatically prepends prior exchanges for that session. **Send only the new information (delta)** in `query` — do not re-summarize prior context. Assign a unique `session_id` at the start of each conversation thread and use the same value for all follow-up calls in that thread."
+
+---
+
+### `session_id` parameter
+
+**What:** An optional string parameter injected into the tool's JSON schema for all tools where `conversation_mode=stateful`.
+
+**Where:** Injected by `BaseDeploymentTool.enrich_openai_tool_schema()` alongside the description suffix.
+
+**Schema shape:**
+```json
+"session_id": {
+  "type": "string",
+  "description": "Identifier for this conversation thread. Assign a unique value when starting a new multi-turn exchange with this subagent (e.g. 'research-climate'). Use the same session_id on all follow-up calls for that thread. Use a different session_id to start an independent conversation thread."
+}
+```
+
+**Who generates `session_id`:** The LLM. The tool description explicitly instructs it to create a unique identifier per thread and use it consistently. The LLM does not need to generate a UUID — any stable string it chooses (e.g., `"badge-task-1"`, `"research-climate"`) is sufficient. Modern instruction-following models reliably maintain such identifiers when clearly instructed.
+
+**`session_id` is NOT sent to the subagent** — it is popped from kwargs in `_run_in_stage_async` before `DialCompletionService.complete_request_async` is called, the same way `attachment_urls` is consumed at the tool layer.
+
+**Fallback when `session_id` is omitted:** If the LLM omits `session_id` on a stateful tool call (e.g., an older model that ignores injected parameters), `_extract_tool_history` falls back to `tool_name`-only filtering — all prior calls to that tool are included regardless of session, which is the same behaviour as `propagate_history=True`.
+
+---
+
+### `_extract_tool_history` changes
+
+Current signature: `_extract_tool_history(tool_name: str)`
+
+New signature: `_extract_tool_history(tool_name: str, session_id: str | None = None)`
+
+**First pass** (collecting TOOL results by `tool_call_id`) — unchanged.
+
+**Second pass** (walking ASSISTANT messages): when `session_id` is provided, only include a tool call if the parsed arguments for that call contain `"session_id": <matching value>`. Tool calls without a matching `session_id` are excluded when filtering is active.
+
+When `session_id` is `None`, falls back to filtering by `tool_name` only — preserving current behavior for `propagate_history=True` callers that do not use `session_id`.
+
+---
+
+### `_run_in_stage_async` changes
+
+At the start of the method, `session_id` is popped from kwargs (consumed here, not forwarded to the subagent). It is then passed as a keyword argument to `_extract_tool_history` when history extraction is triggered by `propagate_history=True` or `conversation_mode=stateful`.
+
+---
+
+## Secondary Fixes
+
+### Empty content with state silently dropped
+
+`_extract_tool_history` previously dropped TOOL messages with empty string content even when `custom_content.state` was present, breaking state threading for subagents that return empty text but carry internal tool-execution history. Fixed:
+
+- First pass: removed `and msg.content` guard; content normalized to `""` for `None`.
+- Second pass: guard changed from `if tool_content:` to `if tool_content or tool_custom_content:`.
+
+---
+
+## Out of Scope
+
+**LLM choosing `conversation_mode`.** Issue #88 proposed `conversation_mode` as a runtime tool argument. This design keeps it as operator config: the app author knows at wiring time whether the subagent is stateful. Making the LLM choose adds prompt-engineering fragility — the LLM must correctly infer statefulness from a description and reliably pick the right mode on every call.
+
+**`conversation_summary` mode.** Mentioned in issue #88 as a future extension. Deferred until there is a concrete use case and a summary provider is defined.
+
+**Deprecation of `propagate_history`.** Triggers the same extraction path as `stateful`. Removing it requires a deprecation notice and grace period; deferred.
+
+---
+
+## Configuration / Usage Examples
+
+### Stateful subagent — multi-step task with session isolation
+
+```json
+{
+  "type": "deployment-tool",
+  "deployment": { "endpoint": "assign-badge-app" },
+  "content_propagation": {
+    "conversation_mode": "stateful"
+  }
+}
+```
+
+The LLM will see `session_id` in the tool schema and call like:
+```json
+{ "query": "Assign badge 'Happy 5th Anniversary' to John Smith", "session_id": "badge-task-1" }
+```
+
+Follow-up (delta only):
+```json
+{ "query": "123456", "session_id": "badge-task-1" }
+```
+
+### Stateless (default)
+
+```json
+{
+  "type": "deployment-tool",
+  "deployment": { "endpoint": "search-tool" }
+}
+```
+
+No `session_id` in schema. No description suffix. No history extraction.
+
+---
+
+## Migration
+
+### Breaking changes
+
+None. Default is `stateless`; existing manifests without `conversation_mode` behave identically to today.
+
+### Non-breaking additions
+
+Default is `stateless`; existing manifests without `conversation_mode` and `propagate_history=True` callers behave identically to before.
+
+---
+
+## Summary of Changes
+
+| Component | Change |
+|---|---|
+| `config/tools/deployment.py` | `ConversationMode` enum with `STATELESS` and `STATEFUL`. `ContentPropagation.conversation_mode` documented. |
+| `common/staged_base_tool.py` | Add `enrich_openai_tool_schema(open_ai_tool)` extension hook (no-op in base, overridden in `BaseDeploymentTool`). |
+| `core/agent/agent_module.py` | `provide_openai_tools`: call `tool.enrich_openai_tool_schema(open_ai_tool)` for every tool after `_append_default_props`. |
+| `dial_deployment_tooling/base_deployment_tool.py` | Override `enrich_openai_tool_schema`: inject description suffix and `session_id` parameter when `conversation_mode=STATEFUL`. `_run_in_stage_async`: pop `session_id` from kwargs, pass to `_extract_tool_history`. `_extract_tool_history`: accept `session_id`, filter by `(tool_name, session_id)` when provided. Fix empty-content-with-state edge case. |
+| `docs/generated-app-schema.json` | Regenerated after config model changes. |

--- a/docs/designs/subagents_conversation_mode.md
+++ b/docs/designs/subagents_conversation_mode.md
@@ -41,7 +41,7 @@ A `session_id` argument lets the LLM tag each call with a thread identifier, ena
 
 **Trigger:** User asks the orchestrator: "Assign badge 'Happy 5th Anniversary' to John Smith."
 
-**Behavior:** Orchestrator calls `assign_badge` with `query: "Assign badge … to John Smith"` and `session_id: "badge-task-1"`. Subagent responds: "Please provide EmployeeID." Orchestrator calls `get_employee_id` → gets `123456`. Now the LLM knows `assign_badge` is history-aware (from the tool description), so it calls `assign_badge` again with `query: "123456"` and `session_id: "badge-task-1"`. The backend prepends the prior exchange for that session, and the subagent receives the full thread and completes the task.
+**Behavior:** Orchestrator calls `assign_badge` with `query: "Assign badge … to John Smith"` (no `session_id` — first call). The backend assigns `session_id = tool_call_id` and appends `[session_id: call-abc]` to the response. Subagent responds: "Please provide EmployeeID." Orchestrator calls `get_employee_id` → gets `123456`. Now the LLM echoes the session_id, calling `assign_badge` again with `query: "123456"` and `session_id: "call-abc"`. The backend prepends the prior exchange for that session, and the subagent receives the full thread and completes the task.
 
 **Outcome:** The second call's `query` contains only the delta. The subagent receives the correct full context without duplication.
 
@@ -57,7 +57,7 @@ A `session_id` argument lets the LLM tag each call with a thread identifier, ena
 
 **Trigger:** An operator configures a tool without `conversation_mode` (default) or with `conversation_mode: "stateless"`.
 
-**Behavior:** No `session_id` parameter is injected into the schema. No description suffix is added. `_extract_tool_history` is never called.
+**Behavior:** No `session_id` parameter is injected into the schema. `_extract_tool_history` is never called.
 
 **Outcome:** Identical to today's behavior. No migration required.
 
@@ -84,13 +84,9 @@ The admin configuring the manifest picks the mode based on what they know about 
 
 ### LLM awareness via `enrich_openai_tool_schema`
 
-**What:** For tools with `conversation_mode=stateful`, append a suffix to `function.description` informing the LLM of stateful semantics and delta-only expectations, and inject a `session_id` parameter into the tool schema.
+**What:** For tools with `conversation_mode=stateful`, inject a `session_id` parameter into the tool schema. Its description alone is sufficient for the LLM to use it correctly — no change to `function.description` is needed.
 
-**Where:** `StagedBaseTool.enrich_openai_tool_schema(open_ai_tool)` — no-op base method, overridden in `BaseDeploymentTool`. Wired into `AgentModule.provide_openai_tools` after `_append_default_props`, before serialization. The ordering is intentional: `_append_default_props` only touches `properties` (adds `query` and `attachment_urls`), never `description`, so `enrich_openai_tool_schema` always appends to the original description rather than to something `_append_default_props` may have written.
-
-**Description suffix (informative draft — exact wording TBD):**
-
-> "This tool is a stateful subagent: it maintains conversation history across calls within the same session. On each follow-up call, the backend automatically prepends prior exchanges for that session. **Send only the new information (delta)** in `query` — do not re-summarize prior context. Assign a unique `session_id` at the start of each conversation thread and use the same value for all follow-up calls in that thread."
+**Where:** `StagedBaseTool.enrich_openai_tool_schema(open_ai_tool)` — no-op base method, overridden in `BaseDeploymentTool`. Wired into `AgentModule.provide_openai_tools` after `_append_default_props`, before serialization.
 
 ---
 
@@ -98,21 +94,21 @@ The admin configuring the manifest picks the mode based on what they know about 
 
 **What:** An optional string parameter injected into the tool's JSON schema for all tools where `conversation_mode=stateful`.
 
-**Where:** Injected by `BaseDeploymentTool.enrich_openai_tool_schema()` alongside the description suffix.
+**Where:** Injected by `BaseDeploymentTool.enrich_openai_tool_schema()`.
 
 **Schema shape:**
 ```json
 "session_id": {
   "type": "string",
-  "description": "Identifier for this conversation thread. Assign a unique value when starting a new multi-turn exchange with this subagent (e.g. 'research-climate'). Use the same session_id on all follow-up calls for that thread. Use a different session_id to start an independent conversation thread."
+  "description": "The session identifier returned at the end of a previous response from this tool. Pass it back unchanged to continue that conversation thread. Omit to start a new independent thread."
 }
 ```
 
-**Who generates `session_id`:** The LLM. The tool description explicitly instructs it to create a unique identifier per thread and use it consistently. The LLM does not need to generate a UUID — any stable string it chooses (e.g., `"badge-task-1"`, `"research-climate"`) is sufficient. Modern instruction-following models reliably maintain such identifiers when clearly instructed.
+**Who generates `session_id`:** The **backend**. On the first call to a stateful tool (no `session_id` in kwargs), `_run_in_stage_async` assigns `session_id = tool_call_id` — the unique call identifier already provided by the LLM framework. The backend then appends `[session_id: {id}]` to the result content so the LLM can read and echo it on follow-up calls. This is more reliable than asking the LLM to invent an identifier: echoing a value you received is a much simpler task than generating a unique, stable, thread-consistent string.
 
 **`session_id` is NOT sent to the subagent** — it is popped from kwargs in `_run_in_stage_async` before `DialCompletionService.complete_request_async` is called, the same way `attachment_urls` is consumed at the tool layer.
 
-**Fallback when `session_id` is omitted:** If the LLM omits `session_id` on a stateful tool call (e.g., an older model that ignores injected parameters), `_extract_tool_history` falls back to `tool_name`-only filtering — all prior calls to that tool are included regardless of session, which is the same behaviour as `propagate_history=True`.
+**Fallback when `session_id` is omitted:** If the LLM omits `session_id` on a stateful follow-up call, `_extract_tool_history` falls back to `tool_name`-only filtering — all prior calls to that tool are included regardless of session, which is the same behaviour as `propagate_history=True`.
 
 ---
 
@@ -124,15 +120,18 @@ New signature: `_extract_tool_history(tool_name: str, session_id: str | None = N
 
 **First pass** (collecting TOOL results by `tool_call_id`) — unchanged.
 
-**Second pass** (walking ASSISTANT messages): when `session_id` is provided, only include a tool call if the parsed arguments for that call contain `"session_id": <matching value>`. Tool calls without a matching `session_id` are excluded when filtering is active.
+**Second pass** (walking ASSISTANT messages): when `session_id` is provided, include a tool call if it matches either condition:
 
-When `session_id` is `None`, falls back to filtering by `tool_name` only — preserving current behavior for `propagate_history=True` callers that do not use `session_id`.
+- **Anchor** (`tc.id == session_id`): the first call in the thread, identified by the `tool_call_id` the backend returned as the session identifier. It has no `session_id` in its own arguments.
+- **Follow-up** (`args["session_id"] == session_id`): a subsequent call where the LLM echoed the session identifier back.
+
+When `session_id` is `None`, falls back to filtering by `tool_name` only — preserving current behavior for `propagate_history=True` callers.
 
 ---
 
 ### `_run_in_stage_async` changes
 
-At the start of the method, `session_id` is popped from kwargs (consumed here, not forwarded to the subagent). It is then passed as a keyword argument to `_extract_tool_history` when history extraction is triggered by `propagate_history=True` or `conversation_mode=stateful`.
+`session_id` is popped from kwargs (consumed here, not forwarded to the subagent). If absent and `conversation_mode=stateful` (first call), the backend assigns `session_id = tool_call_id` and appends `[session_id: {id}]` to the result content. The `session_id` is then passed to `_extract_tool_history` when history extraction is triggered by `propagate_history=True` or `conversation_mode=stateful`.
 
 ---
 
@@ -171,14 +170,13 @@ At the start of the method, `session_id` is popped from kwargs (consumed here, n
 }
 ```
 
-The LLM will see `session_id` in the tool schema and call like:
+First call (no `session_id`):
 ```json
-{ "query": "Assign badge 'Happy 5th Anniversary' to John Smith", "session_id": "badge-task-1" }
+{ "query": "Assign badge 'Happy 5th Anniversary' to John Smith" }
 ```
-
-Follow-up (delta only):
+Backend appends `[session_id: call-abc123]` to the response. Follow-up (delta only, LLM echoes session_id):
 ```json
-{ "query": "123456", "session_id": "badge-task-1" }
+{ "query": "123456", "session_id": "call-abc123" }
 ```
 
 ### Stateless (default)
@@ -190,7 +188,7 @@ Follow-up (delta only):
 }
 ```
 
-No `session_id` in schema. No description suffix. No history extraction.
+No `session_id` in schema. No history extraction.
 
 ---
 
@@ -213,5 +211,5 @@ Default is `stateless`; existing manifests without `conversation_mode` and `prop
 | `config/tools/deployment.py` | `ConversationMode` enum with `STATELESS` and `STATEFUL`. `ContentPropagation.conversation_mode` documented. |
 | `common/staged_base_tool.py` | Add `enrich_openai_tool_schema(open_ai_tool)` extension hook (no-op in base, overridden in `BaseDeploymentTool`). |
 | `core/agent/agent_module.py` | `provide_openai_tools`: call `tool.enrich_openai_tool_schema(open_ai_tool)` for every tool after `_append_default_props`. |
-| `dial_deployment_tooling/base_deployment_tool.py` | Override `enrich_openai_tool_schema`: inject description suffix and `session_id` parameter when `conversation_mode=STATEFUL`. `_run_in_stage_async`: pop `session_id` from kwargs, pass to `_extract_tool_history`. `_extract_tool_history`: accept `session_id`, filter by `(tool_name, session_id)` when provided. Fix empty-content-with-state edge case. |
+| `dial_deployment_tooling/base_deployment_tool.py` | Override `enrich_openai_tool_schema`: inject `session_id` parameter when `conversation_mode=STATEFUL`. `_run_in_stage_async`: pop `session_id` from kwargs, generate from `tool_call_id` on first call, inject into result content, pass to `_extract_tool_history`. `_extract_tool_history`: accept `session_id`, filter by anchor (`tc.id`) or follow-up (`args["session_id"]`) when provided. Fix empty-content-with-state edge case. |
 | `docs/generated-app-schema.json` | Regenerated after config model changes. |

--- a/docs/designs/subagents_conversation_mode.md
+++ b/docs/designs/subagents_conversation_mode.md
@@ -8,11 +8,11 @@ When the orchestrator LLM calls a deployment tool (subagent), it has no way to k
 
 ### 1. Redundant context injection
 
-The LLM's universal fallback assumption is that every tool call is stateless. So when it calls a history-aware subagent for the second time — say, to provide an employee ID that the subagent asked for — it re-summarizes the entire prior exchange into `query`:
+The LLM's universal fallback assumption is that every tool call is stateless. So when it calls a history-aware subagent for the second time — say, to provide an employee ID that the subagent asked for — it re-summarizes the entire prior exchange into its request:
 
 > "Previously you asked me to assign badge 'Happy 5th Anniversary' to John Smith and requested an EmployeeID. The ID is 123456, please proceed."
 
-But because `conversation_mode.resumable=true`, the backend has already reconstructed and prepended the prior `[user, assistant]` exchange. The subagent now receives the prior context twice: once in the prepended history, once in the new `query`. This causes confusion, wasted tokens, and potentially incorrect behavior.
+But because `conversation_mode.resumable=true`, the backend has already reconstructed and prepended the prior `[user, assistant]` exchange. The subagent now receives the prior context twice: once in the prepended history, once in the new request. This causes confusion, wasted tokens, and potentially incorrect behavior.
 
 The LLM should instead send only the **delta** — the new information that wasn't in the prior exchange:
 
@@ -77,7 +77,7 @@ resumable=true             — backend reconstructs [user, assistant] pairs from
 
 The admin configuring the manifest sets `resumable` based on what they know about the target DIAL app: `true` if it needs prior history sent to it; `false` (or omit `conversation_mode` entirely) if it handles continuity itself or has no memory.
 
-**Location:** `ConversationMode` group model in `src/quickapp/config/tools/deployment.py`, exposed as the `conversation_mode` field on `DialDeploymentTool` (sibling to `content_propagation`).
+**Location:** `ConversationMode` group model in `src/quickapp/config/tools/deployment.py`, exposed as the `conversation_mode` field on `DialDeploymentTool`. The same field is also accepted on the two shorthand forms that resolve to a deployment tool — `DialDeploymentSimpleTool` and `DialAppToolSet` — and is threaded onto the synthetic `DialDeploymentTool` when they are expanded. On `DialAppToolSet` it applies only to the chat-completion branch; if the toolset resolves to MCP, a set `resumable` is ignored with a warning.
 
 `propagate_history=True` is **deprecated** (superseded by `conversation_mode.resumable=true`) but still triggers the same extraction path during its grace period.
 
@@ -147,16 +147,6 @@ When `session_id` is `None`, falls back to filtering by `tool_name` only — pre
 
 ---
 
-## Out of Scope
-
-**LLM choosing `conversation_mode`.** Issue #88 proposed `conversation_mode` as a runtime tool argument. This design keeps it as operator config: the app author knows at wiring time whether the subagent is resumable. Making the LLM choose adds prompt-engineering fragility — the LLM must correctly infer statefulness from a description and reliably pick the right mode on every call.
-
-**`conversation_summary` mode.** Mentioned in issue #88 as a future extension. Deferred until there is a concrete use case and a summary provider is defined.
-
-**Removal of `propagate_history`.** Triggers the same extraction path as `conversation_mode.resumable=true`. It is now deprecated in favor of `conversation_mode.resumable`.
-
----
-
 ## Configuration / Usage Examples
 
 ### Resumable subagent — multi-step task with session isolation
@@ -210,6 +200,8 @@ Default is non-resumable; existing manifests without `conversation_mode` and `pr
 | Component | Change |
 |---|---|
 | `config/tools/deployment.py` | `ConversationMode` group model with a `resumable` boolean flag, exposed as the `conversation_mode` field on `DialDeploymentTool`. `ContentPropagation.propagate_history` deprecated in favor of it. |
+| `config/tools/deployment_simple.py`, `config/toolsets/dial_app.py` | Accept the same `conversation_mode` field on the two shorthand forms that expand into a deployment tool. |
+| `dial_app_tooling/_dial_app_resolver.py`, `dial_deployment_tooling/_deployment_tool_initializer.py` | Thread `conversation_mode` onto the synthetic `DialDeploymentTool` when expanding those forms; warn when `resumable` is set on a toolset that resolves to MCP. |
 | `common/staged_base_tool.py` | Add `enrich_openai_tool_schema(open_ai_tool)` extension hook (no-op in base, overridden in `BaseDeploymentTool`). |
 | `core/agent/agent_module.py` | `provide_openai_tools`: call `tool.enrich_openai_tool_schema(open_ai_tool)` for every tool after `_append_default_props`. |
 | `dial_deployment_tooling/base_deployment_tool.py` | Override `enrich_openai_tool_schema`: inject `session_id` parameter when `conversation_mode.resumable=true`. `_run_in_stage_async`: pop `session_id` from kwargs, generate from `tool_call_id` on first call, inject into result content, pass to `_extract_tool_history`. `_extract_tool_history`: accept `session_id`, filter by anchor (`tc.id`) or follow-up (`args["session_id"]`) when provided. Fix empty-content-with-state edge case. |

--- a/docs/designs/subagents_conversation_mode.md
+++ b/docs/designs/subagents_conversation_mode.md
@@ -4,7 +4,7 @@
 
 ## Problem Statement
 
-When the orchestrator LLM calls a deployment tool (subagent), it has no way to know whether the subagent is stateless (each call is independent) or maintains conversation history. The operator may configure `propagate_history=True` or `conversation_mode=stateful`, which causes the backend to reconstruct and prepend prior `[user, assistant]` exchanges on each call — but the LLM is unaware of this. This creates two distinct problems.
+When the orchestrator LLM calls a deployment tool (subagent), it has no way to know whether the subagent is independent (each call is standalone) or maintains conversation history. The operator may configure `propagate_history=True` (deprecated) or `conversation_mode.resumable=true`, which causes the backend to reconstruct and prepend prior `[user, assistant]` exchanges on each call — but the LLM is unaware of this. This creates two distinct problems.
 
 ### 1. Redundant context injection
 
@@ -12,7 +12,7 @@ The LLM's universal fallback assumption is that every tool call is stateless. So
 
 > "Previously you asked me to assign badge 'Happy 5th Anniversary' to John Smith and requested an EmployeeID. The ID is 123456, please proceed."
 
-But because `conversation_mode=stateful`, the backend has already reconstructed and prepended the prior `[user, assistant]` exchange. The subagent now receives the prior context twice: once in the prepended history, once in the new `query`. This causes confusion, wasted tokens, and potentially incorrect behavior.
+But because `conversation_mode.resumable=true`, the backend has already reconstructed and prepended the prior `[user, assistant]` exchange. The subagent now receives the prior context twice: once in the prepended history, once in the new `query`. This causes confusion, wasted tokens, and potentially incorrect behavior.
 
 The LLM should instead send only the **delta** — the new information that wasn't in the prior exchange:
 
@@ -29,15 +29,15 @@ A `session_id` argument lets the LLM tag each call with a thread identifier, ena
 ## Design Goals
 
 - The LLM must be aware, per tool, whether the subagent has conversation history — so it sends only the delta on follow-up calls.
-- `conversation_mode` (operator config) is the authoritative switch for whether the backend propagates history. The LLM does not set this; it is fixed at app-authoring time.
+- `conversation_mode.resumable` (operator config) is the authoritative switch for whether the backend propagates history. The LLM does not set this; it is fixed at app-authoring time.
 - `session_id` isolates conversation threads when the same tool is invoked multiple times in a session.
-- Preserve full backward-compatibility: existing `propagate_history=True` manifests and `stateless` (default) tools are unchanged.
+- Preserve full backward-compatibility: existing `propagate_history=True` manifests and non-resumable (default) tools are unchanged.
 
 ---
 
 ## Use Cases
 
-### UC-1: Single stateful subagent — multi-step task
+### UC-1: Single resumable subagent — multi-step task
 
 **Trigger:** User asks the orchestrator: "Assign badge 'Happy 5th Anniversary' to John Smith."
 
@@ -53,9 +53,9 @@ A `session_id` argument lets the LLM tag each call with a thread identifier, ena
 
 **Outcome:** Each subagent receives only its own prior exchanges, not the other's. The orchestrator can correctly route answers.
 
-### UC-3: Stateless tool — no change
+### UC-3: Non-resumable tool — no change
 
-**Trigger:** An operator configures a tool without `conversation_mode` (default) or with `conversation_mode: "stateless"`.
+**Trigger:** An operator configures a tool without `conversation_mode` (default) or with `conversation_mode: {"resumable": false}`.
 
 **Behavior:** No `session_id` parameter is injected into the schema. `_extract_tool_history` is never called.
 
@@ -65,26 +65,27 @@ A `session_id` argument lets the LLM tag each call with a thread identifier, ena
 
 ## Proposed Design
 
-### `conversation_mode` — two values
+### `conversation_mode.resumable` — boolean flag
 
 ```
-stateless   (default) — each call is independent; no history or state is propagated
-stateful    — backend reconstructs [user, assistant] pairs from the parent's messages and
-              prepends them on each call via _extract_tool_history; subagent's
-              TOOL_EXECUTION_HISTORY state is threaded back automatically
+resumable=false  (default) — each call is independent; no history or state is propagated
+resumable=true             — backend reconstructs [user, assistant] pairs from the parent's
+                             messages and prepends them on each call via _extract_tool_history;
+                             subagent's TOOL_EXECUTION_HISTORY state is threaded back
+                             automatically. The tool also issues a session_id (see below).
 ```
 
-The admin configuring the manifest picks the mode based on what they know about the target DIAL app: `stateful` if it needs prior history sent to it; `stateless` if it handles continuity itself or has no memory.
+The admin configuring the manifest sets `resumable` based on what they know about the target DIAL app: `true` if it needs prior history sent to it; `false` (or omit `conversation_mode` entirely) if it handles continuity itself or has no memory.
 
-**Location:** `ConversationMode` enum in `src/quickapp/config/tools/deployment.py`, field on `ContentPropagation`.
+**Location:** `ConversationMode` group model in `src/quickapp/config/tools/deployment.py`, exposed as the `conversation_mode` field on `DialDeploymentTool` (sibling to `content_propagation`).
 
-`propagate_history=True` remains and continues to trigger the same extraction path — it is not deprecated.
+`propagate_history=True` is **deprecated** (superseded by `conversation_mode.resumable=true`) but still triggers the same extraction path during its grace period.
 
 ---
 
 ### LLM awareness via `enrich_openai_tool_schema`
 
-**What:** For tools with `conversation_mode=stateful`, inject a `session_id` parameter into the tool schema. Its description alone is sufficient for the LLM to use it correctly — no change to `function.description` is needed.
+**What:** For tools with `conversation_mode.resumable=true`, inject a `session_id` parameter into the tool schema. Its description alone is sufficient for the LLM to use it correctly — no change to `function.description` is needed.
 
 **Where:** `StagedBaseTool.enrich_openai_tool_schema(open_ai_tool)` — no-op base method, overridden in `BaseDeploymentTool`. Wired into `AgentModule.provide_openai_tools` after `_append_default_props`, before serialization.
 
@@ -92,7 +93,7 @@ The admin configuring the manifest picks the mode based on what they know about 
 
 ### `session_id` parameter
 
-**What:** An optional string parameter injected into the tool's JSON schema for all tools where `conversation_mode=stateful`.
+**What:** An optional string parameter injected into the tool's JSON schema for all tools where `conversation_mode.resumable=true`.
 
 **Where:** Injected by `BaseDeploymentTool.enrich_openai_tool_schema()`.
 
@@ -104,11 +105,11 @@ The admin configuring the manifest picks the mode based on what they know about 
 }
 ```
 
-**Who generates `session_id`:** The **backend**. On the first call to a stateful tool (no `session_id` in kwargs), `_run_in_stage_async` assigns `session_id = tool_call_id` — the unique call identifier already provided by the LLM framework. The backend then appends `[session_id: {id}]` to the result content so the LLM can read and echo it on follow-up calls. This is more reliable than asking the LLM to invent an identifier: echoing a value you received is a much simpler task than generating a unique, stable, thread-consistent string.
+**Who generates `session_id`:** The **backend**. On the first call to a resumable tool (no `session_id` in kwargs), `_run_in_stage_async` assigns `session_id = tool_call_id` — the unique call identifier already provided by the LLM framework. The backend then appends `[session_id: {id}]` to the result content so the LLM can read and echo it on follow-up calls. This is more reliable than asking the LLM to invent an identifier: echoing a value you received is a much simpler task than generating a unique, stable, thread-consistent string.
 
 **`session_id` is NOT sent to the subagent** — it is popped from kwargs in `_run_in_stage_async` before `DialCompletionService.complete_request_async` is called, the same way `attachment_urls` is consumed at the tool layer.
 
-**Fallback when `session_id` is omitted:** If the LLM omits `session_id` on a stateful follow-up call, `_extract_tool_history` falls back to `tool_name`-only filtering — all prior calls to that tool are included regardless of session, which is the same behaviour as `propagate_history=True`.
+**Fallback when `session_id` is omitted:** If the LLM omits `session_id` on a resumable follow-up call, `_extract_tool_history` falls back to `tool_name`-only filtering — all prior calls to that tool are included regardless of session, which is the same behaviour as `propagate_history=True`.
 
 ---
 
@@ -131,7 +132,7 @@ When `session_id` is `None`, falls back to filtering by `tool_name` only — pre
 
 ### `_run_in_stage_async` changes
 
-`session_id` is popped from kwargs (consumed here, not forwarded to the subagent). If absent and `conversation_mode=stateful` (first call), the backend assigns `session_id = tool_call_id` and appends `[session_id: {id}]` to the result content. The `session_id` is then passed to `_extract_tool_history` when history extraction is triggered by `propagate_history=True` or `conversation_mode=stateful`.
+`session_id` is popped from kwargs (consumed here, not forwarded to the subagent). If absent and `conversation_mode.resumable=true` (first call), the backend assigns `session_id = tool_call_id` and appends `[session_id: {id}]` to the result content. The `session_id` is then passed to `_extract_tool_history` when history extraction is triggered by `propagate_history=True` or `conversation_mode.resumable=true`.
 
 ---
 
@@ -148,24 +149,24 @@ When `session_id` is `None`, falls back to filtering by `tool_name` only — pre
 
 ## Out of Scope
 
-**LLM choosing `conversation_mode`.** Issue #88 proposed `conversation_mode` as a runtime tool argument. This design keeps it as operator config: the app author knows at wiring time whether the subagent is stateful. Making the LLM choose adds prompt-engineering fragility — the LLM must correctly infer statefulness from a description and reliably pick the right mode on every call.
+**LLM choosing `conversation_mode`.** Issue #88 proposed `conversation_mode` as a runtime tool argument. This design keeps it as operator config: the app author knows at wiring time whether the subagent is resumable. Making the LLM choose adds prompt-engineering fragility — the LLM must correctly infer statefulness from a description and reliably pick the right mode on every call.
 
 **`conversation_summary` mode.** Mentioned in issue #88 as a future extension. Deferred until there is a concrete use case and a summary provider is defined.
 
-**Deprecation of `propagate_history`.** Triggers the same extraction path as `stateful`. Removing it requires a deprecation notice and grace period; deferred.
+**Removal of `propagate_history`.** Triggers the same extraction path as `conversation_mode.resumable=true`. It is now deprecated in favor of `conversation_mode.resumable`.
 
 ---
 
 ## Configuration / Usage Examples
 
-### Stateful subagent — multi-step task with session isolation
+### Resumable subagent — multi-step task with session isolation
 
 ```json
 {
   "type": "deployment-tool",
   "deployment": { "endpoint": "assign-badge-app" },
-  "content_propagation": {
-    "conversation_mode": "stateful"
+  "conversation_mode": {
+    "resumable": true
   }
 }
 ```
@@ -179,7 +180,7 @@ Backend appends `[session_id: call-abc123]` to the response. Follow-up (delta on
 { "query": "123456", "session_id": "call-abc123" }
 ```
 
-### Stateless (default)
+### Non-resumable (default)
 
 ```json
 {
@@ -196,11 +197,11 @@ No `session_id` in schema. No history extraction.
 
 ### Breaking changes
 
-None. Default is `stateless`; existing manifests without `conversation_mode` behave identically to today.
+None. Default is non-resumable (`conversation_mode` omitted); existing manifests behave identically to today.
 
 ### Non-breaking additions
 
-Default is `stateless`; existing manifests without `conversation_mode` and `propagate_history=True` callers behave identically to before.
+Default is non-resumable; existing manifests without `conversation_mode` and `propagate_history=True` callers behave identically to before.
 
 ---
 
@@ -208,8 +209,8 @@ Default is `stateless`; existing manifests without `conversation_mode` and `prop
 
 | Component | Change |
 |---|---|
-| `config/tools/deployment.py` | `ConversationMode` enum with `STATELESS` and `STATEFUL`. `ContentPropagation.conversation_mode` documented. |
+| `config/tools/deployment.py` | `ConversationMode` group model with a `resumable` boolean flag, exposed as the `conversation_mode` field on `DialDeploymentTool`. `ContentPropagation.propagate_history` deprecated in favor of it. |
 | `common/staged_base_tool.py` | Add `enrich_openai_tool_schema(open_ai_tool)` extension hook (no-op in base, overridden in `BaseDeploymentTool`). |
 | `core/agent/agent_module.py` | `provide_openai_tools`: call `tool.enrich_openai_tool_schema(open_ai_tool)` for every tool after `_append_default_props`. |
-| `dial_deployment_tooling/base_deployment_tool.py` | Override `enrich_openai_tool_schema`: inject `session_id` parameter when `conversation_mode=STATEFUL`. `_run_in_stage_async`: pop `session_id` from kwargs, generate from `tool_call_id` on first call, inject into result content, pass to `_extract_tool_history`. `_extract_tool_history`: accept `session_id`, filter by anchor (`tc.id`) or follow-up (`args["session_id"]`) when provided. Fix empty-content-with-state edge case. |
+| `dial_deployment_tooling/base_deployment_tool.py` | Override `enrich_openai_tool_schema`: inject `session_id` parameter when `conversation_mode.resumable=true`. `_run_in_stage_async`: pop `session_id` from kwargs, generate from `tool_call_id` on first call, inject into result content, pass to `_extract_tool_history`. `_extract_tool_history`: accept `session_id`, filter by anchor (`tc.id`) or follow-up (`args["session_id"]`) when provided. Fix empty-content-with-state edge case. |
 | `docs/generated-app-schema.json` | Regenerated after config model changes. |

--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -451,14 +451,10 @@
     },
     "ContentPropagation": {
       "properties": {
-        "conversation_mode": {
-          "$ref": "#/$defs/ConversationMode",
-          "default": "stateless",
-          "description": "Controls how prior interactions with this deployment are replayed. 'stateless': each call is independent (default). 'stateful': prior [user, assistant] pairs including the subagent's internal tool-execution state are sent, enabling stateful multi-turn subagents."
-        },
         "propagate_history": {
           "default": false,
-          "description": "Flag to propagate messages to deployment. If True, the messages will be propagated in such way: [assistant, tool] -> [user, assistant].",
+          "deprecated": true,
+          "description": "**Deprecated, use `conversation_mode.resumable: true`**. Flag to propagate messages to deployment. If True, the messages will be propagated in such way: [assistant, tool] -> [user, assistant].",
           "title": "Propagate History",
           "type": "boolean"
         },
@@ -527,12 +523,16 @@
       "type": "object"
     },
     "ConversationMode": {
-      "enum": [
-        "stateless",
-        "stateful"
-      ],
+      "properties": {
+        "resumable": {
+          "default": false,
+          "description": "Whether the deployment tool maintains a resumable conversation. When true, the tool issues a session_id on the first call, accepts it back on follow-up calls, and the backend threads prior [user, assistant] history — including the subagent's internal tool-execution state — for that session. When false (default), each call is independent.",
+          "title": "Resumable",
+          "type": "boolean"
+        }
+      },
       "title": "ConversationMode",
-      "type": "string"
+      "type": "object"
     },
     "ConversationStarter": {
       "properties": {
@@ -1050,6 +1050,18 @@
           ],
           "default": null,
           "description": "The configuration with propagations to DIAL deployment."
+        },
+        "conversation_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConversationMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Conversation session behavior for the DIAL deployment tool."
         },
         "supports_url_attachments": {
           "default": false,

--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -451,6 +451,11 @@
     },
     "ContentPropagation": {
       "properties": {
+        "conversation_mode": {
+          "$ref": "#/$defs/ConversationMode",
+          "default": "stateless",
+          "description": "Controls how prior interactions with this deployment are replayed. 'stateless': each call is independent (default). 'stateful': prior [user, assistant] pairs including the subagent's internal tool-execution state are sent, enabling stateful multi-turn subagents."
+        },
         "propagate_history": {
           "default": false,
           "description": "Flag to propagate messages to deployment. If True, the messages will be propagated in such way: [assistant, tool] -> [user, assistant].",
@@ -520,6 +525,14 @@
       },
       "title": "ContinueStrategyModel",
       "type": "object"
+    },
+    "ConversationMode": {
+      "enum": [
+        "stateless",
+        "stateful"
+      ],
+      "title": "ConversationMode",
+      "type": "string"
     },
     "ConversationStarter": {
       "properties": {

--- a/docs/generated-app-schema.json
+++ b/docs/generated-app-schema.json
@@ -772,6 +772,18 @@
         "fallback_configuration": {
           "$ref": "#/$defs/ToolFallbackConfig",
           "description": "Tool fallback configuration."
+        },
+        "conversation_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConversationMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Conversation session behavior for the DIAL deployment tool. Applies only on the chat-completion branch; ignored (with a warning) when the toolset resolves to MCP."
         }
       },
       "required": [
@@ -956,6 +968,18 @@
           "description": "Whether the tool is enabled.",
           "title": "Enabled",
           "type": "boolean"
+        },
+        "conversation_mode": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/ConversationMode"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "description": "Conversation session behavior for the DIAL deployment tool."
         },
         "type": {
           "const": "dial-deployment-simple",

--- a/src/quickapp/common/staged_base_tool.py
+++ b/src/quickapp/common/staged_base_tool.py
@@ -18,6 +18,7 @@ from quickapp.common.stage_close_registry import (
 from quickapp.config.application import StageDisplayLevel
 from quickapp.config.tools.base import BaseOpenAITool
 from quickapp.config.tools.base import BaseTool as _BaseToolConfig
+from quickapp.config.tools.base import OpenAiToolConfig
 from quickapp.config.tools.tool_fallback import RetryStrategyModel
 
 from .exceptions import InvalidToolCallParameterException, ToolTimeoutError
@@ -152,6 +153,9 @@ class StagedBaseTool(ABC, BaseModel, extra='allow'):
                     Exception("An error occurred while executing the tool.")
                 )
             return FallbackProcessor.process_fallback(fallback.strategies, tool_call_id, e)
+
+    def enrich_openai_tool_schema(self, open_ai_tool: OpenAiToolConfig) -> OpenAiToolConfig:
+        return open_ai_tool
 
     async def _pre_process_params(self, **kwargs: Any) -> dict[str, Any]:
         for transformer in self.__argument_transformers:

--- a/src/quickapp/config/tools/deployment.py
+++ b/src/quickapp/config/tools/deployment.py
@@ -1,3 +1,4 @@
+from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -7,7 +8,21 @@ from quickapp.config.prompt import ToolSystemPromptConfig
 from quickapp.config.tools.base import BaseOpenAITool
 
 
+class ConversationMode(str, Enum):
+    STATELESS = "stateless"
+    STATEFUL = "stateful"
+
+
 class ContentPropagation(BaseModel):
+    conversation_mode: ConversationMode = Field(
+        default=ConversationMode.STATELESS,
+        description=(
+            "Controls how prior interactions with this deployment are replayed. "
+            "'stateless': each call is independent (default). "
+            "'stateful': prior [user, assistant] pairs including the subagent's "
+            "internal tool-execution state are sent, enabling stateful multi-turn subagents."
+        ),
+    )
     propagate_history: bool = Field(
         default=False,
         description="Flag to propagate messages to deployment. If True, the messages will be propagated in such way: [assistant, tool] -> [user, assistant].",

--- a/src/quickapp/config/tools/deployment.py
+++ b/src/quickapp/config/tools/deployment.py
@@ -25,7 +25,15 @@ class ContentPropagation(BaseModel):
     )
     propagate_history: bool = Field(
         default=False,
-        description="Flag to propagate messages to deployment. If True, the messages will be propagated in such way: [assistant, tool] -> [user, assistant].",
+        deprecated=(
+            "Deprecated and will be removed in a future release. "
+            "Use 'conversation_mode: stateful' instead."
+        ),
+        description=(
+            "**Deprecated, use `conversation_mode: stateful`**. "
+            "Flag to propagate messages to deployment. If True, the messages will be "
+            "propagated in such way: [assistant, tool] -> [user, assistant]."
+        ),
     )
     propagate_headers: list[str] | None = Field(
         default=None,

--- a/src/quickapp/config/tools/deployment.py
+++ b/src/quickapp/config/tools/deployment.py
@@ -1,4 +1,3 @@
-from enum import Enum
 from typing import Literal
 
 from pydantic import BaseModel, Field
@@ -8,29 +7,28 @@ from quickapp.config.prompt import ToolSystemPromptConfig
 from quickapp.config.tools.base import BaseOpenAITool
 
 
-class ConversationMode(str, Enum):
-    STATELESS = "stateless"
-    STATEFUL = "stateful"
+class ConversationMode(BaseModel):
+    resumable: bool = Field(
+        default=False,
+        description=(
+            "Whether the deployment tool maintains a resumable conversation. When true, "
+            "the tool issues a session_id on the first call, accepts it back on follow-up "
+            "calls, and the backend threads prior [user, assistant] history — including the "
+            "subagent's internal tool-execution state — for that session. When false "
+            "(default), each call is independent."
+        ),
+    )
 
 
 class ContentPropagation(BaseModel):
-    conversation_mode: ConversationMode = Field(
-        default=ConversationMode.STATELESS,
-        description=(
-            "Controls how prior interactions with this deployment are replayed. "
-            "'stateless': each call is independent (default). "
-            "'stateful': prior [user, assistant] pairs including the subagent's "
-            "internal tool-execution state are sent, enabling stateful multi-turn subagents."
-        ),
-    )
     propagate_history: bool = Field(
         default=False,
         deprecated=(
             "Deprecated and will be removed in a future release. "
-            "Use 'conversation_mode: stateful' instead."
+            "Use 'conversation_mode.resumable: true' instead."
         ),
         description=(
-            "**Deprecated, use `conversation_mode: stateful`**. "
+            "**Deprecated, use `conversation_mode.resumable: true`**. "
             "Flag to propagate messages to deployment. If True, the messages will be "
             "propagated in such way: [assistant, tool] -> [user, assistant]."
         ),
@@ -52,6 +50,10 @@ class DialDeploymentTool(BaseOpenAITool):
     )
     content_propagation: ContentPropagation | None = Field(
         default=None, description="The configuration with propagations to DIAL deployment."
+    )
+    conversation_mode: ConversationMode | None = Field(
+        default=None,
+        description="Conversation session behavior for the DIAL deployment tool.",
     )
     supports_url_attachments: bool = Field(
         default=False,

--- a/src/quickapp/config/tools/deployment_simple.py
+++ b/src/quickapp/config/tools/deployment_simple.py
@@ -3,9 +3,14 @@ from typing import Annotated, Literal
 from pydantic import BaseModel, Field
 
 from quickapp.common.base_config import DialResourceConfigField
+from quickapp.config.tools.deployment import ConversationMode
 
 
 class DialDeploymentSimpleTool(BaseModel):
     deployment_id: Annotated[str, DialResourceConfigField(description="The id of the deployment")]
     enabled: bool = Field(default=True, description="Whether the tool is enabled.")
+    conversation_mode: ConversationMode | None = Field(
+        default=None,
+        description="Conversation session behavior for the DIAL deployment tool.",
+    )
     type: Literal["dial-deployment-simple"] = Field(default="dial-deployment-simple")

--- a/src/quickapp/config/toolsets/dial_app.py
+++ b/src/quickapp/config/toolsets/dial_app.py
@@ -4,6 +4,7 @@ from pydantic import Field
 
 from quickapp.common.base_config import DialResourceConfigField
 from quickapp.config.tools.base import AttachmentConfig
+from quickapp.config.tools.deployment import ConversationMode
 from quickapp.config.tools.tool_fallback import ToolFallbackConfig
 from quickapp.config.toolsets.base import BaseToolSet
 
@@ -36,4 +37,12 @@ class DialAppToolSet(BaseToolSet):
     )
     fallback_configuration: ToolFallbackConfig = Field(
         default_factory=ToolFallbackConfig, description="Tool fallback configuration."
+    )
+    conversation_mode: ConversationMode | None = Field(
+        default=None,
+        description=(
+            "Conversation session behavior for the DIAL deployment tool. Applies only on "
+            "the chat-completion branch; ignored (with a warning) when the toolset resolves "
+            "to MCP."
+        ),
     )

--- a/src/quickapp/core/agent/agent_module.py
+++ b/src/quickapp/core/agent/agent_module.py
@@ -171,6 +171,7 @@ class AgentModule(Module):
                 open_ai_tool = self._remove_const_params(open_ai_tool)
                 if isinstance(tool.tool_config, DialDeploymentTool):
                     open_ai_tool = self._append_default_props(open_ai_tool)
+                open_ai_tool = tool.enrich_openai_tool_schema(open_ai_tool)
                 openai_functions.append(open_ai_tool.model_dump(mode="json", exclude_none=True))
         for default_tool in static_tools:
             openai_functions.append(default_tool.model_dump(mode="json", exclude_none=True))

--- a/src/quickapp/dial_app_tooling/_dial_app_resolver.py
+++ b/src/quickapp/dial_app_tooling/_dial_app_resolver.py
@@ -112,6 +112,12 @@ class _DialAppResolver(CompletionInitializer):
         return bool(metadata.features and metadata.features.mcp)
 
     def _handle_mcp_branch(self, toolset: DialAppToolSet) -> None:
+        if toolset.conversation_mode and toolset.conversation_mode.resumable:
+            logger.warning(
+                "conversation_mode.resumable set on DialAppToolSet '%s' is ignored on the MCP "
+                "branch (resumable sessions apply only to the chat-completion deployment tool).",
+                toolset.name,
+            )
         url = f"{self.__dial_settings.url}/v1/deployments/{toolset.deployment_id}/mcp"
         api_key = self.__api_key_provider.get()
         mcp_toolset = MCPToolSet(
@@ -147,6 +153,7 @@ class _DialAppResolver(CompletionInitializer):
             update={
                 "attachment": toolset.attachment,
                 "fallback_configuration": toolset.fallback_configuration,
+                "conversation_mode": toolset.conversation_mode,
             }
         )
         self.__context.append_deployment_tool(customised)

--- a/src/quickapp/dial_deployment_tooling/_deployment_tool_initializer.py
+++ b/src/quickapp/dial_deployment_tooling/_deployment_tool_initializer.py
@@ -58,6 +58,10 @@ class _DeploymentToolInitializer(CompletionInitializer):
                 self.__tool_config_service.get_basic_tool_config,
                 tool_info.deployment_id,
             )
+            if tool_info.conversation_mode is not None:
+                tool_config = tool_config.model_copy(
+                    update={"conversation_mode": tool_info.conversation_mode}
+                )
             self.__init_deployment_tool(tool_config)
 
         except ToolInitializationException as e:

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -20,7 +20,12 @@ from quickapp.common.payload_logging import log_payload
 from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import to_plain_dict
 from quickapp.config.dial_deployment import DialDeploymentParameters
-from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
+from quickapp.config.tools.base import ConfigurableSchemaSimpleType, JsonTypeEnum, OpenAiToolConfig
+from quickapp.config.tools.deployment import (
+    ContentPropagation,
+    ConversationMode,
+    DialDeploymentTool,
+)
 from quickapp.dial_deployment_tooling._attachment_resolver import AttachmentResolver
 from quickapp.dial_deployment_tooling.constants import (
     ATTACHMENT_PARAM,
@@ -72,9 +77,15 @@ class BaseDeploymentTool(StagedBaseTool):
         **kwargs,
     ) -> ToolCallResult:
         tool_config = cast(DialDeploymentTool, self.tool_config)
+        session_id: str | None = kwargs.pop("session_id", None)
         history = None
-        if self.__content_propagation and self.__content_propagation.propagate_history:
-            history = await self._extract_tool_history(tool_config.open_ai_tool.function.name)
+        if self.__content_propagation and (
+            self.__content_propagation.propagate_history
+            or self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
+        ):
+            history = await self._extract_tool_history(
+                tool_config.open_ai_tool.function.name, session_id=session_id
+            )
         return await self.__dial_completion_service.complete_request_async(
             kwargs,
             self.__application_id,
@@ -84,6 +95,37 @@ class BaseDeploymentTool(StagedBaseTool):
             history=history,
             supports_url_attachments=tool_config.supports_url_attachments,
         )
+
+    _STATEFUL_DESCRIPTION_SUFFIX = (
+        "\n\nThis tool is a stateful subagent: it maintains conversation history across calls "
+        "within the same session. On each follow-up call, the backend automatically prepends "
+        "prior exchanges for that session. Send only the new information (delta) in `query` — "
+        "do not re-summarize prior context. Assign a unique `session_id` at the start of each "
+        "conversation thread and use the same value for all follow-up calls in that thread."
+    )
+
+    _SESSION_ID_PARAM = ConfigurableSchemaSimpleType(
+        type=JsonTypeEnum.string,
+        description=(
+            "Identifier for this conversation thread. Assign a unique value when starting a "
+            "new multi-turn exchange with this subagent (e.g. 'research-climate'). Use the "
+            "same session_id on all follow-up calls for that thread. Use a different "
+            "session_id to start an independent conversation thread."
+        ),
+    )
+
+    def enrich_openai_tool_schema(self, open_ai_tool: OpenAiToolConfig) -> OpenAiToolConfig:
+        if not (
+            self.__content_propagation
+            and self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
+        ):
+            return open_ai_tool
+        open_ai_tool.function.description = (
+            open_ai_tool.function.description or ""
+        ) + self._STATEFUL_DESCRIPTION_SUFFIX
+        if "session_id" not in open_ai_tool.function.parameters.properties:
+            open_ai_tool.function.parameters.properties["session_id"] = self._SESSION_ID_PARAM
+        return open_ai_tool
 
     @staticmethod
     def _sdk_attachment_to_param(attachment: SdkAttachment) -> AttachmentParam:
@@ -97,6 +139,7 @@ class BaseDeploymentTool(StagedBaseTool):
     async def _extract_tool_history(
         self,
         tool_name: str,
+        session_id: str | None = None,
     ) -> list[UserMessageParam | AssistantMessageParam]:
         if not tool_name:
             return []
@@ -106,8 +149,9 @@ class BaseDeploymentTool(StagedBaseTool):
         # Build map: tool_call_id -> (content, custom_content)
         tool_result_by_id: dict[str, tuple[str, CustomContent | None]] = {}
         for msg in messages:
-            if msg.role == Role.TOOL and msg.tool_call_id and msg.content:
-                content = str(msg.content) if not isinstance(msg.content, str) else msg.content
+            if msg.role == Role.TOOL and msg.tool_call_id:
+                raw = msg.content
+                content = "" if raw is None else (str(raw) if not isinstance(raw, str) else raw)
                 tool_result_by_id[msg.tool_call_id] = (content, msg.custom_content)
 
         # Walk ASSISTANT messages, find completed tool_calls matching tool_name
@@ -120,6 +164,16 @@ class BaseDeploymentTool(StagedBaseTool):
                 if tc.function.name != tool_name:
                     continue
 
+                # When session_id is provided, only include calls from the same thread.
+                # Absent session_id falls back to tool_name-only filtering (propagate_history behaviour).
+                if session_id is not None:
+                    try:
+                        call_args = json.loads(tc.function.arguments)
+                        if call_args.get("session_id") != session_id:
+                            continue
+                    except (json.JSONDecodeError, AttributeError):
+                        continue
+
                 result_entry = tool_result_by_id.get(tc.id)
                 if result_entry is None:
                     # Current call — its TOOL result hasn't been appended yet
@@ -131,8 +185,10 @@ class BaseDeploymentTool(StagedBaseTool):
                 if user_msg is not None:
                     history.append(user_msg)
 
-                if tool_content:
-                    assistant_msg = self._build_assistant_message(tool_content, tool_custom_content)
+                if tool_content or tool_custom_content:
+                    assistant_msg = self._build_assistant_message(
+                        tool_content or "", tool_custom_content
+                    )
                     history.append(assistant_msg)
 
         return history

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -21,11 +21,7 @@ from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.utils import to_plain_dict
 from quickapp.config.dial_deployment import DialDeploymentParameters
 from quickapp.config.tools.base import ConfigurableSchemaSimpleType, JsonTypeEnum, OpenAiToolConfig
-from quickapp.config.tools.deployment import (
-    ContentPropagation,
-    ConversationMode,
-    DialDeploymentTool,
-)
+from quickapp.config.tools.deployment import ContentPropagation, DialDeploymentTool
 from quickapp.dial_deployment_tooling._attachment_resolver import AttachmentResolver
 from quickapp.dial_deployment_tooling.constants import (
     ATTACHMENT_PARAM,
@@ -70,7 +66,7 @@ class BaseDeploymentTool(StagedBaseTool):
         if content_propagation and content_propagation.propagate_history:
             logger.warning(
                 "The 'propagate_history' parameter is deprecated and will be removed in a future release. "
-                "Use 'conversation_mode: stateful' instead."
+                "Use 'conversation_mode.resumable: true' instead."
             )
         self.__messages_mixin: MessagesMixin = messages_mixin
 
@@ -83,20 +79,20 @@ class BaseDeploymentTool(StagedBaseTool):
     ) -> ToolCallResult:
         tool_config = cast(DialDeploymentTool, self.tool_config)
         session_id: str | None = kwargs.pop("session_id", None)
-        is_stateful = (
-            self.__content_propagation is not None
-            and self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
+        is_resumable = (
+            tool_config.conversation_mode is not None and tool_config.conversation_mode.resumable
         )
-        is_first_call = is_stateful and session_id is None
+        is_first_call = is_resumable and session_id is None
         if is_first_call:
             session_id = tool_call_id
-            logger.info("Stateful tool first call — assigned session_id=%s", session_id)
-        elif is_stateful and session_id:
-            logger.info("Stateful tool follow-up — session_id=%s", session_id)
+            logger.info("Resumable tool first call — assigned session_id=%s", session_id)
+        elif is_resumable and session_id:
+            logger.info("Resumable tool follow-up — session_id=%s", session_id)
         history = None
-        if self.__content_propagation and (
-            self.__content_propagation.propagate_history or is_stateful
-        ):
+        propagate_history = bool(
+            self.__content_propagation and self.__content_propagation.propagate_history
+        )
+        if propagate_history or is_resumable:
             history = await self._extract_tool_history(
                 tool_config.open_ai_tool.function.name, session_id=session_id
             )
@@ -123,10 +119,8 @@ class BaseDeploymentTool(StagedBaseTool):
     )
 
     def enrich_openai_tool_schema(self, open_ai_tool: OpenAiToolConfig) -> OpenAiToolConfig:
-        if not (
-            self.__content_propagation
-            and self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
-        ):
+        tool_config = cast(DialDeploymentTool, self.tool_config)
+        if not (tool_config.conversation_mode and tool_config.conversation_mode.resumable):
             return open_ai_tool
         if "session_id" not in open_ai_tool.function.parameters.properties:
             open_ai_tool.function.parameters.properties["session_id"] = self._SESSION_ID_PARAM

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -78,15 +78,24 @@ class BaseDeploymentTool(StagedBaseTool):
     ) -> ToolCallResult:
         tool_config = cast(DialDeploymentTool, self.tool_config)
         session_id: str | None = kwargs.pop("session_id", None)
+        is_stateful = (
+            self.__content_propagation is not None
+            and self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
+        )
+        is_first_call = is_stateful and session_id is None
+        if is_first_call:
+            session_id = tool_call_id
+            logger.info("Stateful tool first call — assigned session_id=%s", session_id)
+        elif is_stateful and session_id:
+            logger.info("Stateful tool follow-up — session_id=%s", session_id)
         history = None
         if self.__content_propagation and (
-            self.__content_propagation.propagate_history
-            or self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
+            self.__content_propagation.propagate_history or is_stateful
         ):
             history = await self._extract_tool_history(
                 tool_config.open_ai_tool.function.name, session_id=session_id
             )
-        return await self.__dial_completion_service.complete_request_async(
+        result = await self.__dial_completion_service.complete_request_async(
             kwargs,
             self.__application_id,
             self.__application_name,
@@ -95,22 +104,16 @@ class BaseDeploymentTool(StagedBaseTool):
             history=history,
             supports_url_attachments=tool_config.supports_url_attachments,
         )
-
-    _STATEFUL_DESCRIPTION_SUFFIX = (
-        "\n\nThis tool is a stateful subagent: it maintains conversation history across calls "
-        "within the same session. On each follow-up call, the backend automatically prepends "
-        "prior exchanges for that session. Send only the new information (delta) in `query` — "
-        "do not re-summarize prior context. Assign a unique `session_id` at the start of each "
-        "conversation thread and use the same value for all follow-up calls in that thread."
-    )
+        if is_first_call and session_id:
+            result.content = result.content + f"\n\n[session_id: {session_id}]"
+        return result
 
     _SESSION_ID_PARAM = ConfigurableSchemaSimpleType(
         type=JsonTypeEnum.string,
         description=(
-            "Identifier for this conversation thread. Assign a unique value when starting a "
-            "new multi-turn exchange with this subagent (e.g. 'research-climate'). Use the "
-            "same session_id on all follow-up calls for that thread. Use a different "
-            "session_id to start an independent conversation thread."
+            "The session identifier returned at the end of a previous response from this tool. "
+            "Pass it back unchanged to continue that conversation thread. "
+            "Omit to start a new independent thread."
         ),
     )
 
@@ -120,9 +123,6 @@ class BaseDeploymentTool(StagedBaseTool):
             and self.__content_propagation.conversation_mode == ConversationMode.STATEFUL
         ):
             return open_ai_tool
-        open_ai_tool.function.description = (
-            open_ai_tool.function.description or ""
-        ) + self._STATEFUL_DESCRIPTION_SUFFIX
         if "session_id" not in open_ai_tool.function.parameters.properties:
             open_ai_tool.function.parameters.properties["session_id"] = self._SESSION_ID_PARAM
         return open_ai_tool
@@ -164,15 +164,20 @@ class BaseDeploymentTool(StagedBaseTool):
                 if tc.function.name != tool_name:
                     continue
 
-                # When session_id is provided, only include calls from the same thread.
-                # Absent session_id falls back to tool_name-only filtering (propagate_history behaviour).
+                # When session_id is provided, match calls that are either:
+                # - the thread anchor (tc.id == session_id): the first call, identified by
+                #   the tool_call_id the backend returned to the LLM as the session identifier
+                # - a follow-up (args["session_id"] == session_id): the LLM echoed it back
                 if session_id is not None:
                     try:
                         call_args = json.loads(tc.function.arguments)
-                        if call_args.get("session_id") != session_id:
+                        is_anchor = tc.id == session_id
+                        is_followup = call_args.get("session_id") == session_id
+                        if not (is_anchor or is_followup):
                             continue
                     except (json.JSONDecodeError, AttributeError):
-                        continue
+                        if tc.id != session_id:
+                            continue
 
                 result_entry = tool_result_by_id.get(tc.id)
                 if result_entry is None:

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -70,6 +70,47 @@ class BaseDeploymentTool(StagedBaseTool):
             )
         self.__messages_mixin: MessagesMixin = messages_mixin
 
+    @staticmethod
+    def _is_resumable(tool_config: DialDeploymentTool) -> bool:
+        return tool_config.conversation_mode is not None and tool_config.conversation_mode.resumable
+
+    def _setup_session(
+        self,
+        kwargs: dict,
+        tool_config: DialDeploymentTool,
+        tool_call_id: str | None,
+    ) -> tuple[str | None, bool]:
+        """Pop session_id from kwargs and resolve the resumable session state.
+
+        Returns (session_id, is_first_call): the session identifier to use for this
+        call (the tool_call_id on a resumable first call, otherwise whatever the LLM
+        passed back or None), and whether this is the first call of a resumable thread.
+        """
+        session_id: str | None = kwargs.pop("session_id", None)
+        if not self._is_resumable(tool_config):
+            return session_id, False
+        is_first_call = session_id is None
+        if is_first_call:
+            session_id = tool_call_id
+            logger.info("Resumable tool first call — assigned session_id=%s", session_id)
+        else:
+            logger.info("Resumable tool follow-up — session_id=%s", session_id)
+        return session_id, is_first_call
+
+    async def _resolve_history(
+        self,
+        tool_config: DialDeploymentTool,
+        session_id: str | None,
+    ) -> list[UserMessageParam | AssistantMessageParam] | None:
+        propagate_history = bool(
+            self.__content_propagation and self.__content_propagation.propagate_history
+        )
+        if not (propagate_history or self._is_resumable(tool_config)):
+            return None
+        return await self._extract_tool_history(
+            tool_config.open_ai_tool.function.name, session_id=session_id
+        )
+
     async def _run_in_stage_async(
         self,
         stage_wrapper: BaseStageWrapper | None,
@@ -78,24 +119,8 @@ class BaseDeploymentTool(StagedBaseTool):
         **kwargs,
     ) -> ToolCallResult:
         tool_config = cast(DialDeploymentTool, self.tool_config)
-        session_id: str | None = kwargs.pop("session_id", None)
-        is_resumable = (
-            tool_config.conversation_mode is not None and tool_config.conversation_mode.resumable
-        )
-        is_first_call = is_resumable and session_id is None
-        if is_first_call:
-            session_id = tool_call_id
-            logger.info("Resumable tool first call — assigned session_id=%s", session_id)
-        elif is_resumable and session_id:
-            logger.info("Resumable tool follow-up — session_id=%s", session_id)
-        history = None
-        propagate_history = bool(
-            self.__content_propagation and self.__content_propagation.propagate_history
-        )
-        if propagate_history or is_resumable:
-            history = await self._extract_tool_history(
-                tool_config.open_ai_tool.function.name, session_id=session_id
-            )
+        session_id, is_first_call = self._setup_session(kwargs, tool_config, tool_call_id)
+        history = await self._resolve_history(tool_config, session_id)
         result = await self.__dial_completion_service.complete_request_async(
             kwargs,
             self.__application_id,
@@ -120,7 +145,7 @@ class BaseDeploymentTool(StagedBaseTool):
 
     def enrich_openai_tool_schema(self, open_ai_tool: OpenAiToolConfig) -> OpenAiToolConfig:
         tool_config = cast(DialDeploymentTool, self.tool_config)
-        if not (tool_config.conversation_mode and tool_config.conversation_mode.resumable):
+        if not self._is_resumable(tool_config):
             return open_ai_tool
         if "session_id" not in open_ai_tool.function.parameters.properties:
             open_ai_tool.function.parameters.properties["session_id"] = self._SESSION_ID_PARAM

--- a/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
+++ b/src/quickapp/dial_deployment_tooling/base_deployment_tool.py
@@ -67,6 +67,11 @@ class BaseDeploymentTool(StagedBaseTool):
         self.__dial_completion_service: DialCompletionService = dial_completion_service
         self.__attachment_resolver: AttachmentResolver = attachment_resolver
         self.__content_propagation: ContentPropagation | None = content_propagation
+        if content_propagation and content_propagation.propagate_history:
+            logger.warning(
+                "The 'propagate_history' parameter is deprecated and will be removed in a future release. "
+                "Use 'conversation_mode: stateful' instead."
+            )
         self.__messages_mixin: MessagesMixin = messages_mixin
 
     async def _run_in_stage_async(

--- a/src/tests/unit_tests/dial_app_tooling_tests/test_dial_app_resolver_fallback_branch.py
+++ b/src/tests/unit_tests/dial_app_tooling_tests/test_dial_app_resolver_fallback_branch.py
@@ -3,6 +3,7 @@ import logging
 import pytest
 
 from quickapp.config.tools.base import AttachmentConfig
+from quickapp.config.tools.deployment import ConversationMode
 from quickapp.config.tools.tool_fallback import StopStrategyModel, ToolFallbackConfig
 from quickapp.config.toolsets.dial_app import DialAppToolSet
 
@@ -68,6 +69,40 @@ async def test_fallback_model_copy_overrides_attachment_and_fallback_configurati
     customised = context.resolved_deployment_tools[0]
     assert customised.attachment == custom_attachment
     assert customised.fallback_configuration == custom_fallback
+
+
+@pytest.mark.asyncio
+async def test_fallback_threads_conversation_mode_onto_synthetic_tool():
+    toolset = DialAppToolSet(
+        name="app",
+        deployment_id="dep",
+        conversation_mode=ConversationMode(resumable=True),
+    )
+    resolver, context, _, _ = make_resolver(
+        toolsets=[toolset],
+        metadata=make_metadata(mcp=False),
+        tool_config=make_tool_config(),
+    )
+
+    await resolver.resolve()
+
+    customised = context.resolved_deployment_tools[0]
+    assert customised.conversation_mode is not None
+    assert customised.conversation_mode.resumable is True
+
+
+@pytest.mark.asyncio
+async def test_fallback_conversation_mode_none_leaves_synthetic_default():
+    toolset = DialAppToolSet(name="app", deployment_id="dep")
+    resolver, context, _, _ = make_resolver(
+        toolsets=[toolset],
+        metadata=make_metadata(mcp=False),
+        tool_config=make_tool_config(),
+    )
+
+    await resolver.resolve()
+
+    assert context.resolved_deployment_tools[0].conversation_mode is None
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -1,3 +1,4 @@
+import copy
 import json
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
@@ -9,6 +10,7 @@ from aidial_sdk.chat_completion.request import CustomContent, FunctionCall, Tool
 from pydantic import StrictStr
 
 from quickapp.common.messages_mixin import MessagesMixin
+from quickapp.common.tool_call_result import ToolCallResult
 from quickapp.config.application import StageDisplayLevel
 from quickapp.config.dial_deployment import (
     CustomFieldsConfig,
@@ -22,7 +24,11 @@ from quickapp.config.tools.base import (
     OpenAiToolFunction,
     OpenAiToolFunctionParameters,
 )
-from quickapp.config.tools.deployment import DialDeploymentTool
+from quickapp.config.tools.deployment import (
+    ContentPropagation,
+    ConversationMode,
+    DialDeploymentTool,
+)
 from quickapp.dial_deployment_tooling.base_deployment_tool import BaseDeploymentTool
 
 
@@ -37,10 +43,13 @@ def _make_tool_call(
     name: str,
     query: str,
     attachment_urls: list[str] | None = None,
+    session_id: str | None = None,
 ) -> ToolCall:
     args: dict[str, Any] = {"query": query}
     if attachment_urls is not None:
         args["attachment_urls"] = attachment_urls
+    if session_id is not None:
+        args["session_id"] = session_id
     return ToolCall(
         id=tool_call_id,
         type="function",
@@ -455,3 +464,285 @@ async def test_pre_process_params_standard_params_stay_flat():
     assert result["temperature"] == 0.7
     assert "temperature" not in result.get("custom_fields", {}).get("configuration", {})
     assert result["custom_fields"]["configuration"]["size"] == "1024x1024"
+
+
+# ---------------------------------------------------------------------------
+# _extract_tool_history: empty content with state
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_preserves_state_with_empty_content():
+    """TOOL message with state but empty content still produces an AssistantMessageParam with state."""
+    state_data = {"tool_execution_history": [{"role": "assistant", "content": "step 1"}]}
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Hello")),
+        _make_assistant_with_tool_calls([_make_tool_call("tc1", "my_tool", "go")]),
+        _make_tool_result("tc1", "", custom_content=CustomContent(state=state_data)),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool")
+
+    assert len(history) == 2
+    assistant_msg = history[1]
+    assert assistant_msg["role"] == "assistant"
+    assert assistant_msg["content"] == ""
+    assert assistant_msg["custom_content"]["state"] == state_data
+
+
+# ---------------------------------------------------------------------------
+# conversation_mode: _run_in_stage_async history triggering
+# ---------------------------------------------------------------------------
+
+
+def _build_tool_with_propagation(
+    messages: list[Message],
+    content_propagation: ContentPropagation | None,
+    dial_completion_service: Any = None,
+) -> BaseDeploymentTool:
+    """Build a BaseDeploymentTool with a real tool_config and configurable content_propagation."""
+    if dial_completion_service is None:
+        dial_completion_service = AsyncMock()
+    return BaseDeploymentTool(
+        application_id="test-app",
+        application_name="Test App",
+        tool_config=_make_tool_config(),
+        content_propagation=content_propagation,
+        dial_completion_service=dial_completion_service,
+        attachment_resolver=MagicMock(),
+        messages_mixin=_make_messages_mixin(messages),
+        perf_timer=MagicMock(),
+        stage_wrapper_builder=MagicMock(),
+        stage_display_level=StageDisplayLevel.INFO,
+    )
+
+
+def _make_mock_completion_service() -> Any:
+    svc = AsyncMock()
+    svc.complete_request_async.return_value = ToolCallResult(
+        content="ok", content_type="text/plain"
+    )
+    return svc
+
+
+@pytest.mark.asyncio
+async def test_conversation_mode_stateful_triggers_extract():
+    """conversation_mode=stateful causes history to be built and passed to the service."""
+    svc = _make_mock_completion_service()
+    tool = _build_tool_with_propagation(
+        messages=[],
+        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        dial_completion_service=svc,
+    )
+
+    await tool._run_in_stage_async(stage_wrapper=None, query="hello")
+
+    _, kwargs = svc.complete_request_async.call_args
+    assert kwargs["history"] is not None
+
+
+@pytest.mark.asyncio
+async def test_conversation_mode_stateless_skips_extract():
+    """conversation_mode=stateless with propagate_history=False passes history=None."""
+    svc = _make_mock_completion_service()
+    tool = _build_tool_with_propagation(
+        messages=[],
+        content_propagation=ContentPropagation(
+            conversation_mode=ConversationMode.STATELESS,
+            propagate_history=False,
+        ),
+        dial_completion_service=svc,
+    )
+
+    await tool._run_in_stage_async(stage_wrapper=None, query="hello")
+
+    _, kwargs = svc.complete_request_async.call_args
+    assert kwargs["history"] is None
+
+
+@pytest.mark.asyncio
+async def test_propagate_history_and_stateful_are_independent():
+    """propagate_history=True and conversation_mode=stateful each independently trigger extraction."""
+    for propagation in [
+        ContentPropagation(propagate_history=True, conversation_mode=ConversationMode.STATELESS),
+        ContentPropagation(propagate_history=False, conversation_mode=ConversationMode.STATEFUL),
+    ]:
+        svc = _make_mock_completion_service()
+        tool = _build_tool_with_propagation(
+            messages=[],
+            content_propagation=propagation,
+            dial_completion_service=svc,
+        )
+
+        await tool._run_in_stage_async(stage_wrapper=None, query="hello")
+
+        _, kwargs = svc.complete_request_async.call_args
+        assert kwargs["history"] is not None, f"Expected history for {propagation}"
+
+
+# ---------------------------------------------------------------------------
+# _extract_tool_history: session_id filtering
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_extract_session_id_filters_to_matching_thread():
+    """When session_id is provided, only calls with that session_id are included."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Start")),
+        _make_assistant_with_tool_calls(
+            [
+                _make_tool_call("tc1", "my_tool", "thread-A step 1", session_id="session-A"),
+                _make_tool_call("tc2", "my_tool", "thread-B step 1", session_id="session-B"),
+            ]
+        ),
+        _make_tool_result("tc1", "A answer 1"),
+        _make_tool_result("tc2", "B answer 1"),
+        _make_assistant_with_tool_calls(
+            [
+                _make_tool_call("tc3", "my_tool", "thread-A step 2", session_id="session-A"),
+            ]
+        ),
+        _make_tool_result("tc3", "A answer 2"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool", session_id="session-A")
+
+    assert len(history) == 4
+    assert history[0]["content"] == "thread-A step 1"
+    assert history[1]["content"] == "A answer 1"
+    assert history[2]["content"] == "thread-A step 2"
+    assert history[3]["content"] == "A answer 2"
+
+
+@pytest.mark.asyncio
+async def test_extract_session_id_excludes_other_threads():
+    """Calls with a different session_id are not included."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Start")),
+        _make_assistant_with_tool_calls(
+            [
+                _make_tool_call("tc1", "my_tool", "thread-A step", session_id="session-A"),
+            ]
+        ),
+        _make_tool_result("tc1", "A answer"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool", session_id="session-B")
+
+    assert history == []
+
+
+@pytest.mark.asyncio
+async def test_extract_session_id_none_falls_back_to_tool_name_only():
+    """When session_id is None, falls back to tool_name-only filtering (includes all sessions)."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Start")),
+        _make_assistant_with_tool_calls(
+            [
+                _make_tool_call("tc1", "my_tool", "thread-A", session_id="session-A"),
+                _make_tool_call("tc2", "my_tool", "thread-B", session_id="session-B"),
+            ]
+        ),
+        _make_tool_result("tc1", "A answer"),
+        _make_tool_result("tc2", "B answer"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool", session_id=None)
+
+    assert len(history) == 4
+    assert history[0]["content"] == "thread-A"
+    assert history[1]["content"] == "A answer"
+    assert history[2]["content"] == "thread-B"
+    assert history[3]["content"] == "B answer"
+
+
+# ---------------------------------------------------------------------------
+# _run_in_stage_async: session_id is consumed, not forwarded to subagent
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_pops_session_id_before_forwarding():
+    """session_id is consumed by _run_in_stage_async and not forwarded to the completion service."""
+    svc = _make_mock_completion_service()
+    tool = _build_tool_with_propagation(
+        messages=[],
+        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        dial_completion_service=svc,
+    )
+
+    await tool._run_in_stage_async(stage_wrapper=None, query="hello", session_id="my-thread")
+
+    forwarded_kwargs, _ = svc.complete_request_async.call_args
+    payload = forwarded_kwargs[0]
+    assert "session_id" not in payload
+    assert payload["query"] == "hello"
+
+
+# ---------------------------------------------------------------------------
+# enrich_openai_tool_schema
+# ---------------------------------------------------------------------------
+
+
+def _build_tool_with_content_propagation(
+    content_propagation: ContentPropagation | None,
+) -> BaseDeploymentTool:
+    return BaseDeploymentTool(
+        application_id="test-app",
+        application_name="Test App",
+        tool_config=_make_tool_config(),
+        content_propagation=content_propagation,
+        dial_completion_service=MagicMock(),
+        attachment_resolver=MagicMock(),
+        messages_mixin=_make_messages_mixin([]),
+        perf_timer=MagicMock(),
+        stage_wrapper_builder=MagicMock(),
+        stage_display_level=StageDisplayLevel.INFO,
+    )
+
+
+def test_enrich_stateful_injects_session_id_and_description_suffix():
+    """For conversation_mode=stateful, enrich_openai_tool_schema injects session_id and appends description."""
+    tool = _build_tool_with_content_propagation(
+        ContentPropagation(conversation_mode=ConversationMode.STATEFUL)
+    )
+    tool_config = _make_tool_config()
+    open_ai_tool = copy.deepcopy(tool_config.open_ai_tool)
+    enriched = tool.enrich_openai_tool_schema(open_ai_tool)
+
+    assert "session_id" in enriched.function.parameters.properties
+    assert enriched.function.description is not None
+    assert "stateful subagent" in enriched.function.description
+
+
+def test_enrich_stateless_is_noop():
+    """For conversation_mode=stateless (default), enrich_openai_tool_schema returns the tool unchanged."""
+    tool = _build_tool_with_content_propagation(
+        ContentPropagation(conversation_mode=ConversationMode.STATELESS)
+    )
+    tool_config = _make_tool_config()
+    open_ai_tool = copy.deepcopy(tool_config.open_ai_tool)
+    original_description = open_ai_tool.function.description
+    original_props = set(open_ai_tool.function.parameters.properties.keys())
+
+    enriched = tool.enrich_openai_tool_schema(open_ai_tool)
+
+    assert enriched.function.description == original_description
+    assert set(enriched.function.parameters.properties.keys()) == original_props
+
+
+def test_enrich_no_propagation_is_noop():
+    """With no content_propagation, enrich_openai_tool_schema is a no-op."""
+    tool = _build_tool_with_content_propagation(None)
+    tool_config = _make_tool_config()
+    open_ai_tool = copy.deepcopy(tool_config.open_ai_tool)
+    original_props = set(open_ai_tool.function.parameters.properties.keys())
+
+    enriched = tool.enrich_openai_tool_schema(open_ai_tool)
+
+    assert set(enriched.function.parameters.properties.keys()) == original_props

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -588,33 +588,52 @@ async def test_propagate_history_and_stateful_are_independent():
 
 @pytest.mark.asyncio
 async def test_extract_session_id_filters_to_matching_thread():
-    """When session_id is provided, only calls with that session_id are included."""
+    """Anchor call (tc.id == session_id) and follow-ups (args session_id == session_id) are included; other threads excluded."""
     messages: list[Message] = [
         Message(role=Role.USER, content=StrictStr("Start")),
         _make_assistant_with_tool_calls(
             [
-                _make_tool_call("tc1", "my_tool", "thread-A step 1", session_id="session-A"),
-                _make_tool_call("tc2", "my_tool", "thread-B step 1", session_id="session-B"),
+                _make_tool_call("tc1", "my_tool", "thread-A step 1"),  # anchor for session tc1
+                _make_tool_call("tc2", "my_tool", "thread-B step 1"),  # anchor for session tc2
             ]
         ),
         _make_tool_result("tc1", "A answer 1"),
         _make_tool_result("tc2", "B answer 1"),
         _make_assistant_with_tool_calls(
             [
-                _make_tool_call("tc3", "my_tool", "thread-A step 2", session_id="session-A"),
+                _make_tool_call(
+                    "tc3", "my_tool", "thread-A step 2", session_id="tc1"
+                ),  # follow-up to A
             ]
         ),
         _make_tool_result("tc3", "A answer 2"),
     ]
 
     tool = _build_tool(messages)
-    history = await tool._extract_tool_history("my_tool", session_id="session-A")
+    history = await tool._extract_tool_history("my_tool", session_id="tc1")
 
     assert len(history) == 4
     assert history[0]["content"] == "thread-A step 1"
     assert history[1]["content"] == "A answer 1"
     assert history[2]["content"] == "thread-A step 2"
     assert history[3]["content"] == "A answer 2"
+
+
+@pytest.mark.asyncio
+async def test_extract_anchor_matches_by_tool_call_id():
+    """First call matched by tc.id == session_id (the anchor), even without session_id in its args."""
+    messages: list[Message] = [
+        Message(role=Role.USER, content=StrictStr("Start")),
+        _make_assistant_with_tool_calls([_make_tool_call("call-abc", "my_tool", "first question")]),
+        _make_tool_result("call-abc", "first answer"),
+    ]
+
+    tool = _build_tool(messages)
+    history = await tool._extract_tool_history("my_tool", session_id="call-abc")
+
+    assert len(history) == 2
+    assert history[0]["content"] == "first question"
+    assert history[1]["content"] == "first answer"
 
 
 @pytest.mark.asyncio
@@ -684,6 +703,57 @@ async def test_run_in_stage_pops_session_id_before_forwarding():
     assert payload["query"] == "hello"
 
 
+@pytest.mark.asyncio
+async def test_run_in_stage_injects_session_id_into_first_result():
+    """First stateful call (no session_id) appends session_id from tool_call_id to result content."""
+    svc = _make_mock_completion_service()
+    tool = _build_tool_with_propagation(
+        messages=[],
+        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        dial_completion_service=svc,
+    )
+
+    result = await tool._run_in_stage_async(
+        stage_wrapper=None, tool_call_id="call-xyz", query="hello"
+    )
+
+    assert "[session_id: call-xyz]" in result.content
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_no_injection_on_follow_up():
+    """Follow-up call (session_id already provided) does not modify result content."""
+    svc = _make_mock_completion_service()
+    tool = _build_tool_with_propagation(
+        messages=[],
+        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        dial_completion_service=svc,
+    )
+
+    result = await tool._run_in_stage_async(
+        stage_wrapper=None, tool_call_id="call-xyz2", query="hello", session_id="call-xyz"
+    )
+
+    assert result.content == "ok"
+
+
+@pytest.mark.asyncio
+async def test_run_in_stage_no_injection_for_stateless():
+    """Stateless tool calls never inject session_id, even when tool_call_id is present."""
+    svc = _make_mock_completion_service()
+    tool = _build_tool_with_propagation(
+        messages=[],
+        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATELESS),
+        dial_completion_service=svc,
+    )
+
+    result = await tool._run_in_stage_async(
+        stage_wrapper=None, tool_call_id="call-xyz", query="hello"
+    )
+
+    assert result.content == "ok"
+
+
 # ---------------------------------------------------------------------------
 # enrich_openai_tool_schema
 # ---------------------------------------------------------------------------
@@ -706,8 +776,8 @@ def _build_tool_with_content_propagation(
     )
 
 
-def test_enrich_stateful_injects_session_id_and_description_suffix():
-    """For conversation_mode=stateful, enrich_openai_tool_schema injects session_id and appends description."""
+def test_enrich_stateful_injects_session_id():
+    """For conversation_mode=stateful, enrich_openai_tool_schema injects session_id into the schema."""
     tool = _build_tool_with_content_propagation(
         ContentPropagation(conversation_mode=ConversationMode.STATEFUL)
     )
@@ -716,8 +786,6 @@ def test_enrich_stateful_injects_session_id_and_description_suffix():
     enriched = tool.enrich_openai_tool_schema(open_ai_tool)
 
     assert "session_id" in enriched.function.parameters.properties
-    assert enriched.function.description is not None
-    assert "stateful subagent" in enriched.function.description
 
 
 def test_enrich_stateless_is_noop():

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_base_deployment_tool.py
@@ -360,6 +360,7 @@ async def test_extract_resolves_request_attachments():
 def _make_tool_config(
     parameters: DialDeploymentParameters | None = None,
     configuration_param_names: set[str] | None = None,
+    conversation_mode: ConversationMode | None = None,
 ) -> DialDeploymentTool:
     """Build a real DialDeploymentTool for _pre_process_params tests."""
     deployment = DialDeploymentConfig(
@@ -370,6 +371,7 @@ def _make_tool_config(
         deployment._configuration_param_names = configuration_param_names
     return DialDeploymentTool(
         deployment=deployment,
+        conversation_mode=conversation_mode,
         open_ai_tool=OpenAiToolConfig(
             function=OpenAiToolFunction(
                 name="test_tool",
@@ -498,16 +500,17 @@ async def test_extract_preserves_state_with_empty_content():
 
 def _build_tool_with_propagation(
     messages: list[Message],
-    content_propagation: ContentPropagation | None,
+    content_propagation: ContentPropagation | None = None,
     dial_completion_service: Any = None,
+    conversation_mode: ConversationMode | None = None,
 ) -> BaseDeploymentTool:
-    """Build a BaseDeploymentTool with a real tool_config and configurable content_propagation."""
+    """Build a BaseDeploymentTool with a real tool_config and configurable propagation/mode."""
     if dial_completion_service is None:
         dial_completion_service = AsyncMock()
     return BaseDeploymentTool(
         application_id="test-app",
         application_name="Test App",
-        tool_config=_make_tool_config(),
+        tool_config=_make_tool_config(conversation_mode=conversation_mode),
         content_propagation=content_propagation,
         dial_completion_service=dial_completion_service,
         attachment_resolver=MagicMock(),
@@ -527,12 +530,12 @@ def _make_mock_completion_service() -> Any:
 
 
 @pytest.mark.asyncio
-async def test_conversation_mode_stateful_triggers_extract():
-    """conversation_mode=stateful causes history to be built and passed to the service."""
+async def test_resumable_triggers_extract():
+    """conversation_mode.resumable=True causes history to be built and passed to the service."""
     svc = _make_mock_completion_service()
     tool = _build_tool_with_propagation(
         messages=[],
-        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        conversation_mode=ConversationMode(resumable=True),
         dial_completion_service=svc,
     )
 
@@ -543,15 +546,13 @@ async def test_conversation_mode_stateful_triggers_extract():
 
 
 @pytest.mark.asyncio
-async def test_conversation_mode_stateless_skips_extract():
-    """conversation_mode=stateless with propagate_history=False passes history=None."""
+async def test_not_resumable_skips_extract():
+    """No resumable mode with propagate_history=False passes history=None."""
     svc = _make_mock_completion_service()
     tool = _build_tool_with_propagation(
         messages=[],
-        content_propagation=ContentPropagation(
-            conversation_mode=ConversationMode.STATELESS,
-            propagate_history=False,
-        ),
+        content_propagation=ContentPropagation(propagate_history=False),
+        conversation_mode=ConversationMode(resumable=False),
         dial_completion_service=svc,
     )
 
@@ -562,23 +563,26 @@ async def test_conversation_mode_stateless_skips_extract():
 
 
 @pytest.mark.asyncio
-async def test_propagate_history_and_stateful_are_independent():
-    """propagate_history=True and conversation_mode=stateful each independently trigger extraction."""
-    for propagation in [
-        ContentPropagation(propagate_history=True, conversation_mode=ConversationMode.STATELESS),
-        ContentPropagation(propagate_history=False, conversation_mode=ConversationMode.STATEFUL),
+async def test_propagate_history_and_resumable_are_independent():
+    """propagate_history=True and conversation_mode.resumable=True each independently trigger extraction."""
+    for content_propagation, conversation_mode in [
+        (ContentPropagation(propagate_history=True), None),
+        (ContentPropagation(propagate_history=False), ConversationMode(resumable=True)),
     ]:
         svc = _make_mock_completion_service()
         tool = _build_tool_with_propagation(
             messages=[],
-            content_propagation=propagation,
+            content_propagation=content_propagation,
+            conversation_mode=conversation_mode,
             dial_completion_service=svc,
         )
 
         await tool._run_in_stage_async(stage_wrapper=None, query="hello")
 
         _, kwargs = svc.complete_request_async.call_args
-        assert kwargs["history"] is not None, f"Expected history for {propagation}"
+        assert (
+            kwargs["history"] is not None
+        ), f"Expected history for {content_propagation}, {conversation_mode}"
 
 
 # ---------------------------------------------------------------------------
@@ -691,7 +695,7 @@ async def test_run_in_stage_pops_session_id_before_forwarding():
     svc = _make_mock_completion_service()
     tool = _build_tool_with_propagation(
         messages=[],
-        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        conversation_mode=ConversationMode(resumable=True),
         dial_completion_service=svc,
     )
 
@@ -705,11 +709,11 @@ async def test_run_in_stage_pops_session_id_before_forwarding():
 
 @pytest.mark.asyncio
 async def test_run_in_stage_injects_session_id_into_first_result():
-    """First stateful call (no session_id) appends session_id from tool_call_id to result content."""
+    """First resumable call (no session_id) appends session_id from tool_call_id to result content."""
     svc = _make_mock_completion_service()
     tool = _build_tool_with_propagation(
         messages=[],
-        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        conversation_mode=ConversationMode(resumable=True),
         dial_completion_service=svc,
     )
 
@@ -726,7 +730,7 @@ async def test_run_in_stage_no_injection_on_follow_up():
     svc = _make_mock_completion_service()
     tool = _build_tool_with_propagation(
         messages=[],
-        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATEFUL),
+        conversation_mode=ConversationMode(resumable=True),
         dial_completion_service=svc,
     )
 
@@ -738,12 +742,12 @@ async def test_run_in_stage_no_injection_on_follow_up():
 
 
 @pytest.mark.asyncio
-async def test_run_in_stage_no_injection_for_stateless():
-    """Stateless tool calls never inject session_id, even when tool_call_id is present."""
+async def test_run_in_stage_no_injection_when_not_resumable():
+    """Non-resumable tool calls never inject session_id, even when tool_call_id is present."""
     svc = _make_mock_completion_service()
     tool = _build_tool_with_propagation(
         messages=[],
-        content_propagation=ContentPropagation(conversation_mode=ConversationMode.STATELESS),
+        conversation_mode=ConversationMode(resumable=False),
         dial_completion_service=svc,
     )
 
@@ -761,11 +765,12 @@ async def test_run_in_stage_no_injection_for_stateless():
 
 def _build_tool_with_content_propagation(
     content_propagation: ContentPropagation | None,
+    conversation_mode: ConversationMode | None = None,
 ) -> BaseDeploymentTool:
     return BaseDeploymentTool(
         application_id="test-app",
         application_name="Test App",
-        tool_config=_make_tool_config(),
+        tool_config=_make_tool_config(conversation_mode=conversation_mode),
         content_propagation=content_propagation,
         dial_completion_service=MagicMock(),
         attachment_resolver=MagicMock(),
@@ -776,10 +781,10 @@ def _build_tool_with_content_propagation(
     )
 
 
-def test_enrich_stateful_injects_session_id():
-    """For conversation_mode=stateful, enrich_openai_tool_schema injects session_id into the schema."""
+def test_enrich_resumable_injects_session_id():
+    """For conversation_mode.resumable=True, enrich_openai_tool_schema injects session_id into the schema."""
     tool = _build_tool_with_content_propagation(
-        ContentPropagation(conversation_mode=ConversationMode.STATEFUL)
+        None, conversation_mode=ConversationMode(resumable=True)
     )
     tool_config = _make_tool_config()
     open_ai_tool = copy.deepcopy(tool_config.open_ai_tool)
@@ -788,10 +793,10 @@ def test_enrich_stateful_injects_session_id():
     assert "session_id" in enriched.function.parameters.properties
 
 
-def test_enrich_stateless_is_noop():
-    """For conversation_mode=stateless (default), enrich_openai_tool_schema returns the tool unchanged."""
+def test_enrich_not_resumable_is_noop():
+    """For conversation_mode.resumable=False, enrich_openai_tool_schema returns the tool unchanged."""
     tool = _build_tool_with_content_propagation(
-        ContentPropagation(conversation_mode=ConversationMode.STATELESS)
+        None, conversation_mode=ConversationMode(resumable=False)
     )
     tool_config = _make_tool_config()
     open_ai_tool = copy.deepcopy(tool_config.open_ai_tool)

--- a/src/tests/unit_tests/dial_deployment_tooling_tests/test_deployment_tool_initializer.py
+++ b/src/tests/unit_tests/dial_deployment_tooling_tests/test_deployment_tool_initializer.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -9,7 +9,8 @@ from quickapp.config.tools.base import (
     OpenAiToolFunction,
     OpenAiToolFunctionParameters,
 )
-from quickapp.config.tools.deployment import DialDeploymentTool
+from quickapp.config.tools.deployment import ConversationMode, DialDeploymentTool
+from quickapp.config.tools.deployment_simple import DialDeploymentSimpleTool
 from quickapp.config.toolsets.deployment import DeploymentToolSet
 from quickapp.dial_deployment_tooling._deployment_tool_initializer import _DeploymentToolInitializer
 from tests.unit_tests.common.common import make_provider
@@ -73,3 +74,50 @@ async def test_tool_names_hyphenated_toolset_name_preserved():
 
     assert builder.build.call_args.kwargs["application_name"] == "search_web"
     assert builder.build.call_args.kwargs["tool_config"].open_ai_tool.function.name == "search_web"
+
+
+def _make_simple_initializer(
+    simple_tool: DialDeploymentSimpleTool,
+    builder: MagicMock,
+    cached_config: DialDeploymentTool,
+) -> _DeploymentToolInitializer:
+    deployment_cache = MagicMock()
+    deployment_cache.fetch_basic_tool_config = AsyncMock(return_value=cached_config)
+    return _DeploymentToolInitializer(
+        context=MagicMock(),
+        tool_config_service=MagicMock(),
+        builder=builder,
+        deployment_cache=deployment_cache,
+        dial_tools_provider=make_provider([]),
+        simple_tools_provider=make_provider([simple_tool]),
+    )
+
+
+@pytest.mark.asyncio
+async def test_simple_tool_threads_conversation_mode_onto_synthetic_config():
+    simple_tool = DialDeploymentSimpleTool(
+        deployment_id="my-app",
+        conversation_mode=ConversationMode(resumable=True),
+    )
+    builder = MagicMock()
+    # Synthetic config from the cache has no conversation_mode.
+    cached_config = _make_deployment_tool("my_app_tool")
+
+    await _make_simple_initializer(simple_tool, builder, cached_config).initialize()
+
+    built_config = builder.build.call_args.kwargs["tool_config"]
+    assert built_config.conversation_mode is not None
+    assert built_config.conversation_mode.resumable is True
+    # The cached config must not be mutated in place (model_copy produces a fresh instance).
+    assert cached_config.conversation_mode is None
+
+
+@pytest.mark.asyncio
+async def test_simple_tool_without_conversation_mode_leaves_synthetic_default():
+    simple_tool = DialDeploymentSimpleTool(deployment_id="my-app")
+    builder = MagicMock()
+    cached_config = _make_deployment_tool("my_app_tool")
+
+    await _make_simple_initializer(simple_tool, builder, cached_config).initialize()
+
+    assert builder.build.call_args.kwargs["tool_config"].conversation_mode is None


### PR DESCRIPTION
### Applicable issues

* #88

### Description of changes

Code changes:
* New field in deployment tool config - `conversation_mode`, enum, values: `stateless` (default), `stateful`;
* Deployment tool issues `session_id`, and injects into the tool schema;

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
