### PR TITLE
fix: guide model toward file:url:: for internal_attachments_get_content

### DIFF
--- a/config/predefined/skills/tool-call-file-parameter-formatting/SKILL.md
+++ b/config/predefined/skills/tool-call-file-parameter-formatting/SKILL.md
@@ -22,7 +22,7 @@ Inspect the **Parameter Name** and **Parameter Description** in the tool definit
     *   *Action:* Use `base64` prefix.
 *   **Requirement: Plain Text**
     *   *Purpose:* *   *Purpose:* Use this mode to indicate the tool expects the actual text file content as the parameter. When a file is marked with the `text` prefix, the tool-call processor will read the file's contents and pass that text as the tool call parameter.
-    *   *Clues:* Description mentions "text," "string content," "read file," or the file type is code/markdown/logs.
+    *   *Clues:* Description mentions "text", "string content".
     *   *Action:* Use `text` prefix.
 *   **Requirement: URL/Path Reference**
     *   *Clues:* Parameter name contains `url`, `link`, `uri`, or description says "pass the link" or "reference."

--- a/docs/generated-internal-tools.json
+++ b/docs/generated-internal-tools.json
@@ -10,7 +10,7 @@
     "properties": {
       "attachment_url": {
         "type": "string",
-        "description": "File reference in the file:url:: form. Accepted MIME types: */*."
+        "description": "File reference using ONLY the file:url:: form, e.g. file:url::https://example.com/readme.md or file:url::files/bucket/doc.pdf. Other forms are not valid here and will be rejected. Accepted MIME types: */*."
       }
     },
     "required": [

--- a/src/quickapp/orchestrator_attachment_strategies/lazy_on_demand/_tool_configs.py
+++ b/src/quickapp/orchestrator_attachment_strategies/lazy_on_demand/_tool_configs.py
@@ -23,7 +23,10 @@ GET_CONTENT_TOOL_CONFIG = InternalTool(
                 properties={
                     "attachment_url": ConfigurableSchemaSimpleType(
                         type=JsonTypeEnum.string,
-                        description=("File reference in the file:url:: form."),
+                        description=(
+                            "File reference using ONLY the file:url:: form, e.g. "
+                            "file:url::https://example.com/readme.md or file:url::files/bucket/doc.pdf. Other forms are not valid here and will be rejected."
+                        ),
                     )
                 },
                 required=["attachment_url"],


### PR DESCRIPTION
### Applicable issues

- fixes #410

### Description of changes

`internal_attachments_get_content` resolves file references itself (external URLs get promoted to a durable DIAL file, `files/...` paths are validated directly) — it only ever expects the bare `file:url::` form for its `attachment_url` argument.

Reported in #410: when asked to read an external URL (e.g. a `README.md`), the model would sometimes call this tool with `file:text::https://...` instead of `file:url::https://...`. The generic file-argument transformer treats `text`/`base64` prefixes as "fetch and inline the content," so it fetched the URL and overwrote `attachment_url` with the fetched text — which `internal_attachments_get_content` then couldn't parse as a reference, producing a confusing "cannot read the file" failure even though the fetch had visibly succeeded in the stage.

Root cause traced to the shared `tool-call-file-parameter-formatting` skill's "Plain Text" clue — *"the file type is code/markdown/logs → use `text` prefix"* — which fires on the file's content type regardless of what the specific target tool's own parameter description actually asks for, outweighing this tool's much terser "File reference in the `file:url::` form" description.

This PR addresses the prompt-side cause with two small, description-only changes (a runtime guard in the tool itself is a possible follow-up, tracked separately in #410 if still needed):

- Tighten `attachment_url`'s own description on `internal_attachments_get_content` to state explicitly it accepts only the `file:url::` form, with concrete examples.
- Narrow the skill's "Plain Text" clue so a file being markdown/text/log content no longer nudges the model toward `file:text::` regardless of the target tool's own constraints.

Verified manually against a running instance with `lazy_on_demand` + file tools + external URL fetch enabled: the model now calls `internal_attachments_get_content` with `file:url::` directly for the repro from #410.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for this change)
- [x] Documentation is updated/created (if applicable) — the `tool-call-file-parameter-formatting` skill doc is the relevant doc here and was updated as part of this fix
- [ ] Changes are tested on review environment
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no config/manifest JSON-schema model changed — only an internal tool description string; `docs/generated-app-schema.json` is unchanged)
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
