### PR TITLE
feat: Add script of OpenAPI spec generation (#404)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ export PYDANTIC_V2=True
 
 .PHONY: init_venv install install_dev install_integration install_all clean \
 	lint mypy format install_pre_commit_hooks run_chat test test_cov \
-	dump_app_schema dump_internal_tools generate_dial_config start_test_server stop_test_server \
+	dump_app_schema dump_internal_tools dump_config_support_openapi generate_dial_config start_test_server stop_test_server \
 	integration_test integration_test_run e2e_test run_python \
 	black black_check isort isort_check autoflake autoflake_check flake8
 
@@ -46,6 +46,7 @@ lint: install_dev
 	$(POETRY) run mypy --show-error-codes $(MYPY_DIRS)
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json --check
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_internal_tools.py docs/generated-internal-tools.json --check
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_config_support_openapi.py docs/generated-config-support-openapi.json --check
 
 mypy: install_dev
 	$(POETRY) run mypy --show-error-codes $(MYPY_DIRS)
@@ -59,6 +60,7 @@ format: install_dev
 ifeq ($(FILES), $(SRC_DIRS))
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_app_schema.py docs/generated-app-schema.json
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_internal_tools.py docs/generated-internal-tools.json
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_config_support_openapi.py docs/generated-config-support-openapi.json
 endif
 
 # --- Individual tool targets (honor FILES variable) ---
@@ -111,6 +113,9 @@ dump_app_schema: install_dev
 
 dump_internal_tools: install_dev
 	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_internal_tools.py docs/generated-internal-tools.json
+
+dump_config_support_openapi: install_dev
+	ENABLE_PREVIEW_FEATURES=true $(POETRY) run python src/scripts/dump_config_support_openapi.py docs/generated-config-support-openapi.json
 
 generate_dial_config: install_dev
 	$(POETRY) run python src/scripts/generate_dial_config.py --models \

--- a/docs/generated-config-support-openapi.json
+++ b/docs/generated-config-support-openapi.json
@@ -1,0 +1,262 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "QuickApps Configuration Support API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/v1/configuration-support/application-schema": {
+      "get": {
+        "summary": "Get App Schema",
+        "operationId": "get_app_schema_v1_configuration_support_application_schema_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/configuration-support/default-configuration": {
+      "get": {
+        "summary": "Get Default Configuration",
+        "operationId": "get_default_configuration_v1_configuration_support_default_configuration_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "additionalProperties": true,
+                  "type": "object",
+                  "title": "Response Get Default Configuration V1 Configuration Support Default Configuration Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/configuration-support/skills": {
+      "get": {
+        "summary": "Get Skills",
+        "operationId": "get_skills_v1_configuration_support_skills_get",
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "items": {
+                    "$ref": "#/components/schemas/SkillMetadata"
+                  },
+                  "type": "array",
+                  "title": "Response Get Skills V1 Configuration Support Skills Get"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v1/configuration-support/skills/validate": {
+      "post": {
+        "summary": "Validate Skill",
+        "operationId": "validate_skill_v1_configuration_support_skills_validate_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "oneOf": [
+                  {
+                    "$ref": "#/components/schemas/DialPromptSkillConfig"
+                  }
+                ],
+                "title": "Config",
+                "discriminator": {
+                  "propertyName": "type",
+                  "mapping": {
+                    "dial-prompt": "#/components/schemas/DialPromptSkillConfig"
+                  }
+                }
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/SkillMetadata"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "DialPromptSkillConfig": {
+        "properties": {
+          "type": {
+            "type": "string",
+            "const": "dial-prompt",
+            "title": "Type",
+            "description": "Skill sourced from a DIAL prompt.",
+            "default": "dial-prompt"
+          },
+          "url": {
+            "type": "string",
+            "title": "Url",
+            "description": "Relative prompt URL in DIAL (e.g. prompts/<bucket>/<path>)",
+            "dial:resource": true
+          }
+        },
+        "type": "object",
+        "required": [
+          "url"
+        ],
+        "title": "DialPromptSkillConfig"
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "SkillMetadata": {
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name"
+          },
+          "description": {
+            "type": "string",
+            "title": "Description"
+          },
+          "license": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "License"
+          },
+          "compatibility": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Compatibility"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "additionalProperties": true,
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
+          },
+          "allowed_tools": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Allowed Tools"
+          }
+        },
+        "type": "object",
+        "required": [
+          "name",
+          "description"
+        ],
+        "title": "SkillMetadata",
+        "description": "Metadata extracted from a skill file's YAML frontmatter."
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          },
+          "input": {
+            "title": "Input"
+          },
+          "ctx": {
+            "type": "object",
+            "title": "Context"
+          }
+        },
+        "type": "object",
+        "required": [
+          "loc",
+          "msg",
+          "type"
+        ],
+        "title": "ValidationError"
+      }
+    }
+  }
+}

--- a/src/quickapp/configuration_support/_controller.py
+++ b/src/quickapp/configuration_support/_controller.py
@@ -4,16 +4,10 @@ from typing import Any
 from aidial_client import AsyncDial, DialException
 from fastapi import FastAPI, HTTPException, Request, status
 from injector import inject
-from pydantic import SecretStr, ValidationError
 
 from quickapp.common.dial_settings import DialSettings
 from quickapp.config.application import ApplicationConfig
-from quickapp.config.predefined_content_provider import ContentType
 from quickapp.config.skill import DialPromptSkillConfig, SkillConfig
-from quickapp.config.tools.deployment import DialDeploymentTool
-from quickapp.config.toolsets.toolset import ToolSet
-from quickapp.config.utils import validate_toolset_dict_and_expand
-from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
 from quickapp.dial_prompt_skills._dial_prompt_skill_resolver import (
     fetch_and_validate_dial_prompt_skill,
 )
@@ -33,12 +27,10 @@ class _Controller:
     def __init__(
         self,
         config_resolver: PredefinedConfigResolver,
-        service: ToolConfigCoreService,
         skills_provider: AgentSkillsProvider,
         dial_settings: DialSettings,
     ):
         self.__config_resolver = config_resolver
-        self.__service = service
         self.__skills_provider = skills_provider
         self.__dial_settings = dial_settings
 
@@ -47,38 +39,9 @@ class _Controller:
         async def get_app_schema():
             return ApplicationConfig.model_json_schema(include_dial_fields=False)
 
-        @app.get(CONFIG_SUPPORT_URI + "/system-prompts")
-        async def get_system_prompts():
-            return self.__config_resolver.get_prompts()
-
-        @app.get(CONFIG_SUPPORT_URI + "/tool-sets")
-        async def get_tool_sets():
-            return self.__config_resolver.get_tool_sets()
-
         @app.get(CONFIG_SUPPORT_URI + "/default-configuration")
         async def get_default_configuration() -> dict[str, Any]:
             return self.__config_resolver.get_default_configuration()
-
-        @app.get(CONFIG_SUPPORT_URI + "/tools")
-        async def get_tools():
-            return self.__config_resolver.get_tools()
-
-        @app.get(CONFIG_SUPPORT_URI + "/system-prompts/{deployment_name}")
-        async def get_system_prompt_content(deployment_name: str):
-            return self._get_template_content(ContentType.PROMPT, deployment_name)
-
-        @app.get(CONFIG_SUPPORT_URI + "/tool-sets/{toolset_name}")
-        async def get_toolset_content(toolset_name: str):
-            return self._get_template_content(ContentType.TOOLSET, toolset_name)
-
-        @app.get(CONFIG_SUPPORT_URI + "/tools/{tool_name}")
-        async def get_tool_content(tool_name: str):
-            return self._get_template_content(ContentType.TOOL, tool_name)
-
-        @app.get(CONFIG_SUPPORT_URI + "/template/{deployment}", response_model=DialDeploymentTool)
-        async def get_tool_template(deployment: str, request: Request):
-            api_key = SecretStr(request.headers.get("api-key", ""))
-            return await self.__service.get_basic_tool_config(deployment, api_key)
 
         @app.get(CONFIG_SUPPORT_URI + "/skills")
         async def get_skills() -> list[SkillMetadata]:
@@ -135,42 +98,4 @@ class _Controller:
             raise HTTPException(
                 status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail=str(e),
-            )
-
-    def _get_template_content(
-        self, template_type: ContentType, template_name: str
-    ) -> str | dict[str, Any] | ToolSet:
-        templates = self.__config_resolver.template_map.get(template_type.value, [])
-        if template_name not in templates:
-            raise HTTPException(
-                status_code=status.HTTP_404_NOT_FOUND,
-                detail=f"{template_type.value.capitalize()} '{template_name}' not found.",
-            )
-        try:
-            content = self.__config_resolver.read_template_content(template_type, template_name)
-            if template_type == ContentType.TOOLSET:
-                if not isinstance(content, dict):
-                    raise HTTPException(
-                        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                        detail=f"Toolset '{template_name}' must be a JSON object.",
-                    )
-                try:
-                    return validate_toolset_dict_and_expand(
-                        content,
-                        expand_fn=self.__config_resolver.resolve_toolset,
-                    )
-                except ValidationError as e:
-                    raise HTTPException(
-                        status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
-                        detail=str(e),
-                    ) from e
-            return content
-        except FileNotFoundError as e:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
-        except HTTPException:
-            raise
-        except Exception as e:
-            raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail=f"Failed to load {template_type.value} '{template_name}': {e}",
             )

--- a/src/quickapp/predefined_tooling/_predefined_config_resolver.py
+++ b/src/quickapp/predefined_tooling/_predefined_config_resolver.py
@@ -1,10 +1,8 @@
 import logging
-from functools import cached_property
 from typing import Any
 
 from injector import ProviderOf, inject
-from pydantic import BaseModel, Field, TypeAdapter, ValidationError, model_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic import TypeAdapter, ValidationError
 
 from quickapp.common.exceptions import ConfigResolutionException
 from quickapp.config.application import ApplicationConfig
@@ -28,116 +26,6 @@ def _loc_to_json_pointer(loc: tuple[Any, ...]) -> str:
     return "/" + "/".join(str(p) for p in loc)
 
 
-class PromptConfigResponse(BaseModel):
-    prompt: str
-    allowed_models: list[str] = Field(default=[])
-
-
-class PromptMapping(BaseSettings):
-    model_config = SettingsConfigDict(env_prefix='config_')
-    prompt_mapping: dict[str, list[str]] = Field(
-        default={
-            "gpt_prompt": [
-                "gpt-5-mini-2025-08-07",
-                "gpt-4o-mini-2024-07-18",
-                "gpt-5.1-2025-11-13",
-                "gpt-4o-2024-05-13-adapter-staging",
-                "gpt-5.1-chat-2025-11-13",
-                "gpt-4o-transcribe-2025-03-20",
-                "gpt-5-2025-08-07",
-                "gpt-35-turbo",
-                "gpt-5.1-codex-2025-11-13",
-                "gpt-4o-mini-tts",
-                "gpt-4-turbo-2024-04-09",
-                "gpt-5-2025-08-07-reasoning",
-                "gpt-4o",
-                "gpt-4o-2024-05-13-adapter-prod",
-                "gpt-4o-2024-11-20",
-                "gpt-oss-120b",
-                "gpt-4o-2024-05-13",
-                "gpt-4o-2024-08-06",
-                "gpt-4o-assistants",
-                "gpt-4o-mini-2024-07-18-adapter-prod",
-                "gpt-35-turbo-0125",
-                "gpt-4.1-2025-04-14",
-                "gpt-5-2025-08-07-low-filter",
-                "gpt-4o-2024-11-20-with-caching",
-                "gpt-4o-2024-05-13-adapter-sales",
-                "gpt-35-turbo-1106",
-                "gpt-4o-mini-transcribe-2025-03-20",
-                "gpt-5-nano-2025-08-07",
-                "gpt-image-1",
-                "gpt-4.1-mini-2025-04-14",
-                "gpt-4.1-bing-grounding",
-                "gpt-4-0613-assistants",
-                "gpt-4o-bing-grounding-test",
-                "gpt-4-turbo",
-                "gpt-4o-google-dlp-interceptor",
-                "gpt-5-chat-2025-08-07",
-                "gpt-4.1-nano-2025-04-14",
-            ],
-            "gemini_prompt": [
-                "gemini-pro-vision-adapter",
-                "gemini-2.5-flash-image-preview",
-                "gemini-2.5-pro-google-search",
-                "gemini-2.0-flash-lite-001",
-                "gemini-2.5-flash",
-                "gemini-2.0-flash-exp",
-                "gemini-2.5-pro",
-                "gemini-2.5-flash-lite",
-                "gemini-2.0-flash-exp-google-search",
-            ],
-            "anthropic_prompt": [
-                "anthropic.claude-v3-haiku-interceptor",
-                "us.anthropic.claude-opus-4-1-20250805-v1:0",
-                "anthropic.claude-v3-haiku-google-dlp-interceptor",
-                "anthropic.claude",
-                "claude-haiku-4-5@20251001",
-                "anthropic.claude-v3-5-haiku",
-                "anthropic.claude-v3-haiku-us-east-1",
-                "claude-3-5-sonnet-v2@20241022",
-                "claude-3-opus@20240229",
-                "anthropic.claude-v2",
-                "anthropic.claude-v3-haiku",
-                "claude-3-7-sonnet@20250219",
-                "us.anthropic.claude-3-7-sonnet-20250219-v1-with-thinking",
-                "anthropic.claude-v3-haiku-us-west-2",
-                "anthropic.claude-v3-haiku-pii-interceptor",
-                "anthropic.claude-instant-v1",
-                "anthropic.claude-v3-5-sonnet",
-                "anthropic.claude-v3-5-sonnet-v1",
-                "anthropic.claude-v3-5-sonnet-v2",
-                "claude-3-5-haiku@20241022",
-                "anthropic.claude-v4-5-sonnet-v1",
-                "anthropic.claude-v3-haiku-bundle",
-                "anthropic.claude-haiku-4-5-20251001-v1:0",
-                "claude-3-haiku@20240307",
-                "anthropic.claude-v3-sonnet",
-                "claude-3-5-sonnet-v2@latest",
-                "claude-opus-4@20250514",
-                "claude-3-5-sonnet@20240620",
-                "anthropic.claude-opus-4-20250514-v1",
-                "anthropic.claude-v3-opus",
-                "anthropic.claude-v2-1",
-                "us.anthropic.claude-3-7-sonnet-20250219-v1",
-                "anthropic.claude-sonnet-4-20250514-v1",
-                "claude-sonnet-4@20250514",
-            ],
-        },
-        description="Mapping between predefined system_prompts and DialCore deployments",
-    )
-
-    @model_validator(mode='after')
-    def check_unique_models(self):
-        all_models = []
-        for group in self.prompt_mapping.values():
-            all_models.extend(group)
-        duplicates = {name for name in all_models if all_models.count(name) > 1}
-        if duplicates:
-            raise ValueError(f"Duplicate model/deployment names found: {duplicates}")
-        return self
-
-
 @inject
 class PredefinedConfigResolver(ConfigResolver):
     def __init__(
@@ -147,32 +35,6 @@ class PredefinedConfigResolver(ConfigResolver):
     ):
         self._provider = provider
         self._exceptions_provider = exceptions_provider
-        self.prompt_mapping = PromptMapping()
-
-    @cached_property
-    def template_map(self) -> dict[str, list[str]]:
-        """Read-only map of template type → names, excluding SKILL and default config.
-        Cached: the
-        provider loads templates once at startup, so the result is stable."""
-        return {
-            ct.value: self._provider.list_names(ct)
-            for ct in ContentType
-            if ct not in (ContentType.SKILL, ContentType.DEFAULT_CONFIGURATION)
-        }
-
-    def get_prompts(self) -> list[PromptConfigResponse]:
-        return [
-            PromptConfigResponse(
-                prompt=p, allowed_models=self.prompt_mapping.prompt_mapping.get(p, [])
-            )
-            for p in self._provider.list_names(ContentType.PROMPT)
-        ]
-
-    def get_tools(self) -> list[str]:
-        return self._provider.list_names(ContentType.TOOL)
-
-    def get_tool_sets(self) -> list[str]:
-        return self._provider.list_names(ContentType.TOOLSET)
 
     def get_default_configuration(self) -> dict[str, Any]:
         """Return merged default configuration with ``tool_sets`` fully resolved.

--- a/src/scripts/dump_config_support_openapi.py
+++ b/src/scripts/dump_config_support_openapi.py
@@ -1,0 +1,108 @@
+# CLI script that dumps the configuration-support OpenAPI spec for lint drift detection.
+#
+# Usage:
+#   python dump_config_support_openapi.py docs/generated-config-support-openapi.json
+#   python dump_config_support_openapi.py docs/generated-config-support-openapi.json --check
+
+import json
+import os
+import sys
+from pathlib import Path
+
+if __name__ == "__main__":
+    from utils import add_src_to_system_path, load_env
+
+    add_src_to_system_path()
+    load_env()
+
+from fastapi import FastAPI
+from fastapi.openapi.utils import get_openapi
+from injector import Injector
+
+from quickapp.app_factory import AppFactory
+from quickapp.configuration_support._controller import CONFIG_SUPPORT_URI, _Controller
+
+CONFIG_SUPPORT_OPENAPI_TITLE = "QuickApps Configuration Support API"
+CONFIG_SUPPORT_OPENAPI_VERSION = "1.0.0"
+
+
+def _set_env_if_empty(name: str, value: str) -> None:
+    if not os.getenv(name):
+        os.environ[name] = value
+
+
+def get_config_support_openapi_schema() -> dict:
+    _set_env_if_empty("DIAL_URL", "http://dump-config-support-openapi.invalid")
+    _set_env_if_empty("OPENAI_API_KEY", "dump-config-support-openapi")
+    _set_env_if_empty("OPENAI_ADMIN_KEY", "dump-config-support-openapi")
+
+    injector = Injector(AppFactory.build_di_modules())
+    app = injector.get(FastAPI)
+    controller = injector.get(_Controller)
+    controller.register_routes(app)
+
+    routes = [
+        route for route in app.routes if getattr(route, "path", "").startswith(CONFIG_SUPPORT_URI)
+    ]
+
+    return get_openapi(
+        title=CONFIG_SUPPORT_OPENAPI_TITLE,
+        version=CONFIG_SUPPORT_OPENAPI_VERSION,
+        routes=routes,
+    )
+
+
+def get_config_support_openapi_json() -> str:
+    schema = get_config_support_openapi_schema()
+    return json.dumps(schema, ensure_ascii=False, indent=2) + "\n"
+
+
+def dump_config_support_openapi(output_file: str) -> None:
+    generated = get_config_support_openapi_json()
+    Path(output_file).write_text(generated, encoding="utf-8")
+    print(f"Configuration support OpenAPI spec dumped to {output_file}")
+
+
+def check_config_support_openapi(output_file: str) -> None:
+    generated = get_config_support_openapi_json()
+
+    try:
+        existing = Path(output_file).read_text(encoding="utf-8")
+    except FileNotFoundError:
+        print(
+            f"ERROR: OpenAPI file '{output_file}' not found. " f"Run 'make format' to generate it."
+        )
+        sys.exit(1)
+
+    if generated != existing:
+        print(
+            f"ERROR: OpenAPI file '{output_file}' is out of date. "
+            f"Run 'make format' to regenerate it."
+        )
+        sys.exit(1)
+
+    print(f"OpenAPI file '{output_file}' is up to date.")
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Dump configuration-support OpenAPI spec to a file."
+    )
+    parser.add_argument(
+        "output_file",
+        type=str,
+        help="The output file path for the OpenAPI JSON.",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Check that the file matches the generated spec instead of overwriting.",
+    )
+    args = parser.parse_args()
+
+    if args.check:
+        check_config_support_openapi(args.output_file)
+    else:
+        dump_config_support_openapi(args.output_file)

--- a/src/tests/unit_tests/configuration_support_tests/test_controller.py
+++ b/src/tests/unit_tests/configuration_support_tests/test_controller.py
@@ -5,7 +5,6 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from quickapp.configuration_support._controller import _Controller
-from quickapp.dial_core_services.tool_config_service import ToolConfigCoreService
 from quickapp.predefined_tooling import PredefinedConfigResolver
 from quickapp.skills._skill_metadata import SkillMetadata
 from quickapp.skills.agent_skills_provider import AgentSkillsProvider
@@ -39,7 +38,6 @@ def _make_controller(
 
     return _Controller(
         config_resolver=resolver,
-        service=MagicMock(spec=ToolConfigCoreService),
         skills_provider=skills_provider,
         dial_settings=dial_settings,
     )

--- a/src/tests/unit_tests/scripts_tests/test_dump_config_support_openapi.py
+++ b/src/tests/unit_tests/scripts_tests/test_dump_config_support_openapi.py
@@ -1,0 +1,103 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from scripts.dump_config_support_openapi import (
+    check_config_support_openapi,
+    dump_config_support_openapi,
+    get_config_support_openapi_schema,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+DUMP_SCRIPT = REPO_ROOT / "src" / "scripts" / "dump_config_support_openapi.py"
+EXPECTED_OPERATIONS = {
+    ("get", "/v1/configuration-support/application-schema"),
+    ("get", "/v1/configuration-support/default-configuration"),
+    ("get", "/v1/configuration-support/skills"),
+    ("post", "/v1/configuration-support/skills/validate"),
+}
+REMOVED_PATHS = {
+    "/v1/configuration-support/system-prompts",
+    "/v1/configuration-support/tool-sets",
+    "/v1/configuration-support/tools",
+    "/v1/configuration-support/system-prompts/{deployment_name}",
+    "/v1/configuration-support/tool-sets/{toolset_name}",
+    "/v1/configuration-support/tools/{tool_name}",
+    "/v1/configuration-support/template/{deployment}",
+}
+
+
+def _operation_keys(schema: dict) -> set[tuple[str, str]]:
+    paths = schema.get("paths", {})
+    return {(method.lower(), path) for path, methods in paths.items() for method in methods}
+
+
+class TestConfigSupportOpenApiGeneration:
+    def test_generated_spec_includes_all_endpoints(self):
+        schema = get_config_support_openapi_schema()
+        operations = _operation_keys(schema)
+
+        assert operations == EXPECTED_OPERATIONS
+
+    def test_removed_endpoints_are_absent(self):
+        schema = get_config_support_openapi_schema()
+        paths = set(schema.get("paths", {}))
+
+        assert paths.isdisjoint(REMOVED_PATHS)
+
+    def test_route_filter_excludes_non_config_support_routes(self):
+        schema = get_config_support_openapi_schema()
+        paths = set(schema.get("paths", {}))
+
+        assert all(path.startswith("/v1/configuration-support") for path in paths)
+        assert "/health" not in paths
+        assert "/openapi.json" not in paths
+
+
+class TestConfigSupportOpenApiCheck:
+    def test_check_passes_on_matching_file(self, tmp_path: Path):
+        output_file = tmp_path / "openapi.json"
+        dump_config_support_openapi(str(output_file))
+
+        check_config_support_openapi(str(output_file))
+
+    def test_check_fails_on_stale_file(self, tmp_path: Path):
+        output_file = tmp_path / "openapi.json"
+        output_file.write_text('{"openapi": "3.1.0", "paths": {}}\n', encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc_info:
+            check_config_support_openapi(str(output_file))
+
+        assert exc_info.value.code == 1
+
+    def test_check_fails_when_file_missing(self, tmp_path: Path):
+        missing = tmp_path / "missing.json"
+
+        with pytest.raises(SystemExit) as exc_info:
+            check_config_support_openapi(str(missing))
+
+        assert exc_info.value.code == 1
+
+    def test_cli_check_flag(self, tmp_path: Path):
+        output_file = tmp_path / "openapi.json"
+        dump_config_support_openapi(str(output_file))
+
+        result = subprocess.run(
+            [sys.executable, str(DUMP_SCRIPT), str(output_file), "--check"],
+            cwd=REPO_ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+        assert result.returncode == 0
+        assert "up to date" in result.stdout
+
+    def test_generated_json_is_valid(self):
+        schema = get_config_support_openapi_schema()
+        serialized = json.dumps(schema)
+
+        assert json.loads(serialized)["info"]["title"] == "QuickApps Configuration Support API"


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #404 

### Description of changes

adding a committed, CI-checked OpenAPI spec for the configuration support API and trimming the endpoint surface to what the editor still uses.

Add `src/scripts/dump_config_support_openapi.py` and commit `docs/generated-config-support-openapi.json`, generated from live FastAPI routes (same drift-detection pattern as app schema / internal tools dumps)
Wire make `dump_config_support_openapi` into make format and make lint --check


Remove 7 legacy configuration-support endpoints (system-prompt/tool-set/tool listing, template content, and deployment template lookup). The removed endpoints were development for old way of quickapp creation, it is not used anymore.


Keep 5 endpoints: application-schema, default-configuration, skills, and skills/validate
Clean up unused controller/resolver code (ToolConfigCoreService wiring, PromptMapping, list helpers)
Add unit tests for the reduced API contract and OpenAPI dump --check behavior


**Breaking change**: clients calling the removed `/v1/configuration-support/*` listing/template routes will get 404. As endpoints are legacy, it's safe to remove them.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide
- [x] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
