### PR TITLE
chore: add epic issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/04_epic.yml
+++ b/.github/ISSUE_TEMPLATE/04_epic.yml
@@ -1,0 +1,41 @@
+name: "🎯 Epic"
+description: A larger initiative delivered through multiple child issues
+title: "[EPIC] "
+type: Feature
+labels: ["enhancement", "epic"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this template for initiatives too large for a single feature request.
+        Keep it conceptual — details belong in the child issues and design docs.
+  - type: textarea
+    attributes:
+      label: Goal
+      description: What outcome does this epic deliver, and why now?
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Scope — child issues
+      description: Task list of child issues in suggested delivery order. Link issues as they are filed.
+      placeholder: |
+        - [ ] #123 First increment
+        - [ ] #124 Second increment
+        - [ ] (not yet filed) Third increment
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Out of scope
+      description: Explicitly excluded work, to keep the epic bounded.
+  - type: textarea
+    attributes:
+      label: Dependencies and sequencing
+      description: >
+        External blockers (other DIAL components, upstream releases) and ordering
+        constraints between child issues.
+  - type: textarea
+    attributes:
+      label: Additional information
+      description: Links to design docs, related issues, prior discussions.


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

The repo's issue templates (bug / feature / tech debt) map one-to-one onto the org's issue types, but nothing covers multi-issue initiatives — epics end up squeezed into the feature-request form, which has no place for a child-issue list, sequencing, or external blockers.

Adds `.github/ISSUE_TEMPLATE/04_epic.yml`, a new "🎯 Epic" issue form:

- **Goal** and **Scope — child issues** (task list in suggested delivery order) as required fields; **Out of scope**, **Dependencies and sequencing**, and **Additional information** as optional ones.
- Uses `type: Feature` — the epam org defines only Task/Bug/Feature issue types — together with `enhancement` + `epic` labels.
- The `epic` label has been created in the repo, so the form applies it from day one.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for an issue-template addition)
- [x] Documentation is updated/created (if applicable)
- ~~[ ] Changes are tested on review environment~~ (not deployable — GitHub issue form only)
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no app schema changes)
- ~~[ ] Integration tests pass~~ (no runtime code touched)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
