### PR TITLE
feat: resolve error causes and deliver failures through the DIAL error protocol #411

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ registering each entry separately: `core/` exposes `core_module` (the app's cent
 `AppModule` + `AgentModule`), and `shared/` exposes `shared_module` (cross-cutting utility modules with
 their own DI wiring; today `ExternalFetchModule` in `shared/external_fetch/`).
 
-→ Deep dive: [`docs/agent.md`](docs/agent.md) | [`docs/skills.md`](docs/skills.md) | [`docs/file_transfer.md`](docs/file_transfer.md)
+→ Deep dive: [`docs/agent.md`](docs/agent.md) | [`docs/skills.md`](docs/skills.md) | [`docs/file_transfer.md`](docs/file_transfer.md) | [`docs/error_handling.md`](docs/error_handling.md)
 
 ### Dependency Injection (Core Pattern)
 

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ export
 export PYDANTIC_V2=True
 
 .PHONY: init_venv install install_dev install_integration install_all clean \
-	lint mypy format install_pre_commit_hooks run_chat test test_cov \
+	lint mypy format install_pre_commit_hooks run_chat run_error_injection_app test test_cov \
 	dump_app_schema dump_internal_tools generate_dial_config start_test_server stop_test_server \
 	integration_test integration_test_run e2e_test run_python \
 	black black_check isort isort_check autoflake autoflake_check flake8
@@ -91,6 +91,12 @@ install_pre_commit_hooks:
 
 run_chat: install_dev
 	$(POETRY) run python src/quickapp/app.py
+
+# Error-injection sample model for testing QuickApps error handling end-to-end.
+# Listens on :5002; Core reaches it via host.docker.internal (see docker-compose.yml).
+# Override host/port with ERROR_INJECTION_APP_HOST / ERROR_INJECTION_APP_PORT.
+run_error_injection_app: install_dev
+	$(POETRY) run python src/tests/sample_apps/error_injection_app/error_injection_app.py
 
 run_python: install_dev
 	$(if $(SCRIPT),,$(error SCRIPT is required, e.g. make run_python SCRIPT=path/to/script.py))

--- a/docker_compose_files/core/configuration/applications.json
+++ b/docker_compose_files/core/configuration/applications.json
@@ -1,5 +1,48 @@
 {
   "applications": {
+    "error_handling_tester": {
+      "displayName": "Error Handling Tester",
+      "description": "QuickApp wired to the error-injection sample model. Each conversation starter triggers a distinct failure mode so you can see how QuickApps surfaces it end-to-end. Requires the sample app running on the host (port 5002).",
+      "applicationTypeSchemaId": "https://mydial.epam.com/custom_application_schemas/quickapps2",
+      "inputAttachmentTypes": [
+        "*/*"
+      ],
+      "applicationProperties": {
+        "orchestrator": {
+          "deployment": {
+            "deployment_id": "error-injection-model"
+          },
+          "system_prompt": {
+            "type": "custom",
+            "variables": {},
+            "content": "You are wired to the error-injection sample model. The model ignores this prompt and instead reproduces a failure mode selected by the user's message. Use the conversation starters to trigger each scenario."
+          },
+          "max_iterations": 15
+        },
+        "contexts": [],
+        "tool_sets": [],
+        "conversation_starters": {
+          "intro_text": "Pick an error scenario to trigger",
+          "starters": [
+            {"title": "Happy path (control)", "text": "happy path"},
+            {"title": "Pre-stream 500 (display_message)", "text": "pre-stream 500"},
+            {"title": "Content filter", "text": "content filter"},
+            {"title": "Context length exceeded", "text": "context length exceeded"},
+            {"title": "Rate limit (429)", "text": "rate limit"},
+            {"title": "Auth failed (401)", "text": "auth failed"},
+            {"title": "Permission denied (403)", "text": "permission denied"},
+            {"title": "Not found (404)", "text": "not found"},
+            {"title": "Payload too large (413)", "text": "payload too large"},
+            {"title": "Invalid request (422)", "text": "invalid request"},
+            {"title": "Internal error (no display_message)", "text": "internal error"},
+            {"title": "Mid-stream error (after partial content)", "text": "mid-stream error"},
+            {"title": "Mid-stream stream failure (no display_message)", "text": "stream failure"},
+            {"title": "Uncaught exception", "text": "uncaught exception"},
+            {"title": "Slow response / timeout", "text": "slow response"}
+          ]
+        }
+      }
+    },
     "test_folder_app": {
       "displayName": "TestFolderAppPreConfigured",
       "description": "Application with rag and folder in contexts",

--- a/docker_compose_files/core/configuration/models-template.json
+++ b/docker_compose_files/core/configuration/models-template.json
@@ -1,5 +1,16 @@
 {
-  "models": {},
+  "models": {
+    "error-injection-model": {
+      "type": "chat",
+      "endpoint": "http://host.docker.internal:5002/openai/deployments/error-injection-model/chat/completions",
+      "displayName": "Error Injection Model",
+      "description": "Local test model that deterministically injects error-handling failure modes. Run the sample app on the host: make run_error_injection_app",
+      "features": {
+        "systemPromptSupported": true,
+        "toolsSupported": true
+      }
+    }
+  },
   "applications": {},
   "routes": {},
   "keys": {

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder contains technical documentation for the Quick Apps backend.
 | [Agent Design](./agent.md)                    | Internal architecture of the Quick Apps agent system, including the orchestrator loop, tool system, and message processing pipeline. |
 | [Application Schema](./application-schema.md) | How to configure QuickApps in DIAL Core (schema endpoint vs full schema).                                                            |
 | [ChatHub](./chathub.md)                       | Configuration guide for ChatHub variants — variant structure, authoring, and customization recipes.                                  |
+| [Error Handling](error_handling.md)           | How runtime failures become user-facing errors: resolution precedence, error-reference correlation, DIAL protocol delivery.          |
 | [File Transfer](file_transfer.md)             | How Quick Apps handles file parameters in tool calls (`file:{prefix}::` convention, preprocessing pipeline).                         |
 | [Agent Skills](skills.md)                     | How to create and manage reusable agent skills (directory layout, metadata).                                                         |
 | [Time Awareness](time_awareness.md)           | How the agent knows the current time and reasons about data freshness.                                                               |

--- a/docs/agent.md
+++ b/docs/agent.md
@@ -105,6 +105,10 @@ itself hard (`is_hard=True`) — otherwise `COMPLETED`. Tool-init failures and w
 failures are hard; per-URL skill failures are soft. The request always proceeds; the close status is a
 UI cue.
 
+Failures that *abort* the turn take a different path: they are resolved into safe, user-facing text,
+stamped with an error reference correlated to server logs, and delivered through the DIAL error protocol
+instead of being appended as assistant content. See [Error Handling](error_handling.md).
+
 ### 7. Orchestrator Invocation
 
 The orchestrator is retrieved from the DI container and its invoke method is called, starting the agent loop.

--- a/docs/designs/error_message_resolution.md
+++ b/docs/designs/error_message_resolution.md
@@ -1,6 +1,6 @@
 # Design: User-Facing Error Message Resolution
 
-- **Status:** Approved
+- **Status:** Implemented
 - **Approved:** 2026-07-08
 - **Dependencies:**
   - None

--- a/docs/designs/error_message_resolution.md
+++ b/docs/designs/error_message_resolution.md
@@ -1,0 +1,542 @@
+# Design: User-Facing Error Message Resolution
+
+- **Status:** Approved
+- **Approved:** 2026-07-08
+- **Dependencies:**
+  - None
+
+## Problem Statement
+
+When a request fails, `_QuickAppCompletion` funnels every exception through a single handler that maps it to a
+canned sentence via `resolve_exception_message` and appends it to the choice. The mapping is driven purely by
+**exception type and HTTP status code**, which produces misleading and unactionable messages:
+
+1. **The dominant complaint: "The AI model service encountered an internal error. Please try again later."**
+   This is the bucket for *any* HTTP 5xx returned by DIAL Core on the orchestrator LLM call. DIAL Core is a
+   proxy — a 5xx can mean an upstream provider outage, an adapter bug, a misconfigured deployment, an
+   interceptor failure, or an error raised by a downstream application in a chain. All of these collapse into
+   one sentence. The openai client has already retried transient failures (2 retries with backoff by default)
+   before the user sees this, so "try again later" is often false hope for a deterministic failure.
+
+2. **DIAL's `display_message` is discarded.** The DIAL error protocol carries a field explicitly designated as
+   safe to show end users: `display_message`. It is present on `aidial_sdk.exceptions.HTTPException` and inside
+   the JSON error body of openai exceptions when DIAL Core propagates an upstream error. The resolver never
+   reads it — the precise, user-safe explanation frequently already exists and is thrown away.
+
+3. **Mid-stream errors hit the weakest branch.** When a model fails *after* streaming has started, DIAL sends an
+   `{"error": ...}` chunk over an HTTP 200 stream. The openai SDK surfaces this as a **plain `APIError`** (no
+   status code), which matches none of the resolver's isinstance checks and falls through to the generic
+   fallback ("Something went wrong…"), again discarding the error body. Long orchestrator streams make this a
+   common production failure mode.
+
+4. **Context-length and content-filter handling is dead code for the main path.** The resolver maps the
+   in-process `aidial_sdk.ContextLengthExceededError` type, but the orchestrator calls the model through the
+   openai client — a real context overflow arrives as `openai.BadRequestError` with
+   `code == "context_length_exceeded"`. The user is told the request "was rejected — please try again", which
+   retrying will never fix. Content-filter rejections (`code == "content_filter"`) get the same misleading text.
+
+5. **"Contact your administrator" is a dead end.** The handler logs the full stack trace, but the user-visible
+   message carries no correlation identifier, so the administrator being contacted has no way to find the
+   corresponding log entry.
+
+6. **The delivery mechanism hides the failure from the platform.** The handler appends the error sentence as
+   ordinary assistant *content* over HTTP 200 (`choice.append_content`), bypassing DIAL's error protocol.
+   Verified against the DIAL Core and DIAL Chat sources: DIAL Chat never sets its message-level `errorMessage`
+   field for such a turn, so it renders as a normal successful reply — no error styling, no "Regenerate
+   response" steering — and the error sentence is stored in message `content` and **replayed verbatim to the
+   LLM as assistant history on every subsequent turn**, polluting context and inflating tokens. On the
+   operations side, DIAL Core's analytics pipeline records the request as a `status: 200` success, making
+   application failures invisible to status-based monitoring.
+
+## Design Goals
+
+- Surface DIAL's `display_message` to the user whenever the failing upstream provides one, regardless of which
+  client library delivered the error (openai exception, aidial exception, raw httpx response).
+- Classify errors by **error code** (e.g. `content_filter`, `context_length_exceeded`) before falling back to
+  status-class messages, so actionable causes get actionable text.
+- Handle mid-stream errors (plain `openai.APIError` carrying a DIAL error body) as first-class citizens instead
+  of the generic fallback.
+- Stamp every failure that reaches the top-level handler with a short **error reference** that also appears in
+  the server log entry, making "contact your administrator" actionable. (Requests rejected before the handler —
+  e.g. message-shape validation — already deliver correct protocol errors and carry no server-side stack trace
+  worth correlating, so they are deliberately unstamped.)
+- Stop advising "try again later" for failures classified as non-retryable.
+- Never leak raw internal detail (stack traces, endpoints, header contents) into user-facing text — only
+  `display_message` (user-safe by DIAL contract) and curated canned messages.
+- Deliver errors through the DIAL error protocol — a non-200 response with an OpenAI-style error body where
+  the response is not yet committed (non-streaming requests, failures before the choice opens), an SSE
+  `{"error": ...}` chunk otherwise — so clients render a true error state, steer the user to regenerate, and
+  keep the error text out of LLM-visible history.
+- Never emit a status code that DIAL Core's balancer treats as retriable (429/502/503/504) — for an
+  application, Core discards the response body for those and substitutes a generic error.
+
+---
+
+## Use Cases
+
+### UC-1: Upstream failure with a display message
+
+**Trigger:** The orchestrator LLM call fails with a 502 from DIAL Core; the propagated error body contains
+`display_message: "Daily token budget exhausted for this key."`.\
+**Behavior:** The resolver extracts the error body from the openai exception, finds `display_message`, and uses
+it as the user-facing text, suffixed with the error reference.\
+**Outcome:** The user sees the actual cause rendered as an error state (in DIAL Chat: a red error box)
+instead of "The AI model service encountered an internal error." presented as a normal reply — and the
+error text is not replayed to the LLM on the next turn.
+
+### UC-2: Mid-stream model failure
+
+**Trigger:** The model dies halfway through streaming a response; DIAL delivers an error chunk; the openai SDK
+raises a plain `APIError` with the DIAL error body attached.\
+**Behavior:** The resolver recognizes the body-carrying `APIError`, applies the same resolution order as for
+status errors (display message → code map → status map), and produces a specific message. When the body
+carries nothing usable (no display message, no known code, no usable status), the dedicated stream-failure
+rule applies (Component 2, rule 4).\
+**Outcome:** Instead of "Something went wrong with the execution of your request", the user sees the upstream
+cause — or, in the fully degraded case, "The AI model service failed while responding. Please try again
+later." — plus an error reference. The error is delivered as an SSE error chunk (Component 4): partial
+content already streamed stays visible, with the error state rendered beneath it.
+
+### UC-3: Context window exceeded
+
+**Trigger:** The conversation grows past the model's context limit; DIAL returns 400 with
+`code: "context_length_exceeded"` and the openai client raises `BadRequestError`.\
+**Behavior:** The code map matches before the status map and selects the existing context-length message.\
+**Outcome:** The user is told to shorten their messages — actionable — rather than "try again".
+
+### UC-4: Content policy rejection
+
+**Trigger:** The provider's content filter rejects the request; DIAL returns 400 with `code: "content_filter"`.\
+**Behavior:** The code map selects a dedicated content-policy message.\
+**Outcome:** The user understands the request was blocked by policy and that retrying verbatim will not help.
+
+### UC-5: Genuinely unknown failure
+
+**Trigger:** An unexpected exception (e.g. a bug in QuickApps itself) reaches the top-level handler.\
+**Behavior:** No error body exists; the resolver falls back to the generic message, now suffixed with the error
+reference. The handler logs the stack trace together with the same reference.\
+**Outcome:** The user's screenshot or copy-paste contains a token the administrator can grep in the logs.
+
+### UC-6: User recovers after a failed turn
+
+**Trigger:** Any of UC-1–UC-5 ended the turn with a protocol error; the user wants to continue.\
+**Behavior:** DIAL Chat stores the error in the message-level `errorMessage` field — which it excludes from
+subsequent request bodies — and switches the composer to "Regenerate response", which deletes the failed
+assistant message and resends the last user message.\
+**Outcome:** The retried request replays a clean history: no error sentences, no half-finished assistant
+turn. Today, by contrast, the error sentence is an ordinary assistant message that stays in history forever.
+
+---
+
+## Proposed Design
+
+The change is contained in the `core/application` layer: a new error-detail extraction step, a re-ordered
+resolution policy, and a structured result consumed by `_QuickAppCompletion.__handle_exception` — which now
+delivers the error through the DIAL error protocol instead of appending chat text.
+
+```mermaid
+flowchart LR
+    EX["Exception reaching the<br/>top-level handler"] --> EXTRACT["ErrorDetails extractor<br/>(normalize openai / aidial / httpx)"]
+    EXTRACT --> RESOLVE["Resolution policy"]
+    RESOLVE -->|1| DM["display_message<br/>(user-safe by contract)"]
+    RESOLVE -->|2| CODE["code map<br/>content_filter, context_length_exceeded, …"]
+    RESOLVE -->|3| STATUS["status / type map<br/>(existing canned messages)"]
+    RESOLVE -->|4| STREAM["stream-failure rule<br/>(mid-stream APIError, no usable body)"]
+    RESOLVE -->|5| FB["internal map / fallback"]
+    DM & CODE & STATUS & STREAM & FB --> RESULT["ResolvedError<br/>message + retryable + details"]
+    RESULT --> HANDLER["__handle_exception:<br/>log with ref,<br/>raise aidial_sdk HTTPException"]
+    HANDLER --> PRE["stream=false or choice not open:<br/>non-200 + JSON error body"]
+    HANDLER --> MID["streaming, choice open:<br/>SSE error chunk + DONE"]
+```
+
+### Component 1: `ErrorDetails` extractor
+
+**What:** A normalization step that converts any supported exception into a single value object:
+
+```python
+class ErrorDetails(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    status_code: int | None
+    code: str | None            # e.g. "content_filter", "context_length_exceeded"
+    error_type: str | None      # DIAL/OpenAI "type" field
+    message: str | None         # internal message — logged, never shown
+    display_message: str | None # user-safe by DIAL contract
+```
+
+**Owner:** `_exception_message_resolver` (private helper within the module).
+
+**Semantics:** One extraction function understands the four shapes an error reaches us in:
+
+| Source                                | Where the details live                                                      |
+|---------------------------------------|------------------------------------------------------------------------------|
+| `openai.APIStatusError` (4xx/5xx)      | `.status_code` from the exception; all other fields from the unwrapped body  |
+| plain `openai.APIError` (mid-stream)   | unwrapped body only (the SDK stores it pre-unwrapped); no status code        |
+| `aidial_sdk.exceptions.HTTPException`  | native attributes: `status_code`, `code`, `type`, `display_message`          |
+| `httpx.HTTPStatusError`                | `.response.status_code`; error JSON parsed best-effort from the response body |
+
+**Body unwrapping (openai shapes).** For both openai shapes, `code`, `error_type`, `message`, and
+`display_message` are read from `body.get("error", body)` — **never** from the exception's
+`.code`/`.type`/`.message` attributes. openai populates those attributes from the *top level* of the response
+body, while DIAL Core returns the OpenAI-compatible envelope `{"error": {code, message, type,
+display_message}}` with the fields nested one level down — so on the dominant 4xx path
+(`BadRequestError` etc.) the attributes are `None` and `.message` is openai's synthesized `"Error code: 400 -
+{…}"` wrapper. Mid-stream errors are the asymmetric case: the SDK already stores the unwrapped error object as
+`body`, for which `body.get("error", body)` is a no-op. This unwrap is what makes UC-3
+(`context_length_exceeded`) and UC-4 (`content_filter`) — both arriving as `BadRequestError` — actually reach
+the code map instead of regressing to the status ladder.
+
+Extraction is **best-effort and total**: malformed or absent bodies yield an `ErrorDetails` with `None` fields,
+never an exception. Bodies are only inspected, never mutated or re-serialized.
+
+Two further normalization rules smooth over DIAL conventions:
+
+- **Numeric-code backfill.** DIAL defaults `code` to the stringified status code (`str(status_code)`), so a
+  mid-stream error body frequently carries `code: "429"` with no HTTP status of its own. When `status_code` is
+  absent and `code` is a purely numeric string, the extractor backfills `status_code` from it (and leaves
+  `code` as-is). This lets mid-stream rate limits and 5xx-class stream errors resolve through the ordinary
+  status ladder.
+- **`error_type` never influences resolution.** It is carried for two pass-through consumers: the log record
+  written by Component 3, and the outgoing wire `type` field (Component 4), to which it is forwarded verbatim.
+
+**Change:** New. Today no branch of the resolver reads error bodies at all.
+
+### Component 2: Resolution policy
+
+**What:** `resolve_exception_message` is reworked to resolve in a fixed precedence order over `ErrorDetails`,
+returning a structured result instead of a bare string:
+
+```python
+class ResolvedError(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    message: str            # user-facing text, sanitized, retry suffix already composed
+    retryable: bool         # classification — logged by the handler; future telemetry dimension
+    details: ErrorDetails   # extracted internals, carried for the handler's log record only
+```
+
+**Owner:** `_exception_message_resolver.resolve_exception` (the string-returning
+`resolve_exception_message` is replaced; it has exactly one caller).
+
+**Semantics — precedence order:**
+
+1. **`display_message`**, when present. It is user-safe by DIAL contract, but it is still treated as untrusted
+   *text*: rendered as plain text (no markdown interpretation is assumed) and capped in length (~500 chars,
+   truncated with an ellipsis) so a misbehaving upstream cannot flood the chat.
+2. **Code map** — a small, curated dictionary keyed on error `code` **strings only** (statuses live in the
+   status map; numeric-string codes are backfilled into `status_code` by the extractor, see Component 1):
+
+   | Code                       | Message class                                             | Retryable |
+   |----------------------------|-----------------------------------------------------------|-----------|
+   | `content_filter`           | "blocked by the content management policy"                | no        |
+   | `context_length_exceeded`  | existing context-length message ("shorten your messages") | no        |
+   | `truncate_prompt_error`    | existing context-length message                           | no        |
+
+3. **Status / type map** — the existing canned-message ladders (AI-model wording for orchestrator-call
+   errors, service wording for httpx errors), with the holes closed (see Secondary Fixes) and one structural
+   change: each per-shape ladder returns **unresolved** (`None`) for an unmatched case instead of terminating
+   with the fallback string as today, so precedence continues to the rules below. Status matching keys on the
+   **normalized `ErrorDetails.status_code`** (i.e. post numeric-code backfill), not on exception attributes —
+   this is what lets a backfilled mid-stream 429/5xx resolve to the specific rate-limit/internal-error text
+   here rather than degrading to rule 4. The status-less *type* branches that exist today (`APITimeoutError`,
+   `APIConnectionError`) remain part of this rule and therefore resolve **before** rule 4 — they are never
+   misrouted to the stream-failure message.
+4. **Stream-failure rule** — a plain `openai.APIError` (mid-stream error) that was not resolved by rules
+   1–3 — whether because it carries no HTTP status even after the extractor's numeric-code backfill, or
+   because the backfilled status matched nothing in the status ladder — gets a new dedicated constant,
+   `_MSG_AI_MODEL_STREAM_FAILURE`: *"The AI model service failed while responding."* The rule is classified
+   retryable, so the composed text ends with the appended retry sentence (see Retryability mechanism below) —
+   exactly once. This is the terminal rule for the mid-stream path: no mid-stream error can reach the generic
+   fallback.
+5. **Internal exception map** — the existing `OrchestratorExceedMaxIterations` / toolset / initialization
+   branches, unchanged in structure.
+6. **Fallback** — the existing generic message.
+
+**Retryability mechanism.** Message constants are reworked along a simple split: **retryable-classified
+constants carry the cause only** — their advice *is* the appended retry sentence — while **non-retryable
+constants carry cause + cause-specific advice** (e.g. "…contact your administrator", "…shorten your
+messages"). No constant carries the retry phrase itself, so the append mechanism can never stack a retry
+sentence on top of conflicting advice. The resolver composes the final `message`: when the resolution is
+classified retryable (timeouts, `httpx.NetworkError` transport blips, 429s, 409 conflicts, and 5xx or stream
+failures *without* a more specific code), it appends the standard sentence "Please try again later." —
+exactly once. **`APIConnectionError` on the orchestrator path is classified non-retryable**: by the time it
+surfaces, the openai client has already retried it, so it overwhelmingly indicates deterministic
+misconfiguration (wrong endpoint, DNS, TLS). Consistent with the "false hope for deterministic failures"
+critique in Problem Statement item 1, `_MSG_SERVICE_NO_CONNECTIVITY` keeps its admin-escalation advice
+("…check connectivity or contact your administrator") instead of gaining the retry sentence. Raw
+`httpx.NetworkError` from service calls gets no such client-level retry, so it stays retryable (cause-only
+constant + appended sentence). Rules 5 and 6 are classified **non-retryable**: an internal invariant violation
+or unknown bug will not be fixed by retrying, so the fallback becomes "Something went wrong with the
+execution of your request. Please contact your administrator." `ResolvedError.retryable` therefore has no further effect
+on the text in the handler — it is exposed so Component 3 can include it in the log record, and as the
+natural dimension for future telemetry (Out of Scope). **`display_message` resolutions are terminal and never
+retry-suffixed**: the upstream authored the complete user-facing text, and appending generic advice can
+contradict it (e.g. a "daily budget exhausted" explanation followed by "try again later"). They are still
+*classified* for the log record — `retryable` is derived from the underlying `ErrorDetails` status/code with
+the same rules as above, defaulting to `False` when neither is available — but the text is used as-is (after
+the plain-text/length sanitization of rule 1).
+
+**Trade-off — trusting `display_message`:** the field is defined by the DIAL SDK as the user-displayable
+message, and every hop in a DIAL chain is DIAL-operated infrastructure, so we honor it. The mitigations
+(plain-text rendering, length cap) bound the damage of a buggy upstream. The alternative — ignoring it, as
+today — is exactly the problem this design removes.
+
+**Change:** the string-returning `resolve_exception_message` is replaced by `resolve_exception` returning
+`ResolvedError`; the per-shape ladders switch from terminate-with-fallback to return-unresolved; all message
+constants are reworded per the retryability split.
+
+### Component 3: Error reference correlation
+
+**What:** Every handled exception gets a short opaque reference (8 hex chars derived from a random UUID) that
+appears in **both** the log record and the user-facing message.
+
+**Owner:** `_QuickAppCompletion.__handle_exception` — generation and logging stay with the component that owns
+the log call, keeping the resolver pure.
+
+**Semantics:**
+
+- The handler generates the reference and logs one `logger.exception` record containing: the reference, the
+  exception (with stack trace), the extracted `ErrorDetails` internals (`message`, `code`, `error_type`,
+  `status_code` — reached via `ResolvedError.details`), and `ResolvedError.retryable`. Internal detail
+  belongs in logs.
+- The user-facing text — carried in the outgoing `display_message` (Component 4) — is rendered as:
+  `<resolved message> (error reference: <ref>)` — e.g. "Daily token budget exhausted for this key. (error
+  reference: `a1b2c3d4`)", matching the Usage-table examples.
+- The reference is a correlation token only — it carries no encoded meaning and is not persisted anywhere
+  besides the log stream and the error text shown to the user.
+
+**Change:** `__handle_exception` grows from two lines to: generate ref → resolve → log with ref → raise
+(Component 4).
+
+### Component 4: Error delivery via the DIAL error protocol
+
+**What:** `_QuickAppCompletion.__handle_exception` no longer appends the resolved message to the choice as
+assistant content. It logs (Component 3) and then **raises an `aidial_sdk.exceptions.HTTPException`** built
+from `ResolvedError`, letting the SDK deliver it through the DIAL error protocol.
+
+**Owner:** `_quick_app_completion.py` builds the exception; the aidial-sdk owns the wire format.
+
+**Field mapping:**
+
+| `HTTPException` field | Populated with |
+|-----------------------|----------------|
+| `display_message`     | the composed user-facing text + error reference — **always set** (see client behavior below) |
+| `message`             | identical to `display_message` (including the error reference); internal detail stays in server logs only, retrievable via the reference |
+| `code` / `type`       | propagated from `ErrorDetails` when present (e.g. `content_filter`, or DIAL's numeric-string `"429"`, which the backfill rule leaves as-is) |
+| `status_code`         | per the outgoing-status policy below |
+
+**SDK delivery (verified against the installed aidial-sdk):** the SDK picks the wire shape by position in
+the chunk stream: a DIAL exception in the *first* position becomes a non-200 JSON response carrying
+`json_error()`; any later position becomes an SSE `{"error": ...}` chunk followed by `[DONE]`
+(`aidial_sdk.utils.streaming.to_streaming_response`). For non-streaming (`stream=false`) requests the SDK
+raises the FastAPI error — a non-200 — wherever the exception occurred. One consequence must be stated
+honestly: `create_single_choice()` enqueues the choice-open chunk on entry (`Choice.__enter__` → `open()`),
+so for **streaming requests every failure inside the choice context — even before any visible content —
+delivers as the mid-stream shape (HTTP 200 + SSE error chunk)**. The clean non-200 shape therefore applies
+to non-streaming requests and to exceptions raised before the choice opens (e.g. message-shape validation).
+This is acceptable: DIAL Chat treats both shapes identically for every property this design needs (error
+state, exclusion from history, regenerate steering); the toast + trace id is a non-200-shape extra. Both
+shapes carry `display_message`. A non-DIAL exception escaping `chat_completion` would be wrapped by the SDK
+into a generic 500 `RuntimeServerError`; the handler always raises a fully-populated DIAL exception, so that
+path stays a safety net rather than a delivery route.
+
+**Control-flow restructuring in `chat_completion`:** today the method's `finally` block unconditionally
+creates the "Execution time" stage (when `show_execution_time_stage` is enabled) after `__handle_exception`
+runs. With a raising handler this would append a spurious stage *after* the resolved error. **Change:** the
+`except` clause sets a failure flag that the `finally` consults — the execution-time stage is created only
+when the flag is unset; the perf-timer stop and debug report in the same `finally` are kept. The raise thus
+leaves the error chunk as the last meaningful event of the stream.
+
+**Outgoing-status policy:** the app must never respond with **429, 502, 503, or 504**. DIAL Core treats
+these as retriable; an application has a single synthetic upstream with a retry budget of one, so Core
+cannot retry — it instead **discards the app's error body** and substitutes a generic `502`/`503` with no
+analytics record (verified in DIAL Core's `DeploymentPostController` / `TieredBalancer`). Therefore:
+client-attributable causes keep their natural non-retriable 4xx (400/401/403/404/413/422); everything else —
+upstream 429/5xx, stream failures, timeouts, unknown internal errors — is emitted as **500**, with the true
+cause preserved in `code` and the user-facing explanation in `display_message`. Core passes non-retriable
+statuses and bodies through to the caller verbatim, and its analytics log records the true status for the
+shapes that reach it as non-200 (non-streaming requests, pre-choice failures). Streaming-request failures
+are necessarily logged by Core as 200 — the error chunk is still present in the logged response body — so
+full operator visibility additionally rests on the app's own log record keyed by the error reference
+(Component 3). This is still a strict improvement over today, where the failure is indistinguishable from a
+successful answer in *both* places (Problem Statement item 6). One consequence for consumers: the emitted
+`code` may not correspond to the emitted `status_code` — a `500` can carry `code: "429"` — because the
+status is deliberately downgraded to dodge Core's balancer. `code` carries the true cause; `status_code` is
+the transport classification.
+
+**Client behavior (verified against the DIAL Chat sources):** DIAL Chat maps both error shapes onto the
+message-level `errorMessage` field: the user gets a red error box (plus a toast with a trace id on the
+non-200 shape), partial content and attachments already streamed remain visible, and the composer switches
+to "Regenerate response". Critically, `errorMessage` is **excluded from subsequent request bodies** and the
+failed message is deleted on regenerate — the error text never enters LLM-visible history. On the mid-stream
+path DIAL Chat surfaces **only** `display_message` (the `message` field is dropped there), which is why the
+field mapping above always sets it.
+
+**Stage hygiene:** DIAL Chat renders a stage that was opened but never closed as a perpetual spinner, and its
+error path does not auto-close stages, so every stage must be closed — with the right status — before the
+exception propagates. Streaming stages are already covered: `ChatCompletionStreamHandler` closes them as
+failed on error. Deferred stages are not: `DeferredStageCloseRegistry.flush()` takes no arguments and always
+closes wrappers via a success-shaped `__exit__(None, None, None)`, and `Orchestrator._persisting_state`
+calls it from a `finally` that runs on both the success and error paths. **Change:** `flush()` gains an
+optional failure flag (default success, so the success path is untouched); `_persisting_state` passes the
+failure flag exactly when it holds an exception to re-raise, and the registry then closes still-open
+wrappers with failure exc-info so the stages render as failed. Owner: `DeferredStageCloseRegistry`
+(`common/stage_close_registry.py`) for the interface, `Orchestrator._persisting_state` for the call site.
+
+**State:** `Orchestrator._persisting_state` still persists choice state before re-raising, but a regenerate
+in DIAL Chat deletes the failed message together with that state — the retried request starts from the last
+successful turn. This is the desired outcome: a failed turn leaves no trace in either history or state.
+
+**Change:** `__handle_exception` raises instead of appending; the exception escapes `chat_completion` into
+the SDK. The deferred-stage flush on the error path closes stages as `failed`.
+
+---
+
+## Secondary Fixes
+
+Small corrections that fall out of reviewing the same code paths:
+
+- **httpx 401** — currently resolves to "An unexpected HTTP error occurred"; add a service-context
+  authentication constant (`_MSG_SERVICE_AUTH_FAILED`) for it — the httpx ladder is the *service* wording
+  family, so reusing the AI-model auth message would mislabel the failing component.
+- **aidial plain 400** — the status ladder in `_resolve_aidial_error` skips 400 (only the `InvalidRequestError`
+  *type* is matched); add it to the invalid-request branch.
+- **openai 409 / 413** — currently fall to the fallback; map 409 to retryable service-conflict wording, and
+  413 (*Payload Too Large* — request byte size, distinct from token-context overflow) to dedicated size
+  wording: "The request payload is too large. Please reduce the size of your message or attachments."
+- **Toolset identity in messages** — `ToolsetNotFoundException` / `ToolsetForbiddenException` carry a
+  `toolset_id` that the resolver currently drops; include it in the message (it is configuration identity, not
+  sensitive detail).
+- **Redundant exception tuple** — `except (BadRequestError, APIError)` in `AssistantInvoker.invoke` and
+  `Orchestrator.__invoke_and_accumulate_stream_with_recovery` — `BadRequestError` is a subclass of `APIError`;
+  reduce to `except APIError` for clarity (no behavior change).
+- **Misleading comment** — the subclass-ordering comment in `_resolve_httpx_error` describes a relationship
+  that does not exist; fix alongside the refactor.
+
+---
+
+## Out of Scope
+
+- **DIAL Chat's stuck-spinner asymmetry.** Chat strips still-open stages on manual stop but not on the error
+  path, so an unclosed stage renders as a perpetual spinner. The app-side mitigation (closing stages as
+  `failed` before raising, Component 4) is in scope; a client-side fix belongs to the ai-dial-chat repo.
+- **The initialization-issues flow.** `ConfigResolutionException` (and skip-and-record tool/toolset init
+  failures) bypass `__handle_exception`: `_InitializationErrorHandler` deliberately renders detailed
+  diagnostics into the chat over HTTP 200 for the app-builder persona fixing their manifest. That flow shares
+  the history-pollution caveat of Problem Statement item 6, but changing it is a separate UX decision — its
+  audience *wants* rich in-chat diagnostics — and is deferred to its own pass.
+- **Recovering LLM-fixable tool-call failures** (malformed JSON arguments in `ToolExecutor.execute`,
+  hallucinated tool names) by feeding an error tool-message back to the model instead of aborting the turn.
+  This is a change to orchestrator-loop semantics, not message resolution; the existing
+  `InvalidToolCallParameterException` fallback pattern is the natural home, and it should be designed with
+  retry-budget considerations.
+- **Message catalog / i18n / per-deployment customization** of the canned texts. The refactor concentrates all
+  strings in one module, which is the prerequisite; externalizing them is deferred until a real localization or
+  white-labeling need appears.
+- **Automatic retry policy changes.** The openai client's built-in retries (2, exponential backoff) are kept
+  as-is; adding orchestrator-level retry loops risks doubling latency on deterministic failures.
+- **Error-class metrics/telemetry.** The `ResolvedError` classification would be a natural metrics dimension;
+  wiring it into monitoring is left to the observability backlog.
+
+---
+
+## Configuration / Usage Examples
+
+How an error reaches the user (verified behavior of DIAL Core and DIAL Chat):
+
+| Failure point | Wire format | DIAL Chat behavior |
+|---------------|-------------|--------------------|
+| Non-streaming request, or failure before the choice opens | non-200 + OpenAI-style JSON error body, passed through Core verbatim | red error box + toast with trace id; composer switches to "Regenerate response" |
+| Streaming request, failure after the choice opens (with or without prior content) | SSE `{"error": ...}` chunk + `[DONE]` in the open 200 stream, forwarded by Core uninterpreted | partial content/attachments stay visible; red error box beneath; regenerate; no toast |
+
+In both cases the error text lands in the message-level `errorMessage` field, which DIAL Chat excludes from
+subsequent requests — the "After" texts below never re-enter the LLM context.
+
+Before/after examples of the text the user sees (today: appended as a normal assistant reply; after:
+rendered in the error state):
+
+| Scenario | Today | After |
+|----------|-------|-------|
+| Upstream 502 with `display_message: "Daily token budget exhausted for this key."` | The AI model service encountered an internal error. Please try again later. | Daily token budget exhausted for this key. (error reference: `a1b2c3d4`) |
+| Mid-stream model crash, error body without display message or usable code/status | Something went wrong with the execution of your request. Please try again or contact your administrator. | The AI model service failed while responding. Please try again later. (error reference: `a1b2c3d4`) |
+| 400 `context_length_exceeded` from the model | The request was rejected by the AI model service. Please try again or contact your administrator. | The request exceeds the maximum context length of the AI model. Please shorten your messages and try again. (error reference: `a1b2c3d4`) |
+| 400 `content_filter` | The request was rejected by the AI model service. Please try again or contact your administrator. | The request was blocked by the content management policy. Please rephrase your message. (error reference: `a1b2c3d4`) |
+| Unknown internal bug | Something went wrong with the execution of your request. Please try again or contact your administrator. | Something went wrong with the execution of your request. Please contact your administrator. (error reference: `a1b2c3d4`) |
+
+Administrator workflow: user reports the reference → `grep a1b2c3d4` over application logs → full stack trace
+and internal error message at the matching record.
+
+---
+
+## Migration
+
+### Breaking changes
+
+- **Failures change wire shape.** Today every failure is an HTTP 200 completion whose content is an error
+  sentence; after this design, failures surface as protocol errors — a non-200 JSON error body (non-streaming
+  requests and failures before the choice opens), or an SSE `{"error": ...}` chunk in the 200 stream
+  (streaming requests). This is the standard OpenAI-compatible contract and DIAL Chat handles it natively,
+  but API consumers that treated QuickApps failures as successful completions must start handling error
+  responses and in-stream error chunks.
+- **Failed turns no longer produce assistant messages.** The error sentence no longer becomes part of
+  conversation history (in DIAL Chat it lives in `errorMessage`, stripped from subsequent requests). Any
+  workflow that read error text back out of the conversation must consume the error response instead.
+- User-visible error **texts change** (that is the point): deployments that pattern-match on the exact canned
+  sentences (e.g. alerting on chat transcripts) should switch to the error `code` — it carries the true cause;
+  the HTTP status is the transport classification and may be deliberately downgraded (see the outgoing-status
+  policy, e.g. a `500` carrying `code: "429"`).
+
+### Non-breaking changes
+
+- All resolution changes are internal to `core/application`; no config schema, no env vars, no DI wiring
+  changes outside the module.
+- Unit tests for the resolver (`test_exception_message_resolver.py`) are extended for the new precedence
+  order, body extraction, and the no-leak guarantee (the existing `test_no_internal_detail_leaked` contract is
+  kept and extended to the wire format: the outgoing `message` mirrors the sanitized text, so raw internal
+  detail, stack traces, and URLs never leave the process — only via server logs keyed by the error reference).
+
+## Summary of Changes
+
+**`core/application/_exception_message_resolver.py`**
+
+- Added: `ErrorDetails` value object + best-effort extractor over openai / aidial / httpx error shapes,
+  including numeric-code → status backfill.
+- Added: code map (`content_filter`, `context_length_exceeded`, `truncate_prompt_error`).
+- Added: `_MSG_AI_MODEL_STREAM_FAILURE` constant — terminal rule for mid-stream `APIError` with no usable body.
+- Added: `ResolvedError` (message + retryable + details) returned by the new `resolve_exception`;
+  string-returning `resolve_exception_message` removed (single caller).
+- Changed: resolution precedence — display message → code map → status/type map → stream-failure rule →
+  internal map → fallback; per-shape ladders return unresolved (`None`) on a miss instead of terminating with
+  the fallback string.
+- Changed: all message constants (including `_FALLBACK_MESSAGE` and the internal-map messages) reworked —
+  retryable-classified constants to cause-only, non-retryable to cause + specific advice, none carrying the
+  retry phrase; the retry sentence is appended by the resolver exactly once for retryable classifications;
+  internal-map and fallback resolutions are non-retryable; `display_message` resolutions are terminal and
+  never retry-suffixed.
+- Changed: plain `openai.APIError` (mid-stream) resolved via its body instead of falling to the fallback.
+- Fixed: httpx 401 (new `_MSG_SERVICE_AUTH_FAILED` service-context constant), aidial 400, openai 409/413
+  mappings; toolset id included in toolset messages; misleading subclass comment.
+
+**`core/application/_quick_app_completion.py`**
+
+- Changed: `__handle_exception` generates an error reference, logs it with the stack trace and internal error
+  detail, and **raises `aidial_sdk.exceptions.HTTPException`** — `display_message` = `<message> (error
+  reference: <ref>)`, sanitized `message`, propagated `code`/`type`, non-retriable `status_code` per the
+  outgoing-status policy — instead of appending text to the choice. The SDK renders it as a non-200 response
+  (non-streaming requests, pre-choice failures) or an SSE error chunk (streaming requests).
+- Changed: the "Execution time" stage in `chat_completion`'s `finally` is skipped when an exception is in
+  flight, so no spurious stage trails the error.
+
+**`common/stage_close_registry.py`, `core/agent/orchestrator.py`**
+
+- Changed: `DeferredStageCloseRegistry.flush()` gains an optional failure flag; `_persisting_state` passes it
+  on the error path so still-open deferred stages close as `failed` (success path unchanged).
+
+**`core/agent/assistant_invoker.py`, `core/agent/orchestrator.py`**
+
+- Cleanup: redundant `(BadRequestError, APIError)` tuples reduced to `APIError` (no behavior change).
+
+**Tests**
+
+- Extended: resolver unit tests for extraction, precedence, retryability, and leak guarantees; completion
+  handler test for reference formatting.

--- a/docs/error_handling.md
+++ b/docs/error_handling.md
@@ -1,0 +1,154 @@
+# Error Handling
+
+This document explains what happens when a Quick Apps request fails: how the cause of a failure is
+identified, how it is translated into a safe and actionable message, how it is correlated with server logs,
+and how it reaches the user. For the design rationale and the platform contracts behind these choices, see
+[`designs/error_message_resolution.md`](designs/error_message_resolution.md).
+
+## The Three Error Surfaces
+
+Quick Apps surfaces failures in three distinct ways, each aimed at a different audience:
+
+| Surface | When it applies | What the user sees | Documented in |
+|---|---|---|---|
+| **Request failure** | Something aborts the whole turn — the AI model call fails, a required service is unavailable, or the app hits an internal error | A true error state: an explanation of the cause plus an error reference, rendered by the client as an error rather than as a chat reply | This document |
+| **Initialization issues** | Some tools or skills fail to load, but the request can still proceed without them | A diagnostic *Initialization issues* stage above a normal, successful answer — aimed at the app builder fixing their manifest | [Agent Design §6](agent.md#6-error-handling) |
+| **Tool-execution fallbacks** | A single tool call fails mid-conversation and the tool's configured fallback strategy decides what happens next | Usually nothing directly — the agent is instructed to recover, retry, or explain the failure in its own words | [Agent Design — Tool System](agent.md#error-handling) |
+
+The rest of this document covers the first surface.
+
+## What Happens When a Request Fails
+
+Every failure that aborts a turn goes through the same four steps:
+
+```mermaid
+flowchart LR
+    EX["Failure occurs"] --> EXTRACT["1. Understand<br/>the cause"]
+    EXTRACT --> RESOLVE["2. Choose the<br/>user-facing message"]
+    RESOLVE --> REF["3. Stamp an error reference<br/>and log the details"]
+    REF --> DELIVER["4. Deliver as a<br/>protocol error"]
+```
+
+## 1. Understanding the Cause
+
+Failures reach Quick Apps from several directions — the AI model call routed through DIAL Core, direct calls
+to platform services, or the app's own logic — and each direction reports errors in a slightly different
+shape. The first step normalizes them all into one common picture built from the fields the DIAL error
+protocol defines:
+
+| Field | Meaning |
+|---|---|
+| **status** | The HTTP status class of the failure, when one exists |
+| **code** | A machine-readable cause, e.g. `content_filter` or `context_length_exceeded` |
+| **type** | The protocol's error category; carried through but never used to pick a message |
+| **message** | The internal explanation — logged, never shown to the user |
+| **display message** | Text the failing component authored *specifically for end users* |
+
+Normalization is best-effort: a failure that carries no usable details (or a malformed payload) simply yields
+an empty picture and falls through to the generic rules below — diagnosing an error can never itself fail.
+
+One DIAL convention deserves a note: when a model fails *mid-stream* (after it has already started answering),
+the error arrives without an HTTP status of its own, but usually carries the original status inside its
+`code` field (e.g. `"429"`). Quick Apps recognizes this and treats such failures as if they had the real
+status, so a mid-stream rate limit gets the same precise message as an up-front one.
+
+## 2. Choosing the User-Facing Message
+
+The message is selected by a fixed precedence — the most specific and trustworthy information available wins:
+
+1. **The upstream's own display message.** If the failing component authored user-facing text, it is shown
+   verbatim (capped in length, and skipped if it turns out to be empty). Nothing is appended to it — generic
+   advice could contradict a precise upstream explanation.
+2. **Known error codes.** A curated set of causes gets tailored, actionable advice: content-policy
+   rejections ("please rephrase your message"), context-window overflows ("please shorten your messages").
+3. **Status-class messages.** Failing that, the status determines a canned message, worded for the failing
+   component: *AI model* wording when the model call failed, *service* wording when a platform service did.
+   Authentication, permission, not-found, payload-size, rate-limit, timeout, and connectivity causes each
+   have their own text.
+4. **Stream failures.** A mid-stream model failure that none of the above could explain is reported as "the
+   AI model service failed while responding" — never as a generic mystery.
+5. **Known internal conditions.** Failures originating inside Quick Apps itself (iteration limit reached,
+   a configured toolset missing or inaccessible) have their own messages.
+6. **The generic fallback.** Only a genuinely unknown failure ends with "Something went wrong with the
+   execution of your request. Please contact your administrator."
+
+### Retryability
+
+Every resolved failure is also classified as retryable or not, and the advice matches the classification:
+transient causes (rate limits, timeouts, upstream outages, network blips) end with "Please try again later.",
+while deterministic causes carry advice that can actually help — contact an administrator, shorten the
+conversation, rephrase the message. Notably, a *connection* failure to the model service is treated as
+deterministic: by the time the user sees it, the platform has already retried it, so "try again later" would
+be false hope. The classification is also recorded in the log entry for operators.
+
+## 3. Error-Reference Correlation
+
+"Contact your administrator" is only useful if the administrator can find the failure. Every request failure
+is therefore stamped with a short opaque reference that appears in **both** places:
+
+- **In the user-facing text** — `<message> (error reference: a1b2c3d4)`.
+- **In a single server log record** — together with the full stack trace, the internal error details, and
+  the retryability classification.
+
+The workflow: the user reports the reference (a screenshot or copy-paste suffices) → the administrator greps
+the application logs for it → the matching record has everything needed to diagnose the failure. Internal
+detail lives *only* in the logs; user-facing text is limited to upstream display messages (user-safe by DIAL
+contract) and Quick Apps' own curated wording.
+
+## 4. Delivery as a Protocol Error
+
+Failures are delivered through the **DIAL error protocol**, not as chat text. This distinction matters more
+than it may seem:
+
+- The client renders a **true error state** (in DIAL Chat: a red error box) instead of presenting the
+  failure as a normal assistant reply.
+- The error text is **kept out of conversation history** — it is never replayed to the LLM on later turns.
+- The client steers the user toward **regenerating** the failed turn, which replays a clean history.
+- Any partial answer streamed before the failure **stays visible**, with the error shown beneath it.
+- Monitoring sees a failure instead of a fake success.
+
+The wire shape depends on how far the response had progressed:
+
+| Failure point | Wire format |
+|---|---|
+| Before the response stream opens (e.g. request validation), or on a non-streaming request | A non-200 response with a standard OpenAI-style error body |
+| After the response stream opens — which in practice is every failure of an accepted streaming request | An error chunk inside the already-open stream, as the stream's final meaningful event |
+
+Both shapes carry the same fields, and DIAL Chat treats them the same way for everything described above.
+
+### Outgoing-status policy
+
+Quick Apps never responds with a status that DIAL Core's load balancer treats as retriable (429, 502, 503,
+504) — for an application Core cannot retry, so it would discard the explanation and substitute a generic
+error. Instead:
+
+- Failures attributable to the request itself keep their natural client status (bad request, authentication,
+  permission, not-found, payload-too-large, validation).
+- Everything else — upstream rate limits and outages, stream failures, timeouts, unknown internal errors —
+  is reported as a plain internal error (500).
+
+The true cause is preserved in the error's `code` field, so a 500 may legitimately carry `code: "429"`:
+the code says *what happened*, the status says *how to route it*. API consumers should classify by code,
+not status. Similarly, when the upstream supplied no `type`, Quick Apps fills in the protocol-conventional
+one for the outgoing status: `invalid_request_error` for client statuses, `runtime_error` otherwise.
+
+### Leaving the conversation tidy
+
+An aborted turn must not leave visual debris behind. Before the error is delivered:
+
+- Any still-open progress stages are closed in a **failed** state — otherwise the client would show them as
+  perpetually running.
+- Bookkeeping stages that decorate successful answers (such as the execution-time report) are suppressed, so
+  the error is the last thing the user sees.
+
+## Testing Error Handling End-to-End
+
+The repository ships an **error-injection sample model**
+([`src/tests/sample_apps/error_injection_app/`](../src/tests/sample_apps/error_injection_app/README.md))
+that deterministically reproduces every failure mode described above — upstream errors with and without
+display messages, content-filter and context-length rejections, mid-stream failures after partial content,
+unknown internal errors, and slow responses.
+
+Run it with `make run_error_injection_app`; the local docker-compose configuration registers it as the
+`error-injection-model` deployment and wires an *Error Handling Tester* Quick App with one conversation
+starter per scenario, so each failure mode can be triggered with a single click in DIAL Chat.

--- a/src/quickapp/common/stage_close_registry.py
+++ b/src/quickapp/common/stage_close_registry.py
@@ -66,7 +66,19 @@ class DeferredStageCloseRegistry:
                 _stage_hook_from_tool_message(wrapper, tool_msg),
             )
 
-    def flush(self) -> None:
+    def flush(self, *, failed: bool = False) -> None:
+        """Run pending UI hooks and close every deferred stage wrapper.
+
+        On the error path (``failed=True``) wrappers are closed with failure exc-info so
+        their stages render as ``FAILED``; DIAL Chat otherwise shows a stage that was
+        opened but never closed as a perpetual spinner. The success path is unchanged.
+        """
+        exit_args: tuple[type[BaseException] | None, BaseException | None, None] = (
+            (RuntimeError, RuntimeError("Request failed before the stage completed."), None)
+            if failed
+            else (None, None, None)
+        )
+
         keyed_by_wrapper_id: dict[int, list[tuple[str, Callable[[], None]]]] = {}
         for tcid, (wrapper, fn) in self._deferred_ui_by_tool_call_id.items():
             keyed_by_wrapper_id.setdefault(id(wrapper), []).append((tcid, fn))
@@ -86,7 +98,7 @@ class DeferredStageCloseRegistry:
                 except Exception:
                     logger.exception("Failed while applying deferred stage UI before close")
             try:
-                wrapper.__exit__(None, None, None)
+                wrapper.__exit__(*exit_args)
             except Exception:
                 logger.exception("Failed while closing deferred stage wrapper")
         self._pending.clear()
@@ -121,5 +133,8 @@ class ImmediateStageCloseRegistry:
         except Exception:
             logger.exception("Failed while closing deferred stage wrapper")
 
-    def flush(self) -> None:
+    def flush(self, *, failed: bool = False) -> None:
+        # No-op: this registry closes stages eagerly in defer_close, so there is nothing
+        # to flush. The `failed` flag exists only for signature parity with the deferred
+        # registry (the two are used interchangeably via a union type).
         pass

--- a/src/quickapp/core/agent/assistant_invoker.py
+++ b/src/quickapp/core/agent/assistant_invoker.py
@@ -1,6 +1,6 @@
 from aidial_sdk.chat_completion.request import Message
 from injector import inject
-from openai import APIError, AsyncStream, BadRequestError
+from openai import APIError, AsyncStream
 from openai.types.chat import ChatCompletionChunk
 
 from quickapp.common import ORCHESTRATOR_AZURE_CLIENT
@@ -29,12 +29,12 @@ class AssistantInvoker:
         self.__chat_completion_recovery = chat_completion_recovery
 
     async def invoke(self) -> AsyncStream[ChatCompletionChunk]:
-        """Create chat completion; on APIError/BadRequest, run message recovery once and retry."""
+        """Create chat completion; on APIError, run message recovery once and retry."""
         while True:
             completion_config = self.__chat_completion_config_builder.build(self.__messages)
             try:
                 return await self.__azure_client.chat.completions.create(**completion_config)
-            except (BadRequestError, APIError) as e:
+            except APIError as e:
                 self.__chat_completion_recovery.apply_message_recovery(
                     e, retry_scope=CHAT_COMPLETION_CREATE_RETRY_SCOPE
                 )

--- a/src/quickapp/core/agent/orchestrator.py
+++ b/src/quickapp/core/agent/orchestrator.py
@@ -5,7 +5,7 @@ from contextlib import asynccontextmanager
 from aidial_sdk.chat_completion import Choice
 from aidial_sdk.chat_completion.request import CustomContent, Message, Role
 from injector import ProviderOf, inject
-from openai import APIError, AsyncStream, BadRequestError
+from openai import APIError, AsyncStream
 from openai.types.chat import ChatCompletionChunk
 
 from quickapp.common import EXTERNAL_TOOL_NAMES, DeploymentUsage
@@ -95,7 +95,7 @@ class Orchestrator:
             exc_to_reraise = exc
             logger.warning("Orchestrator interrupted by %s, saving state before re-raising", exc)
         finally:
-            self.__deferred_stage_close_registry.flush()
+            self.__deferred_stage_close_registry.flush(failed=exc_to_reraise is not None)
             # Close any per-request async resources (e.g. live MCP sessions) held open
             # for the duration of the request. Runs on both success and error paths.
             await self.__request_async_close_registry.aclose_all()
@@ -224,13 +224,13 @@ class Orchestrator:
         self.__deferred_stage_close_registry.flush()
 
     async def __invoke_and_accumulate_stream_with_recovery(self) -> ChatStreamAccumulator:
-        """Invoke assistant and consume stream; on APIError/BadRequest during stream, run recovery once."""
+        """Invoke assistant and consume stream; on APIError during stream, run recovery once."""
         while True:
             assistant_invoker = self.__assistant_invoker_provider.get()
             chat_completion_stream = await assistant_invoker.invoke()
             try:
                 return await self.accumulate_stream(chat_completion_stream)
-            except (BadRequestError, APIError) as e:
+            except APIError as e:
                 self.__chat_completion_recovery.apply_message_recovery(
                     e, retry_scope=STREAM_ACCUMULATION_RETRY_SCOPE
                 )

--- a/src/quickapp/core/application/_exception_message_resolver.py
+++ b/src/quickapp/core/application/_exception_message_resolver.py
@@ -336,13 +336,16 @@ def resolve_exception(e: Exception) -> ResolvedError:
     details = _extract_error_details(e)
 
     # 1. Upstream-authored, user-safe text wins. Used as-is (never retry-suffixed), since
-    #    appending generic advice can contradict a precise upstream explanation.
+    #    appending generic advice can contradict a precise upstream explanation. A message
+    #    that sanitizes to nothing (whitespace-only) falls through to the rules below.
     if details.display_message:
-        return ResolvedError(
-            message=_sanitize_display_message(details.display_message),
-            retryable=_is_retryable_from_details(details),
-            details=details,
-        )
+        display_message = _sanitize_display_message(details.display_message)
+        if display_message:
+            return ResolvedError(
+                message=display_message,
+                retryable=_is_retryable_from_details(details),
+                details=details,
+            )
 
     # 2. Specific, actionable error codes.
     resolution = _resolve_by_code(details)

--- a/src/quickapp/core/application/_exception_message_resolver.py
+++ b/src/quickapp/core/application/_exception_message_resolver.py
@@ -1,8 +1,10 @@
+import logging
+from typing import Any
+
 import httpx
 import openai
-from aidial_sdk.exceptions import ContextLengthExceededError, DeploymentNotFoundError
 from aidial_sdk.exceptions import HTTPException as AiDialHTTPException
-from aidial_sdk.exceptions import InvalidRequestError, RequestValidationError, ResourceNotFoundError
+from pydantic import BaseModel, ConfigDict
 
 from quickapp.common.exceptions import (
     OrchestratorExceedMaxIterationsException,
@@ -13,12 +15,30 @@ from quickapp.dial_core_services.exceptions import (
     ToolsetNotFoundException,
 )
 
+logger = logging.getLogger(__name__)
+
+# Appended by the resolver to any retryable-classified message — and only those. No
+# message constant carries it, so it is never stacked on top of conflicting advice.
+_RETRY_SENTENCE = "Please try again later."
+
+# display_message is user-safe by DIAL contract but still untrusted text: capped so a
+# misbehaving upstream cannot flood the chat.
+_DISPLAY_MESSAGE_MAX_LEN = 500
+
+
 _FALLBACK_MESSAGE = (
-    "Something went wrong with the execution of your request. "
-    "Please try again or contact your administrator."
+    "Something went wrong with the execution of your request. Please contact your administrator."
 )
 
+# --- AI-model wording (orchestrator LLM call) ---
+# Retryable-classified constants carry the cause only; the retry sentence is appended.
+_MSG_AI_MODEL_RATE_LIMITED = "The request was rate-limited by the AI model service."
+_MSG_AI_MODEL_INTERNAL_ERROR = "The AI model service encountered an internal error."
+_MSG_AI_MODEL_TIMEOUT = "The request to the AI model service timed out."
+_MSG_AI_MODEL_STREAM_FAILURE = "The AI model service failed while responding."
+_MSG_AI_MODEL_CONFLICT = "The AI model service reported a temporary conflict."
 
+# Non-retryable constants carry the cause plus cause-specific advice.
 _MSG_AI_MODEL_NO_PERMISSION = (
     "You don't have permission to use the AI model configured in this application. "
     "Please contact your administrator."
@@ -30,131 +50,319 @@ _MSG_AI_MODEL_NOT_FOUND = (
     "The AI model configured in this application could not be found. "
     "Please contact your administrator."
 )
-_MSG_AI_MODEL_RATE_LIMITED = (
-    "The request was rate-limited by the AI model service. Please try again later."
-)
 _MSG_AI_MODEL_INVALID_REQUEST = (
     "The request was rejected as invalid by the AI model service. "
-    "Please try again or contact your administrator."
+    "Please contact your administrator."
 )
-_MSG_AI_MODEL_INTERNAL_ERROR = (
-    "The AI model service encountered an internal error. Please try again later."
+_MSG_AI_MODEL_CONTENT_FILTER = (
+    "The request was blocked by the content management policy. Please rephrase your message."
 )
-_MSG_AI_MODEL_TIMEOUT = "The request to the AI model service timed out. Please try again later."
 _MSG_AI_MODEL_CONTEXT_LENGTH = (
     "The request exceeds the maximum context length of the AI model. "
     "Please shorten your messages and try again."
 )
+_MSG_AI_MODEL_PAYLOAD_TOO_LARGE = (
+    "The request payload is too large. Please reduce the size of your message or attachments."
+)
+
+# --- Service wording (DIAL core service calls surfaced as httpx errors) ---
+_MSG_SERVICE_RATE_LIMITED = "A required service is currently rate-limiting requests."
+_MSG_SERVICE_INTERNAL_ERROR = "A required service encountered an internal error."
+_MSG_SERVICE_TIMEOUT = "A request to a required service timed out."
+_MSG_SERVICE_NETWORK_ERROR = "A network error occurred while contacting a required service."
 
 _MSG_SERVICE_NO_PERMISSION = (
-    "You don't have permission to access a required service. " "Please contact your administrator."
+    "You don't have permission to access a required service. Please contact your administrator."
+)
+_MSG_SERVICE_AUTH_FAILED = (
+    "Authentication failed when accessing a required service. Please contact your administrator."
 )
 _MSG_SERVICE_NOT_FOUND = (
     "A required service or resource could not be found. Please contact your administrator."
-)
-_MSG_SERVICE_RATE_LIMITED = (
-    "A required service is currently rate-limiting requests. Please try again later."
-)
-_MSG_SERVICE_INTERNAL_ERROR = (
-    "A required service encountered an internal error. Please try again later."
-)
-_MSG_SERVICE_TIMEOUT = "A request to a required service timed out. Please try again later."
-_MSG_SERVICE_NETWORK_ERROR = (
-    "A network error occurred while contacting a required service. " "Please try again later."
 )
 _MSG_SERVICE_NO_CONNECTIVITY = (
     "Could not connect to the AI model service. "
     "Please check connectivity or contact your administrator."
 )
+_MSG_HTTP_UNEXPECTED = (
+    "An unexpected HTTP error occurred. Please try again or contact your administrator."
+)
+_MSG_HTTP_GENERIC = "An HTTP error occurred. Please try again or contact your administrator."
+
+# Error codes that resolve to a specific message ahead of the status ladder. All are
+# non-retryable: re-sending the same request will not change the outcome.
+_CODE_MESSAGES: dict[str, str] = {
+    "content_filter": _MSG_AI_MODEL_CONTENT_FILTER,
+    "context_length_exceeded": _MSG_AI_MODEL_CONTEXT_LENGTH,
+    "truncate_prompt_error": _MSG_AI_MODEL_CONTEXT_LENGTH,
+}
 
 
-def _resolve_openai_error(e: openai.OpenAIError) -> str:
-    if isinstance(e, openai.PermissionDeniedError):
-        return _MSG_AI_MODEL_NO_PERMISSION
-    if isinstance(e, openai.AuthenticationError):
-        return _MSG_AI_MODEL_AUTH_FAILED
-    if isinstance(e, openai.NotFoundError):
-        return _MSG_AI_MODEL_NOT_FOUND
-    if isinstance(e, openai.RateLimitError):
-        return _MSG_AI_MODEL_RATE_LIMITED
-    if isinstance(e, openai.BadRequestError):
-        return (
-            "The request was rejected by the AI model service. "
-            "Please try again or contact your administrator."
-        )
-    if isinstance(e, openai.InternalServerError):
-        return _MSG_AI_MODEL_INTERNAL_ERROR
-    # APITimeoutError must be checked before APIConnectionError — it is a subclass of it
-    if isinstance(e, openai.APITimeoutError):
-        return _MSG_AI_MODEL_TIMEOUT
-    if isinstance(e, openai.APIConnectionError):
-        return _MSG_SERVICE_NO_CONNECTIVITY
-    return _FALLBACK_MESSAGE
+class ErrorDetails(BaseModel):
+    """Normalized view of an upstream error, extracted from any supported exception shape."""
+
+    model_config = ConfigDict(frozen=True)
+
+    status_code: int | None = None
+    code: str | None = None
+    error_type: str | None = None  # never influences resolution; forwarded to logs and wire `type`
+    message: str | None = None  # internal message — logged, never shown to the user
+    display_message: str | None = None  # user-safe by DIAL contract
 
 
-def _resolve_httpx_error(e: httpx.HTTPError) -> str:
-    if isinstance(e, httpx.HTTPStatusError):
-        status = e.response.status_code
-        if status == 403:
-            return _MSG_SERVICE_NO_PERMISSION
-        if status == 404:
-            return _MSG_SERVICE_NOT_FOUND
-        if status == 429:
-            return _MSG_SERVICE_RATE_LIMITED
-        if status >= 500:
-            return _MSG_SERVICE_INTERNAL_ERROR
-        return "An unexpected HTTP error occurred. Please try again or contact your administrator."
-    # TimeoutException must be checked before NetworkError — it is a subclass of TransportError,
-    # not NetworkError, but keeping it explicit avoids future confusion
-    if isinstance(e, httpx.TimeoutException):
-        return _MSG_SERVICE_TIMEOUT
-    if isinstance(e, httpx.NetworkError):
-        return _MSG_SERVICE_NETWORK_ERROR
-    return "An HTTP error occurred. Please try again or contact your administrator."
+class ResolvedError(BaseModel):
+    """Resolution result: user-facing text plus classification and the raw details."""
+
+    model_config = ConfigDict(frozen=True)
+
+    message: str  # user-facing text, sanitized, retry suffix already composed
+    retryable: bool  # classification — logged by the handler; not re-applied to the text
+    details: ErrorDetails  # extracted internals, carried for the handler's log record
 
 
-def _resolve_aidial_error(e: AiDialHTTPException) -> str:
-    # ContextLengthExceededError must be checked before InvalidRequestError — it is a subclass of it
-    if isinstance(e, ContextLengthExceededError):
-        return _MSG_AI_MODEL_CONTEXT_LENGTH
-    if isinstance(e, (InvalidRequestError, RequestValidationError)):
-        return _MSG_AI_MODEL_INVALID_REQUEST
-    if isinstance(e, (DeploymentNotFoundError, ResourceNotFoundError)):
-        return _MSG_AI_MODEL_NOT_FOUND
-    status = e.status_code
+# A resolved (cause message, retryable) pair, before the retry sentence is composed in.
+_Resolution = tuple[str, bool]
+
+
+def _unwrap_error_body(body: Any) -> dict[str, Any]:
+    """Return the DIAL error object from a response/exception body.
+
+    openai populates its ``.code`` / ``.type`` attributes from the *top level* of the
+    response body, but DIAL Core nests those fields under ``error`` for 4xx/5xx
+    responses (``{"error": {...}}``). Mid-stream errors are already unwrapped by the SDK,
+    so ``body.get("error", body)`` is a no-op for them and the correct unwrap otherwise.
+    The same nesting applies to raw httpx JSON error bodies, so both paths share this.
+    """
+    if not isinstance(body, dict):
+        return {}
+    inner = body.get("error", body)
+    return inner if isinstance(inner, dict) else {}
+
+
+def _backfill_status_from_code(status_code: int | None, code: str | None) -> int | None:
+    """Recover a status for shapes that carry none of their own.
+
+    DIAL defaults ``code`` to ``str(status_code)``, so a mid-stream ``APIError`` (which
+    has no HTTP status) frequently carries e.g. ``code="429"``. Backfill lets those
+    resolve through the ordinary status ladder.
+    """
+    if status_code is None and code is not None and code.isdigit():
+        return int(code)
+    return status_code
+
+
+def _details_from_body(status_code: int | None, body: dict[str, Any]) -> ErrorDetails:
+    raw_code = body.get("code")
+    code = str(raw_code) if raw_code is not None else None
+    return ErrorDetails(
+        status_code=_backfill_status_from_code(status_code, code),
+        code=code,
+        error_type=body.get("type"),
+        message=body.get("message"),
+        display_message=body.get("display_message"),
+    )
+
+
+def _extract_from_openai(e: openai.APIError) -> ErrorDetails:
+    # Only APIStatusError carries a status code; plain/mid-stream APIError does not.
+    status_code = getattr(e, "status_code", None)
+    return _details_from_body(status_code, _unwrap_error_body(e.body))
+
+
+def _extract_from_aidial(e: AiDialHTTPException) -> ErrorDetails:
+    return ErrorDetails(
+        status_code=e.status_code,
+        code=e.code,
+        error_type=e.type,
+        message=e.message,
+        display_message=e.display_message,
+    )
+
+
+def _extract_from_httpx(e: httpx.HTTPError) -> ErrorDetails:
+    if not isinstance(e, httpx.HTTPStatusError):
+        return ErrorDetails()
+    try:
+        parsed = e.response.json()
+    except Exception:
+        parsed = None
+    return _details_from_body(e.response.status_code, _unwrap_error_body(parsed))
+
+
+def _extract_error_details(e: Exception) -> ErrorDetails:
+    """Best-effort, total: malformed or absent bodies yield an empty ``ErrorDetails``."""
+    try:
+        if isinstance(e, openai.APIError):
+            return _extract_from_openai(e)
+        if isinstance(e, AiDialHTTPException):
+            return _extract_from_aidial(e)
+        if isinstance(e, httpx.HTTPError):
+            return _extract_from_httpx(e)
+    except Exception:
+        logger.debug("Failed to extract error details from %s", type(e), exc_info=True)
+    return ErrorDetails()
+
+
+def _resolve_by_code(details: ErrorDetails) -> _Resolution | None:
+    if details.code is None:
+        return None
+    message = _CODE_MESSAGES.get(details.code)
+    return (message, False) if message is not None else None
+
+
+def _resolve_ai_model_status(status: int | None) -> _Resolution | None:
+    if status is None:
+        return None
     if status == 401:
-        return _MSG_AI_MODEL_AUTH_FAILED
+        return (_MSG_AI_MODEL_AUTH_FAILED, False)
     if status == 403:
-        return _MSG_AI_MODEL_NO_PERMISSION
+        return (_MSG_AI_MODEL_NO_PERMISSION, False)
     if status == 404:
-        return _MSG_AI_MODEL_NOT_FOUND
-    if status == 422:
-        return _MSG_AI_MODEL_INVALID_REQUEST
+        return (_MSG_AI_MODEL_NOT_FOUND, False)
+    if status == 413:
+        return (_MSG_AI_MODEL_PAYLOAD_TOO_LARGE, False)
+    if status in (400, 422):
+        return (_MSG_AI_MODEL_INVALID_REQUEST, False)
+    if status == 409:
+        return (_MSG_AI_MODEL_CONFLICT, True)
     if status == 429:
-        return _MSG_AI_MODEL_RATE_LIMITED
+        return (_MSG_AI_MODEL_RATE_LIMITED, True)
     if status >= 500:
-        return _MSG_AI_MODEL_INTERNAL_ERROR
-    return _FALLBACK_MESSAGE
+        return (_MSG_AI_MODEL_INTERNAL_ERROR, True)
+    return None
 
 
-def _resolve_internal_error(e: Exception) -> str:
-    if isinstance(e, OrchestratorExceedMaxIterationsException):
-        return str(e)
-    if isinstance(e, OrchestratorInitializationException):
-        return _MSG_AI_MODEL_NOT_FOUND
-    if isinstance(e, ToolsetNotFoundException):
-        return "A required toolset could not be found. Please contact your administrator."
-    if isinstance(e, ToolsetForbiddenException):
-        return "Access to a required toolset is forbidden. Please contact your administrator."
-    return _FALLBACK_MESSAGE
+def _resolve_openai_status_or_type(e: openai.APIError, details: ErrorDetails) -> _Resolution | None:
+    # Type branches carry no HTTP status. APITimeoutError must precede APIConnectionError
+    # (it is a subclass), and both must precede the stream-failure rule.
+    if isinstance(e, openai.APITimeoutError):
+        return (_MSG_AI_MODEL_TIMEOUT, True)
+    if isinstance(e, openai.APIConnectionError):
+        # The openai client already retried this; a lingering failure is deterministic
+        # (wrong endpoint / DNS / TLS), so it is non-retryable with admin-escalation advice.
+        return (_MSG_SERVICE_NO_CONNECTIVITY, False)
+    return _resolve_ai_model_status(details.status_code)
 
 
-def resolve_exception_message(e: Exception) -> str:
-    """Return a safe, user-friendly message for any exception."""
-    if isinstance(e, openai.OpenAIError):
-        return _resolve_openai_error(e)
-    if isinstance(e, httpx.HTTPError):
-        return _resolve_httpx_error(e)
+def _resolve_httpx_status_or_type(e: httpx.HTTPError, details: ErrorDetails) -> _Resolution:
+    # httpx is a terminal source (no stream-failure fallthrough), so it always resolves.
+    if isinstance(e, httpx.TimeoutException):
+        return (_MSG_SERVICE_TIMEOUT, True)
+    if isinstance(e, httpx.NetworkError):
+        return (_MSG_SERVICE_NETWORK_ERROR, True)
+    if isinstance(e, httpx.HTTPStatusError):
+        status = details.status_code
+        if status == 401:
+            return (_MSG_SERVICE_AUTH_FAILED, False)
+        if status == 403:
+            return (_MSG_SERVICE_NO_PERMISSION, False)
+        if status == 404:
+            return (_MSG_SERVICE_NOT_FOUND, False)
+        if status == 429:
+            return (_MSG_SERVICE_RATE_LIMITED, True)
+        if status is not None and status >= 500:
+            return (_MSG_SERVICE_INTERNAL_ERROR, True)
+        return (_MSG_HTTP_UNEXPECTED, False)
+    return (_MSG_HTTP_GENERIC, False)
+
+
+def _resolve_status_or_type(e: Exception, details: ErrorDetails) -> _Resolution | None:
+    if isinstance(e, openai.APIError):
+        return _resolve_openai_status_or_type(e, details)
     if isinstance(e, AiDialHTTPException):
-        return _resolve_aidial_error(e)
-    return _resolve_internal_error(e)
+        return _resolve_ai_model_status(details.status_code)
+    if isinstance(e, httpx.HTTPError):
+        return _resolve_httpx_status_or_type(e, details)
+    return None
+
+
+def _resolve_internal(e: Exception) -> _Resolution | None:
+    if isinstance(e, OrchestratorExceedMaxIterationsException):
+        return (str(e), False)
+    if isinstance(e, OrchestratorInitializationException):
+        return (_MSG_AI_MODEL_NOT_FOUND, False)
+    if isinstance(e, ToolsetNotFoundException):
+        toolset = f" ({e.toolset_id})" if e.toolset_id else ""
+        return (
+            f"A required toolset{toolset} could not be found. "
+            "Please contact your administrator.",
+            False,
+        )
+    if isinstance(e, ToolsetForbiddenException):
+        toolset = f" ({e.toolset_id})" if e.toolset_id else ""
+        return (
+            f"Access to a required toolset{toolset} is forbidden. "
+            "Please contact your administrator.",
+            False,
+        )
+    return None
+
+
+def _sanitize_display_message(text: str) -> str:
+    text = text.strip()
+    if len(text) > _DISPLAY_MESSAGE_MAX_LEN:
+        text = text[: _DISPLAY_MESSAGE_MAX_LEN - 1].rstrip() + "…"
+    return text
+
+
+def _is_retryable_from_details(details: ErrorDetails) -> bool:
+    """Derive retryability from status/code for the display_message path (rule 1).
+
+    Follows the same classification as the status ladder, defaulting to ``False`` when
+    neither a status nor a known code is available.
+    """
+    if details.code in _CODE_MESSAGES:
+        return False
+    status = details.status_code
+    if status is None:
+        return False
+    if status in (409, 429):
+        return True
+    return status >= 500
+
+
+def _compose(message: str, retryable: bool, details: ErrorDetails) -> ResolvedError:
+    text = f"{message} {_RETRY_SENTENCE}" if retryable else message
+    return ResolvedError(message=text, retryable=retryable, details=details)
+
+
+def resolve_exception(e: Exception) -> ResolvedError:
+    """Resolve any exception into user-facing text plus a retryability classification.
+
+    Precedence: display_message -> code map -> status/type map -> stream-failure rule ->
+    internal map -> fallback. Never leaks raw internal detail: only ``display_message``
+    (user-safe by contract) and curated canned messages reach the user.
+    """
+    details = _extract_error_details(e)
+
+    # 1. Upstream-authored, user-safe text wins. Used as-is (never retry-suffixed), since
+    #    appending generic advice can contradict a precise upstream explanation.
+    if details.display_message:
+        return ResolvedError(
+            message=_sanitize_display_message(details.display_message),
+            retryable=_is_retryable_from_details(details),
+            details=details,
+        )
+
+    # 2. Specific, actionable error codes.
+    resolution = _resolve_by_code(details)
+    if resolution is not None:
+        return _compose(*resolution, details)
+
+    # 3. Status / type ladders (source-specific wording; unmatched -> None to continue).
+    resolution = _resolve_status_or_type(e, details)
+    if resolution is not None:
+        return _compose(*resolution, details)
+
+    # 4. Mid-stream openai APIError with no usable status/code — terminal for the stream
+    #    path, so a mid-stream failure can never reach the generic fallback.
+    if isinstance(e, openai.APIError) and not isinstance(e, openai.APIStatusError):
+        return _compose(_MSG_AI_MODEL_STREAM_FAILURE, True, details)
+
+    # 5. Internal, in-process exceptions.
+    resolution = _resolve_internal(e)
+    if resolution is not None:
+        return _compose(*resolution, details)
+
+    # 6. Generic fallback (non-retryable).
+    return _compose(_FALLBACK_MESSAGE, False, details)

--- a/src/quickapp/core/application/_quick_app_completion.py
+++ b/src/quickapp/core/application/_quick_app_completion.py
@@ -113,10 +113,14 @@ class _QuickAppCompletion(ChatCompletion):
             e,
         )
         display = f"{resolved.message} (error reference: {error_reference})"
+        status_code = _outgoing_status_code(resolved)
+        # OpenAI-protocol convention when the upstream supplied no type: client-attributable
+        # 4xx -> invalid_request_error, everything else -> runtime_error.
+        default_type = "invalid_request_error" if status_code < 500 else "runtime_error"
         raise DialHTTPException(
-            status_code=_outgoing_status_code(resolved),
+            status_code=status_code,
             message=display,
             display_message=display,
             code=resolved.details.code,
-            type=resolved.details.error_type or "runtime_error",
+            type=resolved.details.error_type or default_type,
         )

--- a/src/quickapp/core/application/_quick_app_completion.py
+++ b/src/quickapp/core/application/_quick_app_completion.py
@@ -1,8 +1,9 @@
 import logging
+import uuid
 
 from aidial_sdk.chat_completion import ChatCompletion, Request, Response
-from aidial_sdk.chat_completion.choice import Choice
 from aidial_sdk.deployment.configuration import ConfigurationRequest, ConfigurationResponse
+from aidial_sdk.exceptions import HTTPException as DialHTTPException
 from injector import Injector, inject
 
 from quickapp.common import InitializerType
@@ -12,13 +13,25 @@ from quickapp.common.perf_timer.perf_timer import PerformanceTimer
 from quickapp.common.presentation_settings import PresentationSettings
 from quickapp.core.agent import Orchestrator
 
-from ._exception_message_resolver import resolve_exception_message
+from ._exception_message_resolver import ResolvedError, resolve_exception
 from ._initialization_error_handler import _InitializationErrorHandler
 from ._messages_validator import validate_messages_shape
 from ._request_context_setup import _RequestContextSetup
 from .configuration import Configuration
 
 logger = logging.getLogger(__name__)
+
+# Statuses safe to surface verbatim: client-attributable causes. Everything else — most
+# importantly Core's retriable set (429/502/503/504), which for a single-upstream
+# application Core cannot retry and would replace with a generic error — collapses to 500.
+_CLIENT_ERROR_STATUS_CODES = frozenset({400, 401, 403, 404, 413, 422})
+
+
+def _outgoing_status_code(resolved: ResolvedError) -> int:
+    status = resolved.details.status_code
+    if status in _CLIENT_ERROR_STATUS_CODES:
+        return status
+    return 500
 
 
 # The _QuickAppCompletion class is a dependency-injected implementation of the ChatCompletion interface.
@@ -44,6 +57,7 @@ class _QuickAppCompletion(ChatCompletion):
         timer_service = self.__injector.get(PerformanceTimer)
         timer_service.start_period(self.__timer_period_name, level=1)
         with response.create_single_choice() as choice:
+            failed = False
             try:
                 request_context_setup = self.__injector.get(_RequestContextSetup)
                 try:
@@ -63,13 +77,18 @@ class _QuickAppCompletion(ChatCompletion):
                 agent_invoker = self.__injector.get(Orchestrator)  # type: ignore[type-abstract]
                 await agent_invoker.invoke()
             except Exception as e:
-                self.__handle_exception(choice, e)
+                # Raises a DIAL protocol error; the SDK delivers it as a non-200 response
+                # (or an SSE error chunk once the choice has opened the stream).
+                failed = True
+                self.__handle_exception(e)
             finally:
                 timer_service.stop_period(self.__timer_period_name)
                 logger.debug(
                     "Chat completion performance report:\n%s", timer_service.get_report_json()
                 )
-                if self.__presentation_settings.show_execution_time_stage:
+                # Skip the execution-time stage when an error is propagating, so no
+                # spurious stage trails the delivered error.
+                if not failed and self.__presentation_settings.show_execution_time_stage:
                     with choice.create_stage("Execution time") as stage:
                         stage.append_content(timer_service.get_report_md())
 
@@ -82,6 +101,22 @@ class _QuickAppCompletion(ChatCompletion):
         return Configuration.from_list_of_configurations(configurations).to_configuration_response()
 
     @staticmethod
-    def __handle_exception(choice: Choice, e: Exception) -> None:
-        logger.exception("Exception %s occurred. %s", type(e), e)
-        choice.append_content(resolve_exception_message(e))
+    def __handle_exception(e: Exception) -> None:
+        error_reference = uuid.uuid4().hex[:8]
+        resolved = resolve_exception(e)
+        logger.exception(
+            "Exception %s occurred (error_reference=%s, retryable=%s, details=%s). %s",
+            type(e),
+            error_reference,
+            resolved.retryable,
+            resolved.details,
+            e,
+        )
+        display = f"{resolved.message} (error reference: {error_reference})"
+        raise DialHTTPException(
+            status_code=_outgoing_status_code(resolved),
+            message=display,
+            display_message=display,
+            code=resolved.details.code,
+            type=resolved.details.error_type or "runtime_error",
+        )

--- a/src/tests/sample_apps/error_injection_app/README.md
+++ b/src/tests/sample_apps/error_injection_app/README.md
@@ -1,0 +1,155 @@
+# Error-injection sample model
+
+A tiny standalone **DIAL chat-completion** app (built on `aidial-sdk`) whose only job is
+to **deterministically reproduce every failure mode** that QuickApps' error resolver
+(`src/quickapp/core/application/_exception_message_resolver.py`) distinguishes.
+
+Register it in DIAL Core as a model, wire it as a QuickApp's **orchestrator deployment**,
+and use DIAL Chat conversation-starter buttons to trigger each scenario with one click.
+It is **not** a pytest and never runs as part of `make test`.
+
+Deployment name: **`error-injection-model`** (see `DEPLOYMENT_NAME`).
+
+## Files
+
+| File | Purpose |
+|---|---|
+| `error_injection_app.py` | Runnable entry point: assembles the `DIALApp` and runs uvicorn. |
+| `completion.py` | The `ErrorInjectionModel` (`ChatCompletion` subclass) and the pre-/mid-stream error mechanics. |
+| `scenarios.py` | The scenario registry (`SCENARIOS`), the `Scenario` model, trigger matching, and tunable constants. |
+| `sample_quickapp_config.json` | Minimal, schema-valid QuickApp manifest with a conversation starter per trigger. |
+
+## How it works
+
+The app reads the **last user message**, matches it (case-insensitive substring, longest
+trigger wins) against a scenario registry (`_SCENARIOS`), and reproduces that scenario.
+Unmatched messages stream a help text listing all triggers.
+
+Two error-delivery shapes are reproduced (verified against `aidial-sdk` 0.32.0):
+
+- **Pre-stream errors** are raised *before* any chunk is emitted. The SDK returns a
+  **non-200 JSON** body `{"error": {...}}` with the exception's `status_code`.
+- **Mid-stream errors** are raised *after* a choice is opened and content appended. The
+  HTTP response is already committed as `200 text/event-stream`, so the error is
+  delivered as an **SSE `data: {"error": ...}` chunk** appended to the live stream.
+  DIAL Chat surfaces **only `display_message`** on the mid-stream path.
+
+> Note: in **non-streaming** mode the SDK cannot commit a partial stream, so mid-stream
+> scenarios also come back as a non-200 error. Trigger behaviour matches the table below
+> when the caller uses `stream: true` — which QuickApps' orchestrator always does.
+
+## Run it
+
+From the repo root (`ai-dial-quickapps-backend/`):
+
+```bash
+poetry run python src/tests/sample_apps/error_injection_app/error_injection_app.py
+```
+
+Listens on `0.0.0.0:5002` by default. Override with env vars:
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `ERROR_INJECTION_APP_HOST` | `0.0.0.0` | Bind host |
+| `ERROR_INJECTION_APP_PORT` | `5002` | Bind port |
+
+The "slow response" delay is the module constant `SLOW_SCENARIO_DELAY_SECONDS` in
+`scenarios.py` (default 30s) — edit it to comfortably exceed your client's read timeout.
+
+Endpoints (added by the SDK):
+
+- `POST /openai/deployments/error-injection-model/chat/completions`
+- `GET  /health`
+
+### Quick manual check
+
+The SDK requires an `Api-Key` header on every request (DIAL Core forwards it in real
+use; for manual curl any non-empty value works).
+
+```bash
+# Pre-stream error -> non-200 JSON body {"error": {...}}
+curl -i -X POST \
+  http://localhost:5002/openai/deployments/error-injection-model/chat/completions \
+  -H 'Content-Type: application/json' -H 'Api-Key: dummy' \
+  -d '{"stream": true, "messages": [{"role": "user", "content": "pre-stream 500"}]}'
+
+# Mid-stream error -> HTTP 200 SSE with content then a data: {"error": ...} chunk
+curl -N -X POST \
+  http://localhost:5002/openai/deployments/error-injection-model/chat/completions \
+  -H 'Content-Type: application/json' -H 'Api-Key: dummy' \
+  -d '{"stream": true, "messages": [{"role": "user", "content": "mid-stream error"}]}'
+```
+
+## Register it in DIAL Core as a model
+
+Add a model entry to your DIAL Core config that proxies to this server. Example
+(`core/configuration` style):
+
+```json
+{
+  "models": {
+    "error-injection-model": {
+      "type": "chat",
+      "displayName": "Error Injection Model",
+      "endpoint": "http://<host-reachable-from-core>:5002/openai/deployments/error-injection-model/chat/completions"
+    }
+  }
+}
+```
+
+Use a host/port reachable from DIAL Core (e.g. a container name in docker-compose, or
+`host.docker.internal:5002` when Core runs in Docker and this server on the host).
+
+## Wire it as a QuickApp orchestrator
+
+Point the QuickApp manifest's `orchestrator.deployment.deployment_id` at the DIAL Core
+model id above. A minimal, schema-valid manifest is provided in
+[`sample_quickapp_config.json`](./sample_quickapp_config.json) — it also defines a
+conversation starter per trigger phrase so a tester can one-click each scenario:
+
+```json
+{
+  "orchestrator": {
+    "deployment": { "deployment_id": "error-injection-model" },
+    "system_prompt": { "type": "custom", "variables": {}, "content": "..." }
+  },
+  "contexts": [],
+  "tool_sets": [],
+  "conversation_starters": { "starters": [ { "title": "...", "text": "happy path" } ] }
+}
+```
+
+## Trigger phrases
+
+Each conversation starter sends the **text** below; the model matches it and produces the
+listed behaviour. Values are what a QuickApp tester sees in DIAL Chat.
+
+| Trigger text | Delivery | Status / code | What DIAL Chat shows |
+|---|---|---|---|
+| `happy path` | 200 stream | — | A normal streamed answer (control case) |
+| `pre-stream 500` | non-200 | 500 | `display_message`: "The upstream provider is temporarily unavailable." |
+| `content filter` | non-200 | 400 / `content_filter` | Content-policy message: "…blocked by the content management policy. Please rephrase your message." |
+| `context length exceeded` | non-200 | 400 / `context_length_exceeded` | "…exceeds the maximum context length… Please shorten your messages and try again." |
+| `rate limit` | non-200 | 429 | `display_message`: "Too many requests right now. Please slow down." |
+| `auth failed` | non-200 | 401 | Authentication-failed message (contact administrator) |
+| `permission denied` | non-200 | 403 | No-permission message (contact administrator) |
+| `not found` | non-200 | 404 | Model-not-found message (contact administrator) |
+| `payload too large` | non-200 | 413 | Payload-too-large message |
+| `invalid request` | non-200 | 422 | Invalid-request message (contact administrator) |
+| `internal error` | non-200 | 500 (no `display_message`) | Generic internal-error message + "Please try again later." |
+| `mid-stream error` | 200 stream + SSE error | 500 | Partial text, then `display_message`: "The model failed while responding." |
+| `stream failure` | 200 stream + SSE error | 500 (no `display_message`) | Partial text, then generic stream-failure message + "Please try again later." |
+| `uncaught exception` | non-200 | 500 (SDK-wrapped `RuntimeError`) | Generic internal-error message + "Please try again later." |
+| `slow response` | 200 stream (delayed) | — | A token, a long pause (`SLOW_SCENARIO_DELAY_SECONDS`), then completion — exercises client timeouts |
+
+> **Key distinction:** pre-stream errors arrive as a **non-200 response** (no content was
+> streamed); mid-stream errors arrive as an **SSE error chunk inside a committed 200
+> stream** (after visible partial content). QuickApps' resolver handles both; only
+> `display_message` reaches the user on the mid-stream path.
+
+## Extending
+
+Append a new `Scenario` to `SCENARIOS` in `scenarios.py` (and a matching conversation
+starter in `sample_quickapp_config.json`). If it needs behaviour beyond the existing
+`ScenarioKind` variants, add a branch in `ErrorInjectionModel._run_scenario`
+(`completion.py`). No other wiring is needed.

--- a/src/tests/sample_apps/error_injection_app/completion.py
+++ b/src/tests/sample_apps/error_injection_app/completion.py
@@ -1,0 +1,122 @@
+"""The error-injection ``ChatCompletion`` implementation.
+
+Two error-delivery shapes are reproduced here (verified against aidial-sdk 0.32.0):
+
+* **Pre-stream error** -- raising an ``HTTPException`` *before* any chunk is emitted.
+  The SDK turns the first (and only) queued chunk into a non-200 JSON error response
+  ``{"error": {...}}``. The HTTP status is the exception's ``status_code``.
+* **Mid-stream error** -- raising *after* a choice has been opened and content appended
+  (see ``_stream_then_fail``). The HTTP response is already committed as
+  ``200 text/event-stream``, so the SDK serializes the exception as an SSE
+  ``data: {"error": ...}`` chunk appended to the live stream. DIAL Chat surfaces only
+  ``display_message`` on this path.
+"""
+
+import asyncio
+import logging
+
+from aidial_sdk import HTTPException
+from aidial_sdk.chat_completion import (
+    ChatCompletion,
+    MessageContentTextPart,
+    Request,
+    Response,
+    Role,
+)
+from scenarios import (
+    HAPPY_ANSWER,
+    PARTIAL_CONTENT,
+    SLOW_SCENARIO_DELAY_SECONDS,
+    Scenario,
+    ScenarioKind,
+    build_help_text,
+    match_scenario,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _extract_last_user_text(request: Request) -> str:
+    """Return the text of the last user message (string or joined text parts)."""
+    for message in reversed(request.messages):
+        if message.role is not Role.USER:
+            continue
+        content = message.content
+        if isinstance(content, str):
+            return content
+        if isinstance(content, list):
+            parts = [p.text for p in content if isinstance(p, MessageContentTextPart)]
+            return " ".join(parts)
+    return ""
+
+
+def _build_dial_exception(scenario: Scenario) -> HTTPException:
+    """Build the aidial-sdk ``HTTPException`` described by an error scenario.
+
+    Uses ``HTTPException`` directly (rather than the typed subclasses in
+    ``aidial_sdk.exceptions``) so the whole matrix -- status_code, code, type,
+    display_message -- stays declaratively driven by the registry.
+    """
+    return HTTPException(
+        message=scenario.message or f"Injected error: {scenario.title}",
+        status_code=scenario.status_code or 500,
+        type=scenario.error_type or "runtime_error",
+        code=scenario.code,
+        display_message=scenario.display_message,
+    )
+
+
+class ErrorInjectionModel(ChatCompletion):
+    """A DIAL chat-completion deployment that deterministically injects errors."""
+
+    async def chat_completion(self, request: Request, response: Response) -> None:
+        user_text = _extract_last_user_text(request)
+        scenario = match_scenario(user_text)
+
+        if scenario is None:
+            logger.info("No scenario matched %r; streaming help text.", user_text)
+            await self._stream_help(response)
+            return
+
+        logger.info("Matched scenario trigger=%r kind=%s", scenario.trigger, scenario.kind.value)
+        await self._run_scenario(scenario, response)
+
+    async def _run_scenario(self, scenario: Scenario, response: Response) -> None:
+        kind = scenario.kind
+        if kind is ScenarioKind.HAPPY:
+            await self._stream_text(response, HAPPY_ANSWER)
+        elif kind is ScenarioKind.PRE_STREAM_ERROR:
+            # Raised before any chunk is queued -> non-200 JSON error response.
+            raise _build_dial_exception(scenario)
+        elif kind is ScenarioKind.MID_STREAM_ERROR:
+            await self._stream_then_fail(scenario, response)
+        elif kind is ScenarioKind.UNCAUGHT_EXCEPTION:
+            # Non-DIAL exception -> SDK wraps it as a generic RuntimeServerError (500).
+            raise RuntimeError("boom")
+        elif kind is ScenarioKind.SLOW:
+            await self._stream_slow(response)
+        else:  # pragma: no cover - defensive, all kinds handled above
+            logger.warning("Unhandled scenario kind %s; streaming help.", kind)
+            await self._stream_help(response)
+
+    async def _stream_text(self, response: Response, text: str) -> None:
+        with response.create_single_choice() as choice:
+            choice.append_content(text)
+
+    async def _stream_help(self, response: Response) -> None:
+        await self._stream_text(response, build_help_text())
+
+    async def _stream_then_fail(self, scenario: Scenario, response: Response) -> None:
+        # Open the choice and append content first so the HTTP 200 stream is committed;
+        # the choice is intentionally left open (not closed) to model an interrupted
+        # stream. Raising now yields an SSE error chunk after the visible content.
+        choice = response.create_single_choice()
+        choice.open()
+        choice.append_content(scenario.partial_content or PARTIAL_CONTENT)
+        raise _build_dial_exception(scenario)
+
+    async def _stream_slow(self, response: Response) -> None:
+        with response.create_single_choice() as choice:
+            choice.append_content("Starting a deliberately slow response... ")
+            await asyncio.sleep(SLOW_SCENARIO_DELAY_SECONDS)
+            choice.append_content("done.")

--- a/src/tests/sample_apps/error_injection_app/error_injection_app.py
+++ b/src/tests/sample_apps/error_injection_app/error_injection_app.py
@@ -1,0 +1,63 @@
+"""Standalone runnable server for the error-injection sample model.
+
+This is a *sample* DIAL application built directly on the installed ``aidial-sdk``. It is
+meant to be registered in DIAL Core as a model and wired as the orchestrator deployment
+of a QuickApp so that QuickApps' error-handling pipeline
+(``_exception_message_resolver`` -> ``_quick_app_completion``) can be exercised
+end-to-end.
+
+The scenario registry lives in ``scenarios.py`` and the request handler in
+``completion.py``. This module only assembles the ``DIALApp`` and runs uvicorn.
+
+This module is NOT a pytest and must not run as part of ``make test``. Run it as a
+standalone server -- see ``README.md``:
+
+    poetry run python src/tests/sample_apps/error_injection_app/error_injection_app.py
+"""
+
+import logging
+
+import uvicorn
+from aidial_sdk import DIALApp
+from completion import ErrorInjectionModel
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+logger = logging.getLogger(__name__)
+
+# Deployment name this app registers under. Point a QuickApp's
+# ``orchestrator.deployment.deployment_id`` at this (via a DIAL Core model that proxies
+# to this server) to test the error resolver.
+DEPLOYMENT_NAME = "error-injection-model"
+
+
+class _ServerSettings(BaseSettings):
+    """Runner configuration read from the environment."""
+
+    model_config = SettingsConfigDict()
+
+    host: str = Field(default="0.0.0.0", alias="ERROR_INJECTION_APP_HOST")
+    port: int = Field(default=5002, alias="ERROR_INJECTION_APP_PORT")
+
+
+def build_app() -> DIALApp:
+    """Assemble the DIAL app with the error-injection deployment registered."""
+    app = DIALApp(add_healthcheck=True)
+    app.add_chat_completion(DEPLOYMENT_NAME, ErrorInjectionModel())
+    return app
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    settings = _ServerSettings()
+    logger.info(
+        "Starting error-injection model on %s:%d (deployment %r)",
+        settings.host,
+        settings.port,
+        DEPLOYMENT_NAME,
+    )
+    uvicorn.run(build_app(), host=settings.host, port=settings.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/tests/sample_apps/error_injection_app/sample_quickapp_config.json
+++ b/src/tests/sample_apps/error_injection_app/sample_quickapp_config.json
@@ -1,0 +1,82 @@
+{
+  "orchestrator": {
+    "deployment": {
+      "deployment_id": "error-injection-model"
+    },
+    "system_prompt": {
+      "type": "custom",
+      "variables": {},
+      "content": "You are wired to the error-injection sample model. The model ignores this prompt and instead reproduces a failure mode selected by the user's message. Use the conversation starters to trigger each scenario."
+    },
+    "max_iterations": 15
+  },
+  "contexts": [],
+  "tool_sets": [],
+  "conversation_starters": {
+    "intro_text": "Pick an error scenario to trigger",
+    "chat_message_input_disabled": false,
+    "auto_submit": true,
+    "starters": [
+      {
+        "title": "Happy path (control)",
+        "text": "happy path"
+      },
+      {
+        "title": "Pre-stream 500 (display_message)",
+        "text": "pre-stream 500"
+      },
+      {
+        "title": "Content filter",
+        "text": "content filter"
+      },
+      {
+        "title": "Context length exceeded",
+        "text": "context length exceeded"
+      },
+      {
+        "title": "Rate limit (429)",
+        "text": "rate limit"
+      },
+      {
+        "title": "Auth failed (401)",
+        "text": "auth failed"
+      },
+      {
+        "title": "Permission denied (403)",
+        "text": "permission denied"
+      },
+      {
+        "title": "Not found (404)",
+        "text": "not found"
+      },
+      {
+        "title": "Payload too large (413)",
+        "text": "payload too large"
+      },
+      {
+        "title": "Invalid request (422)",
+        "text": "invalid request"
+      },
+      {
+        "title": "Internal error (no display_message)",
+        "text": "internal error"
+      },
+      {
+        "title": "Mid-stream error (after partial content)",
+        "text": "mid-stream error"
+      },
+      {
+        "title": "Mid-stream stream failure (no display_message)",
+        "text": "stream failure"
+      },
+      {
+        "title": "Uncaught exception",
+        "text": "uncaught exception"
+      },
+      {
+        "title": "Slow response / timeout",
+        "text": "slow response"
+      }
+    ]
+  }
+}

--- a/src/tests/sample_apps/error_injection_app/scenarios.py
+++ b/src/tests/sample_apps/error_injection_app/scenarios.py
@@ -1,0 +1,223 @@
+"""Scenario registry for the error-injection sample model.
+
+Each scenario maps a trigger phrase -- matched case-insensitively as a substring of the
+last user message -- to one specific failure mode. The registry (``SCENARIOS``) is a
+flat, ordered list; extend it by appending a new ``Scenario`` (and a matching
+conversation starter in ``sample_quickapp_config.json``).
+"""
+
+from enum import Enum
+
+from pydantic import BaseModel, ConfigDict
+
+# Delay (seconds) for the "slow response" scenario. Module constant on purpose: bump it
+# to comfortably exceed your client's read timeout when exercising timeout behaviour.
+SLOW_SCENARIO_DELAY_SECONDS: float = 30.0
+
+# Content streamed before a mid-stream failure, so the tester sees partial output first.
+PARTIAL_CONTENT = (
+    "Here is the beginning of my answer, streaming normally so far. "
+    "The stream is about to fail... "
+)
+
+# Short control answer for the happy path.
+HAPPY_ANSWER = (
+    "This is the error-injection model. Everything is working: this is a normal, "
+    "successful streamed answer with no error."
+)
+
+
+class ScenarioKind(str, Enum):
+    """How a scenario produces its behaviour."""
+
+    HAPPY = "happy"
+    PRE_STREAM_ERROR = "pre_stream_error"
+    MID_STREAM_ERROR = "mid_stream_error"
+    UNCAUGHT_EXCEPTION = "uncaught_exception"
+    SLOW = "slow"
+
+
+class Scenario(BaseModel):
+    """Declarative description of one failure-mode scenario."""
+
+    model_config = ConfigDict(frozen=True)
+
+    trigger: str  # lowercase keyword matched as a substring of the user message
+    title: str  # short human label (help text + docs)
+    expected: str  # what the tester should observe in DIAL Chat
+    kind: ScenarioKind
+    status_code: int | None = None  # HTTP status for error kinds
+    code: str | None = None  # DIAL error ``code`` (e.g. "content_filter")
+    error_type: str | None = None  # DIAL error ``type``
+    message: str | None = None  # internal message (logged, not shown to the user)
+    display_message: str | None = None  # user-safe text; the only field DIAL Chat shows
+    partial_content: str | None = None  # text streamed before a mid-stream failure
+
+
+# --- Scenario registry -------------------------------------------------------------
+# One entry per trigger phrase. Conversation starters in ``sample_quickapp_config.json``
+# send these ``trigger`` phrases verbatim.
+SCENARIOS: list[Scenario] = [
+    Scenario(
+        trigger="happy path",
+        title="Happy path",
+        expected="A normal streamed answer, HTTP 200, no error.",
+        kind=ScenarioKind.HAPPY,
+    ),
+    Scenario(
+        trigger="pre-stream 500",
+        title="Pre-stream 500 with display_message",
+        expected=(
+            "Non-200 (500) JSON error before any content; DIAL Chat shows the "
+            "display_message verbatim."
+        ),
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=500,
+        message="Injected pre-stream 500 from the error-injection model.",
+        display_message="The upstream provider is temporarily unavailable.",
+    ),
+    Scenario(
+        trigger="content filter",
+        title="Content filter",
+        expected="Non-200 (400), code=content_filter; resolver -> content-policy message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=400,
+        code="content_filter",
+        error_type="invalid_request_error",
+        message="Injected content_filter error.",
+    ),
+    Scenario(
+        trigger="context length exceeded",
+        title="Context length exceeded",
+        expected="Non-200 (400), code=context_length_exceeded; resolver -> shorten-messages message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=400,
+        code="context_length_exceeded",
+        error_type="invalid_request_error",
+        message="Injected context_length_exceeded error.",
+    ),
+    Scenario(
+        trigger="rate limit",
+        title="Rate limit (429)",
+        expected="Non-200 (429); resolver -> rate-limited message with 'Please try again later.'",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=429,
+        message="Injected rate-limit error.",
+        display_message="Too many requests right now. Please slow down.",
+    ),
+    Scenario(
+        trigger="auth failed",
+        title="Authentication failed (401)",
+        expected="Non-200 (401); resolver -> authentication-failed message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=401,
+        message="Injected authentication error.",
+    ),
+    Scenario(
+        trigger="permission denied",
+        title="Permission denied (403)",
+        expected="Non-200 (403); resolver -> no-permission message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=403,
+        message="Injected permission-denied error.",
+    ),
+    Scenario(
+        trigger="not found",
+        title="Not found (404)",
+        expected="Non-200 (404); resolver -> model-not-found message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=404,
+        message="Injected not-found error.",
+    ),
+    Scenario(
+        trigger="payload too large",
+        title="Payload too large (413)",
+        expected="Non-200 (413); resolver -> payload-too-large message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=413,
+        message="Injected payload-too-large error.",
+    ),
+    Scenario(
+        trigger="invalid request",
+        title="Invalid request (422)",
+        expected="Non-200 (422); resolver -> invalid-request message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=422,
+        error_type="invalid_request_error",
+        message="Injected invalid-request error.",
+    ),
+    Scenario(
+        trigger="internal error",
+        title="Internal error, no display_message (500)",
+        expected="Non-200 (500), no display_message; resolver -> generic internal-error message.",
+        kind=ScenarioKind.PRE_STREAM_ERROR,
+        status_code=500,
+        message="Injected internal error without a display_message.",
+    ),
+    Scenario(
+        trigger="mid-stream error",
+        title="Mid-stream error after partial content",
+        expected=(
+            "HTTP 200 stream with visible partial content, then an SSE error chunk; "
+            "DIAL Chat shows the display_message."
+        ),
+        kind=ScenarioKind.MID_STREAM_ERROR,
+        status_code=500,
+        message="Injected mid-stream failure.",
+        display_message="The model failed while responding.",
+        partial_content=PARTIAL_CONTENT,
+    ),
+    Scenario(
+        trigger="stream failure",
+        title="Mid-stream stream failure, no display_message",
+        expected=(
+            "HTTP 200 stream with visible partial content, then an SSE error chunk with "
+            "no display_message; resolver -> generic stream-failure message."
+        ),
+        kind=ScenarioKind.MID_STREAM_ERROR,
+        status_code=500,
+        message="Injected mid-stream stream failure without a display_message.",
+        partial_content=PARTIAL_CONTENT,
+    ),
+    Scenario(
+        trigger="uncaught exception",
+        title="Uncaught (non-DIAL) exception",
+        expected=(
+            "A plain RuntimeError; the SDK wraps it as a generic 500 (pre-stream, " "non-200)."
+        ),
+        kind=ScenarioKind.UNCAUGHT_EXCEPTION,
+    ),
+    Scenario(
+        trigger="slow response",
+        title="Slow response / timeout",
+        expected=(
+            f"Streams a token, waits {SLOW_SCENARIO_DELAY_SECONDS:.0f}s, then finishes; "
+            "use it to exercise client-timeout behaviour."
+        ),
+        kind=ScenarioKind.SLOW,
+    ),
+]
+
+
+def match_scenario(user_text: str) -> Scenario | None:
+    """Match the message against the registry, preferring the longest trigger.
+
+    Longest-first tie-breaking keeps overlapping phrases unambiguous (e.g. a message
+    containing "mid-stream error" is not shadowed by a shorter trigger).
+    """
+    text = user_text.lower()
+    for scenario in sorted(SCENARIOS, key=lambda s: len(s.trigger), reverse=True):
+        if scenario.trigger in text:
+            return scenario
+    return None
+
+
+def build_help_text() -> str:
+    lines = [
+        "Error-injection model. Send one of these phrases (or click a conversation "
+        "starter) to trigger a scenario:",
+        "",
+    ]
+    for scenario in SCENARIOS:
+        lines.append(f'- "{scenario.trigger}" -> {scenario.title}: {scenario.expected}')
+    return "\n".join(lines)

--- a/src/tests/unit_tests/application_tests/test_completion.py
+++ b/src/tests/unit_tests/application_tests/test_completion.py
@@ -4,6 +4,7 @@ from unittest.mock import Mock
 import fastapi
 import pytest
 from aidial_sdk.chat_completion import Message, Request, Role
+from aidial_sdk.exceptions import HTTPException as DialHTTPException
 from aidial_sdk.exceptions import InvalidRequestError
 from httpx import HTTPError
 
@@ -189,7 +190,7 @@ async def test_chat_completion_success(make_request_completion):
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_orchestrator_exceed_exception(make_request_completion):
+async def test_chat_completion_orchestrator_exceed_raises_dial_error(make_request_completion):
     # Arrange
     choice = FakeChoice()
     response = FakeResponse(choice)
@@ -200,15 +201,18 @@ async def test_chat_completion_orchestrator_exceed_exception(make_request_comple
 
     request, completion, _ = make_request_completion(OrchRaise(), api_key="k")
 
-    # Act
-    await completion.chat_completion(request, response)
+    # Act + Assert: delivered as a DIAL protocol error, not swallowed into choice content
+    with pytest.raises(DialHTTPException) as exc:
+        await completion.chat_completion(request, response)
 
-    # Assert
-    assert any("Agent stopped due to max iterations." in c for c in choice.contents)
+    display = exc.value.display_message
+    assert display is not None
+    assert "Agent stopped due to max iterations." in display
+    assert choice.contents == []
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_generic_exception_appends_generic_message(make_request_completion):
+async def test_chat_completion_generic_exception_raises_generic_message(make_request_completion):
     # Arrange
     choice = FakeChoice()
     response = FakeResponse(choice)
@@ -219,13 +223,15 @@ async def test_chat_completion_generic_exception_appends_generic_message(make_re
 
     request, completion, _ = make_request_completion(OrchRaise(), api_key="k")
 
-    # Act
-    await completion.chat_completion(request, response)
+    # Act + Assert
+    with pytest.raises(DialHTTPException) as exc:
+        await completion.chat_completion(request, response)
 
-    # Assert
-    assert any(
-        "Something went wrong with the execution of your request" in c for c in choice.contents
-    )
+    display = exc.value.display_message
+    assert display is not None
+    assert "Something went wrong with the execution of your request" in display
+    assert exc.value.status_code == 500
+    assert choice.contents == []
 
 
 @pytest.mark.asyncio
@@ -270,7 +276,7 @@ async def test_configuration_with_binding_returns_config_response(
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_http_error_appends_safe_message(make_request_completion):
+async def test_chat_completion_http_error_raises_safe_message(make_request_completion):
     # Arrange
     choice = FakeChoice()
     response = FakeResponse(choice)
@@ -281,16 +287,19 @@ async def test_chat_completion_http_error_appends_safe_message(make_request_comp
 
     request, completion, _ = make_request_completion(OrchRaise(), api_key="k")
 
-    # Act
-    await completion.chat_completion(request, response)
+    # Act + Assert: a user-friendly message is delivered and the raw internal URL is NOT leaked
+    with pytest.raises(DialHTTPException) as exc:
+        await completion.chat_completion(request, response)
 
-    # Assert: a user-friendly message is shown and the raw internal URL is NOT leaked
-    assert any("http error" in c.lower() for c in choice.contents)
-    assert not any("http://internal-service" in c for c in choice.contents)
+    display = exc.value.display_message
+    assert display is not None
+    assert "http error" in display.lower()
+    assert "http://internal-service" not in display
+    assert choice.contents == []
 
 
 @pytest.mark.asyncio
-async def test_chat_completion_openai_internal_server_error_appends_safe_message(
+async def test_chat_completion_openai_internal_server_error_raises_safe_message(
     make_request_completion,
 ):
     # Arrange
@@ -311,13 +320,18 @@ async def test_chat_completion_openai_internal_server_error_appends_safe_message
 
     request, completion, _ = make_request_completion(OrchRaise(), api_key="k")
 
-    # Act
-    await completion.chat_completion(request, response)
+    # Act + Assert: clean message delivered, raw internal details NOT exposed. An upstream
+    # 500 is downgraded to 500 (never a Core-retriable status).
+    with pytest.raises(DialHTTPException) as exc:
+        await completion.chat_completion(request, response)
 
-    # Assert: clean message shown, raw internal details NOT exposed
-    assert any("internal error" in c.lower() for c in choice.contents)
-    assert not any("http://internal-dial-core" in c for c in choice.contents)
-    assert not any("upstream internal error" in c for c in choice.contents)
+    display = exc.value.display_message
+    assert display is not None
+    assert "internal error" in display.lower()
+    assert "http://internal-dial-core" not in display
+    assert "upstream internal error" not in display
+    assert exc.value.status_code == 500
+    assert choice.contents == []
 
 
 @pytest.mark.asyncio
@@ -330,8 +344,13 @@ async def test_chat_completion_sets_context_messages_when_request_is_request(
     choice = FakeChoice()
     response = FakeResponse(choice)
 
-    # Create request via fixture (no orchestrator needed — we only need __setup_request_context to run)
-    request, completion, injector = make_request_completion(None, api_key="k")
+    class OrchestratorFake:
+        async def invoke(self):
+            return None
+
+    # We only need the request-context setup to run; a no-op orchestrator lets the
+    # success path complete so we can inspect the resolved messages.
+    request, completion, injector = make_request_completion(OrchestratorFake(), api_key="k")
 
     # Act
     await completion.chat_completion(request, response)

--- a/src/tests/unit_tests/application_tests/test_exception_message_resolver.py
+++ b/src/tests/unit_tests/application_tests/test_exception_message_resolver.py
@@ -1,9 +1,11 @@
 import httpx
 import openai
 import pytest
+from aidial_sdk.exceptions import ContextLengthExceededError as AiDialContextLengthError
+from aidial_sdk.exceptions import InvalidRequestError as AiDialInvalidRequestError
 
 from quickapp.common.exceptions import OrchestratorExceedMaxIterationsException
-from quickapp.core.application._exception_message_resolver import resolve_exception_message
+from quickapp.core.application._exception_message_resolver import _RETRY_SENTENCE, resolve_exception
 from quickapp.dial_core_services.exceptions import (
     ToolsetForbiddenException,
     ToolsetNotFoundException,
@@ -19,126 +21,266 @@ def _make_httpx_response(status_code: int) -> httpx.Response:
 
 
 def _make_openai_status_error(
-    cls: type[openai.APIStatusError], status_code: int
+    cls: type[openai.APIStatusError], status_code: int, body: object = None
 ) -> openai.APIStatusError:
-    return cls("raw error detail", response=_make_httpx_response(status_code), body=None)
+    return cls("raw error detail", response=_make_httpx_response(status_code), body=body)
+
+
+def _make_openai_api_error(body: object) -> openai.APIError:
+    return openai.APIError("raw error detail", request=_make_httpx_request(), body=body)
+
+
+def _resolve(e: Exception) -> str:
+    return resolve_exception(e).message
 
 
 class TestResolveOpenAIError:
     def test_permission_denied(self) -> None:
         e = _make_openai_status_error(openai.PermissionDeniedError, 403)
-        assert "permission" in resolve_exception_message(e).lower()
+        assert "permission" in _resolve(e).lower()
 
     def test_authentication_error(self) -> None:
         e = _make_openai_status_error(openai.AuthenticationError, 401)
-        assert "authentication" in resolve_exception_message(e).lower()
+        assert "authentication" in _resolve(e).lower()
 
     def test_not_found_error(self) -> None:
         e = _make_openai_status_error(openai.NotFoundError, 404)
-        assert "could not be found" in resolve_exception_message(e).lower()
+        assert "could not be found" in _resolve(e).lower()
 
     def test_rate_limit_error(self) -> None:
         e = _make_openai_status_error(openai.RateLimitError, 429)
-        assert "rate-limited" in resolve_exception_message(e).lower()
+        assert "rate-limited" in _resolve(e).lower()
 
     def test_bad_request_error(self) -> None:
         e = _make_openai_status_error(openai.BadRequestError, 400)
-        assert "rejected" in resolve_exception_message(e).lower()
+        assert "rejected" in _resolve(e).lower()
 
     def test_internal_server_error(self) -> None:
         e = _make_openai_status_error(openai.InternalServerError, 500)
-        assert "internal error" in resolve_exception_message(e).lower()
+        assert "internal error" in _resolve(e).lower()
 
     def test_api_timeout_error(self) -> None:
         e = openai.APITimeoutError(request=_make_httpx_request())
-        assert "timed out" in resolve_exception_message(e).lower()
+        assert "timed out" in _resolve(e).lower()
 
     def test_api_connection_error(self) -> None:
         e = openai.APIConnectionError(request=_make_httpx_request())
-        assert "connect" in resolve_exception_message(e).lower()
+        assert "connect" in _resolve(e).lower()
 
     # APITimeoutError is a subclass of APIConnectionError — ensure it does NOT fall
-    # through to the connection error branch
+    # through to the connection error branch.
     def test_api_timeout_not_handled_as_connection_error(self) -> None:
         e = openai.APITimeoutError(request=_make_httpx_request())
-        assert "timed out" in resolve_exception_message(e).lower()
-        assert "connect" not in resolve_exception_message(e).lower()
+        assert "timed out" in _resolve(e).lower()
+        assert "connect" not in _resolve(e).lower()
+
+    def test_conflict_is_retryable(self) -> None:
+        e = _make_openai_status_error(openai.ConflictError, 409)
+        resolved = resolve_exception(e)
+        assert resolved.retryable is True
+        assert resolved.message.endswith(_RETRY_SENTENCE)
+
+    def test_payload_too_large(self) -> None:
+        e = _make_openai_status_error(openai.APIStatusError, 413)
+        resolved = resolve_exception(e)
+        assert "payload is too large" in resolved.message.lower()
+        assert resolved.retryable is False
 
 
 class TestResolveHttpxError:
+    def test_http_status_401(self) -> None:
+        e = httpx.HTTPStatusError(
+            "unauthorized", request=_make_httpx_request(), response=_make_httpx_response(401)
+        )
+        message = _resolve(e).lower()
+        assert "authentication failed" in message
+        assert "required service" in message
+
     def test_http_status_403(self) -> None:
         e = httpx.HTTPStatusError(
             "forbidden", request=_make_httpx_request(), response=_make_httpx_response(403)
         )
-        assert "permission" in resolve_exception_message(e).lower()
+        assert "permission" in _resolve(e).lower()
 
     def test_http_status_404(self) -> None:
         e = httpx.HTTPStatusError(
             "not found", request=_make_httpx_request(), response=_make_httpx_response(404)
         )
-        assert "could not be found" in resolve_exception_message(e).lower()
+        assert "could not be found" in _resolve(e).lower()
 
     def test_http_status_429(self) -> None:
         e = httpx.HTTPStatusError(
             "rate limit", request=_make_httpx_request(), response=_make_httpx_response(429)
         )
-        assert "rate-limiting" in resolve_exception_message(e).lower()
+        assert "rate-limiting" in _resolve(e).lower()
 
     def test_http_status_500(self) -> None:
         e = httpx.HTTPStatusError(
             "server error", request=_make_httpx_request(), response=_make_httpx_response(500)
         )
-        assert "internal error" in resolve_exception_message(e).lower()
+        assert "internal error" in _resolve(e).lower()
 
     def test_http_status_503(self) -> None:
         e = httpx.HTTPStatusError(
             "unavailable", request=_make_httpx_request(), response=_make_httpx_response(503)
         )
-        assert "internal error" in resolve_exception_message(e).lower()
+        assert "internal error" in _resolve(e).lower()
 
     def test_http_status_422_other(self) -> None:
         e = httpx.HTTPStatusError(
             "unprocessable", request=_make_httpx_request(), response=_make_httpx_response(422)
         )
-        assert "unexpected http" in resolve_exception_message(e).lower()
+        assert "unexpected http" in _resolve(e).lower()
 
     def test_timeout_exception(self) -> None:
         e = httpx.TimeoutException("timed out", request=_make_httpx_request())
-        assert "timed out" in resolve_exception_message(e).lower()
+        assert "timed out" in _resolve(e).lower()
 
     def test_network_error(self) -> None:
         e = httpx.NetworkError("connection reset")
-        assert "network error" in resolve_exception_message(e).lower()
+        assert "network error" in _resolve(e).lower()
 
     def test_generic_http_error_fallback(self) -> None:
         e = httpx.HTTPError("some low-level http error")
-        assert "http error" in resolve_exception_message(e).lower()
+        assert "http error" in _resolve(e).lower()
 
 
 class TestResolveInternalError:
     def test_orchestrator_exceed_max_iterations(self) -> None:
         e = OrchestratorExceedMaxIterationsException()
-        assert "max iterations" in resolve_exception_message(e).lower()
+        assert "max iterations" in _resolve(e).lower()
 
-    def test_toolset_not_found(self) -> None:
-        e = ToolsetNotFoundException("my-toolset")
-        assert "toolset" in resolve_exception_message(e).lower()
+    def test_toolset_not_found_includes_id(self) -> None:
+        message = _resolve(ToolsetNotFoundException("my-toolset"))
+        assert "toolset" in message.lower()
+        assert "my-toolset" in message
 
-    def test_toolset_forbidden(self) -> None:
-        e = ToolsetForbiddenException("my-toolset")
-        assert "forbidden" in resolve_exception_message(e).lower()
+    def test_toolset_forbidden_includes_id(self) -> None:
+        message = _resolve(ToolsetForbiddenException("my-toolset"))
+        assert "forbidden" in message.lower()
+        assert "my-toolset" in message
 
     def test_unknown_exception_fallback(self) -> None:
-        e = RuntimeError("boom")
-        assert "something went wrong" in resolve_exception_message(e).lower()
+        assert "something went wrong" in _resolve(RuntimeError("boom")).lower()
 
     def test_generic_value_error_fallback(self) -> None:
-        e = ValueError("unexpected value")
-        assert "something went wrong" in resolve_exception_message(e).lower()
+        assert "something went wrong" in _resolve(ValueError("unexpected value")).lower()
+
+
+class TestDisplayMessagePreference:
+    def test_openai_display_message_used_over_canned(self) -> None:
+        e = _make_openai_status_error(
+            openai.InternalServerError,
+            500,
+            body={"error": {"display_message": "Daily token budget exhausted for this key."}},
+        )
+        resolved = resolve_exception(e)
+        assert resolved.message == "Daily token budget exhausted for this key."
+
+    def test_display_message_never_retry_suffixed_even_when_retryable(self) -> None:
+        e = _make_openai_status_error(
+            openai.InternalServerError,
+            500,
+            body={"error": {"display_message": "Upstream is down."}},
+        )
+        resolved = resolve_exception(e)
+        # Classified retryable (5xx) for logging, but the upstream text is used verbatim.
+        assert resolved.retryable is True
+        assert resolved.message == "Upstream is down."
+        assert not resolved.message.endswith(_RETRY_SENTENCE)
+
+    def test_display_message_truncated(self) -> None:
+        long_text = "x" * 900
+        e = _make_openai_status_error(
+            openai.BadRequestError, 400, body={"error": {"display_message": long_text}}
+        )
+        resolved = resolve_exception(e)
+        assert len(resolved.message) <= 500
+        assert resolved.message.endswith("…")
+
+    def test_aidial_display_message_used(self) -> None:
+        e = AiDialInvalidRequestError("internal detail", display_message="Please fix your input.")
+        assert resolve_exception(e).message == "Please fix your input."
+
+
+class TestCodeMap:
+    def test_content_filter(self) -> None:
+        e = _make_openai_status_error(
+            openai.BadRequestError, 400, body={"error": {"code": "content_filter"}}
+        )
+        resolved = resolve_exception(e)
+        assert "content management policy" in resolved.message.lower()
+        assert resolved.retryable is False
+
+    def test_context_length_exceeded_on_openai_bad_request(self) -> None:
+        e = _make_openai_status_error(
+            openai.BadRequestError, 400, body={"error": {"code": "context_length_exceeded"}}
+        )
+        resolved = resolve_exception(e)
+        assert "context length" in resolved.message.lower()
+        assert resolved.retryable is False
+
+    def test_context_length_on_aidial_exception(self) -> None:
+        e = AiDialContextLengthError(max_context_length=1000, prompt_tokens=2000)
+        assert "context length" in resolve_exception(e).message.lower()
+
+
+class TestStreamFailure:
+    def test_plain_api_error_without_body_is_stream_failure(self) -> None:
+        resolved = resolve_exception(_make_openai_api_error(body=None))
+        assert "failed while responding" in resolved.message.lower()
+        assert resolved.retryable is True
+        assert resolved.message.endswith(_RETRY_SENTENCE)
+
+    def test_mid_stream_numeric_code_backfills_to_status_ladder(self) -> None:
+        # DIAL defaults code to str(status); a mid-stream 429 carries code="429" and no
+        # HTTP status, and must resolve to the specific rate-limit message, not stream-failure.
+        resolved = resolve_exception(_make_openai_api_error(body={"code": "429"}))
+        assert "rate-limited" in resolved.message.lower()
+        assert resolved.retryable is True
+
+    def test_mid_stream_unknown_code_is_stream_failure(self) -> None:
+        resolved = resolve_exception(_make_openai_api_error(body={"code": "weird_upstream_code"}))
+        assert "failed while responding" in resolved.message.lower()
+
+
+class TestRetryabilityComposition:
+    def test_retryable_appends_retry_sentence_once(self) -> None:
+        resolved = resolve_exception(_make_openai_status_error(openai.InternalServerError, 500))
+        assert resolved.retryable is True
+        assert resolved.message.endswith(_RETRY_SENTENCE)
+        assert resolved.message.count(_RETRY_SENTENCE) == 1
+
+    def test_non_retryable_has_no_retry_sentence(self) -> None:
+        resolved = resolve_exception(_make_openai_status_error(openai.PermissionDeniedError, 403))
+        assert resolved.retryable is False
+        assert not resolved.message.endswith(_RETRY_SENTENCE)
+
+    def test_connection_error_is_non_retryable(self) -> None:
+        resolved = resolve_exception(openai.APIConnectionError(request=_make_httpx_request()))
+        assert resolved.retryable is False
+
+    def test_network_error_is_retryable(self) -> None:
+        resolved = resolve_exception(httpx.NetworkError("reset"))
+        assert resolved.retryable is True
+        assert resolved.message.endswith(_RETRY_SENTENCE)
+
+
+class TestExtraction:
+    def test_details_carried_on_resolved_error(self) -> None:
+        e = _make_openai_status_error(
+            openai.BadRequestError,
+            400,
+            body={"error": {"code": "content_filter", "type": "invalid_request_error"}},
+        )
+        resolved = resolve_exception(e)
+        assert resolved.details.status_code == 400
+        assert resolved.details.code == "content_filter"
+        assert resolved.details.error_type == "invalid_request_error"
 
 
 class TestNoLeakage:
-    """Verify that HTTP-related exceptions never expose internal URLs or raw error text."""
+    """HTTP-related exceptions must never expose internal URLs or raw error text."""
 
     _INTERNAL_URL = "http://internal-dial-core.svc.cluster.local/api"
     _RAW_DETAIL = "raw error detail"
@@ -157,6 +299,10 @@ class TestNoLeakage:
             pytest.param(
                 _make_openai_status_error(openai.InternalServerError, 500),
                 id="openai-500",
+            ),
+            pytest.param(
+                _make_openai_api_error(body=None),
+                id="openai-stream-failure",
             ),
             pytest.param(
                 httpx.HTTPStatusError(
@@ -181,6 +327,6 @@ class TestNoLeakage:
         ],
     )
     def test_no_internal_detail_leaked(self, exc: Exception) -> None:
-        result = resolve_exception_message(exc)
+        result = _resolve(exc)
         assert self._INTERNAL_URL not in result
         assert self._RAW_DETAIL not in result

--- a/src/tests/unit_tests/application_tests/test_exception_message_resolver.py
+++ b/src/tests/unit_tests/application_tests/test_exception_message_resolver.py
@@ -189,6 +189,15 @@ class TestDisplayMessagePreference:
         assert resolved.message == "Upstream is down."
         assert not resolved.message.endswith(_RETRY_SENTENCE)
 
+    def test_whitespace_only_display_message_falls_through(self) -> None:
+        e = _make_openai_status_error(
+            openai.InternalServerError, 500, body={"error": {"display_message": "   "}}
+        )
+        resolved = resolve_exception(e)
+        # Sanitizes to nothing -> the status ladder resolves instead of an empty message.
+        assert "internal error" in resolved.message.lower()
+        assert resolved.retryable is True
+
     def test_display_message_truncated(self) -> None:
         long_text = "x" * 900
         e = _make_openai_status_error(

--- a/src/tests/unit_tests/application_tests/test_quick_app_completion_error_delivery.py
+++ b/src/tests/unit_tests/application_tests/test_quick_app_completion_error_delivery.py
@@ -43,6 +43,7 @@ class TestHandleException:
             _handle_exception(e)
         exc = excinfo.value
         assert exc.status_code == 500
+        assert exc.type == "runtime_error"
         assert exc.display_message is not None
         assert "timed out" in exc.display_message.lower()
         assert exc.display_message == exc.message
@@ -57,6 +58,8 @@ class TestHandleException:
         with pytest.raises(DialHTTPException) as excinfo:
             _handle_exception(e)
         assert excinfo.value.status_code == 400
+        # No upstream type -> the OpenAI-idiomatic default for a client-attributable 4xx.
+        assert excinfo.value.type == "invalid_request_error"
 
     def test_rate_limit_downgraded_to_500(self) -> None:
         e = openai.RateLimitError(
@@ -67,6 +70,8 @@ class TestHandleException:
         with pytest.raises(DialHTTPException) as excinfo:
             _handle_exception(e)
         assert excinfo.value.status_code == 500
+        # The default type keys on the *outgoing* (downgraded) status, not the upstream one.
+        assert excinfo.value.type == "runtime_error"
 
     def test_code_and_type_propagated_to_wire(self) -> None:
         e = openai.BadRequestError(

--- a/src/tests/unit_tests/application_tests/test_quick_app_completion_error_delivery.py
+++ b/src/tests/unit_tests/application_tests/test_quick_app_completion_error_delivery.py
@@ -1,0 +1,81 @@
+import re
+
+import httpx
+import openai
+import pytest
+from aidial_sdk.exceptions import HTTPException as DialHTTPException
+
+from quickapp.core.application._exception_message_resolver import ErrorDetails, ResolvedError
+from quickapp.core.application._quick_app_completion import (
+    _outgoing_status_code,
+    _QuickAppCompletion,
+)
+
+# The handler is a name-mangled private static method; reach it directly for unit testing.
+_handle_exception = _QuickAppCompletion._QuickAppCompletion__handle_exception  # type: ignore[attr-defined]
+
+
+def _resolved(status_code: int | None) -> ResolvedError:
+    return ResolvedError(
+        message="msg", retryable=False, details=ErrorDetails(status_code=status_code)
+    )
+
+
+class TestOutgoingStatusCode:
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 413, 422])
+    def test_client_errors_pass_through(self, status: int) -> None:
+        assert _outgoing_status_code(_resolved(status)) == status
+
+    @pytest.mark.parametrize("status", [429, 502, 503, 504])
+    def test_core_retriable_statuses_collapse_to_500(self, status: int) -> None:
+        # An application cannot be retried by Core; these would have their body discarded.
+        assert _outgoing_status_code(_resolved(status)) == 500
+
+    @pytest.mark.parametrize("status", [None, 500, 409])
+    def test_other_statuses_collapse_to_500(self, status: int | None) -> None:
+        assert _outgoing_status_code(_resolved(status)) == 500
+
+
+class TestHandleException:
+    def test_raises_dial_error_with_reference(self) -> None:
+        e = openai.APITimeoutError(request=httpx.Request("GET", "http://x/api"))
+        with pytest.raises(DialHTTPException) as excinfo:
+            _handle_exception(e)
+        exc = excinfo.value
+        assert exc.status_code == 500
+        assert exc.display_message is not None
+        assert "timed out" in exc.display_message.lower()
+        assert exc.display_message == exc.message
+        assert re.search(r"\(error reference: [0-9a-f]{8}\)$", exc.display_message)
+
+    def test_client_error_status_preserved(self) -> None:
+        e = openai.BadRequestError(
+            "bad",
+            response=httpx.Response(400, request=httpx.Request("GET", "http://x/api")),
+            body=None,
+        )
+        with pytest.raises(DialHTTPException) as excinfo:
+            _handle_exception(e)
+        assert excinfo.value.status_code == 400
+
+    def test_rate_limit_downgraded_to_500(self) -> None:
+        e = openai.RateLimitError(
+            "slow",
+            response=httpx.Response(429, request=httpx.Request("GET", "http://x/api")),
+            body=None,
+        )
+        with pytest.raises(DialHTTPException) as excinfo:
+            _handle_exception(e)
+        assert excinfo.value.status_code == 500
+
+    def test_code_and_type_propagated_to_wire(self) -> None:
+        e = openai.BadRequestError(
+            "blocked",
+            response=httpx.Response(400, request=httpx.Request("GET", "http://x/api")),
+            body={"error": {"code": "content_filter", "type": "invalid_request_error"}},
+        )
+        with pytest.raises(DialHTTPException) as excinfo:
+            _handle_exception(e)
+        exc = excinfo.value
+        assert exc.code == "content_filter"
+        assert exc.type == "invalid_request_error"


### PR DESCRIPTION
### Applicable issues

- fixes #411

### Description of changes

Reworks how Quick Apps handles a failed turn, so users get an accurate, actionable error instead of a generic
sentence disguised as a normal reply.

- **Cause resolution** — a failure is now resolved by the most specific information available: an
  upstream-authored display message first, then known error codes (content filter, context length), then
  status-class wording, with dedicated handling for mid-stream model failures. Transient causes advise a
  retry; deterministic ones give advice that actually helps.
- **Protocol delivery** — errors are delivered through the DIAL error protocol rather than appended as
  assistant content, so clients render a real error state, the text stays out of LLM history, and monitoring
  sees a failure instead of a fake success. Outgoing statuses avoid Core's retriable set so error bodies are
  never discarded.
- **Correlation** — every failure carries a short error reference echoed in the server logs, making "contact
  your administrator" traceable.

Included in this PR:

- Approved design doc [`docs/designs/error_message_resolution.md`](https://github.com/epam/ai-dial-quickapps-backend/blob/feat/411-error-message-resolution/docs/designs/error_message_resolution.md).
- The implementation in the `core/application` layer, plus stage-hygiene fixes on the orchestrator error path.
- Conceptual documentation [`docs/error_handling.md`](https://github.com/epam/ai-dial-quickapps-backend/blob/feat/411-error-message-resolution/docs/error_handling.md), linked from `docs/agent.md` and `CLAUDE.md`.
- An error-injection sample app for triggering every failure mode end-to-end in DIAL Chat.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Design documented is updated/created and approved by the team (if applicable)
- [x] Documentation is updated/created (if applicable)
- [x] Changes are tested on review environment
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no app schema changes)
- ~~[ ] Integration tests pass~~ (no changes to AI logic)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
