### PR TITLE
feat: add structured JSON logging mode and deprecate LOG_FORMAT #438

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,9 @@ Controls which tool-execution stages are surfaced in the DIAL UI for each app. S
 | `DIAL_URL`                                 | —                          | Yes      | URL of the DIAL Core API                                                                                     |
 | `DIAL_API_VERSION`                         | `2025-01-01-preview`       | No       | API version for DIAL Core API                                                                                |
 | **Logging**                                |                            |          |                                                                                                              |
-| `LOG_FORMAT`                               | [see below](#log-format-configuration) | No | Custom logging format string (Python `logging` `%`-style). See [Log Format Configuration](#log-format-configuration) for the built-in default and available placeholders (including OTEL trace-correlation fields). |
-| `LOG_DATE_FORMAT`                          | `%Y-%m-%d %H:%M:%S`        | No       | `strftime`-style format for the `%(asctime)s` field                                                          |
+| `DIAL_SDK_LOG_FORMAT`                      | `text`                     | No       | Console log output format: `text` (human-readable) or `json` (escape-safe, one record per line). See [docs/logging.md](docs/logging.md). |
+| `DIAL_SDK_TEXT_LOG_FORMAT`                 | [see docs/logging.md](docs/logging.md) | No | Custom `%`-style format string for `text` output. Unset (default) keeps the built-in format with the conditional OTEL trace block. |
+| `DIAL_SDK_JSON_LOG_FORMAT`                 | [see docs/logging.md](docs/logging.md) | No | Custom template for `json` output — a JSON document whose string leaves are `%`-style format strings, values escaped via `json.dumps`. |
 | `LOG_LEVEL`                                | `INFO`                     | No       | Root logger level (all loggers except quickapp)                                                              |
 | `QUICKAPP_LOG_LEVEL`                       | `INFO`                     | No       | Log level for quickapp loggers                                                                               |
 | **Agent**                                  |                            |          |                                                                                                              |
@@ -181,6 +182,8 @@ Controls which tool-execution stages are surfaced in the DIAL UI for each app. S
 |---------------------------------|--------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------|
 | `PREDEFINED_BASE_PATH`          | `PREDEFINED_EXTRA_PATHS`                                           | If set alone, treated as a single extra layer on top of the built-in content                                                 |
 | `PY_INTERPRETER_CLIENT_TIMEOUT` | `DEFAULT_TOOL_TIMEOUT_SECONDS` or `tool_defaults.timeout_seconds`  | When set, still controls the PyInterpreter client timeout (seconds, default `60.0`), but the unified tool-timeout settings are preferred. |
+| `LOG_FORMAT`                    | `DIAL_SDK_TEXT_LOG_FORMAT` or `DIAL_SDK_LOG_FORMAT=json`           | When set, still controls the `text` output format (and wins over the replacements); a warning is emitted at startup. See [docs/logging.md](docs/logging.md). |
+| `LOG_DATE_FORMAT`               | —                                                                  | Still honored alongside `LOG_FORMAT`; going forward the timestamp format is fixed to `%Y-%m-%d %H:%M:%S` (the previous default). |
 
 **Notes:**
 
@@ -192,46 +195,8 @@ Controls which tool-execution stages are surfaced in the DIAL UI for each app. S
 
 #### Log Format Configuration
 
-`LOG_FORMAT` is a standard Python `logging` [`%`-style](https://docs.python.org/3/library/logging.html#logrecord-attributes)
-format string, rendered by uvicorn's `DefaultFormatter`. The built-in default is:
-
-```
-%(levelprefix)s | %(asctime)s | %(process)d | %(name)s | %(otel_context)s%(message)s
-```
-
-Any `LogRecord` attribute can be referenced, e.g. `%(levelprefix)s` (padded, colorized level), `%(levelname)s`,
-`%(asctime)s` (formatted via `LOG_DATE_FORMAT`), `%(process)d`, `%(name)s`, `%(message)s`.
-
-**OTEL trace correlation.** Custom formats can reference either the composite `%(otel_context)s` field or the
-individual `otel*` placeholders:
-
-| Placeholder            | Rendered value                                                                                                                                                     |
-|------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `%(otel_context)s`     | Synthesized by `OtelAwareFormatter` to a `[trace_id=… span_id=… resource.service.name=… trace_sampled=…] \| ` block when a span is active, and to an empty string otherwise. |
-| `%(otelTraceID)s`      | Active trace id (`0` when no span is in scope).                                                                                                                     |
-| `%(otelSpanID)s`       | Active span id (`0` when no span is in scope).                                                                                                                      |
-| `%(otelServiceName)s`  | Resource service name (from `OTEL_SERVICE_NAME`).                                                                                                                   |
-| `%(otelTraceSampled)s` | Whether the active trace is sampled.                                                                                                                                |
-
-The individual `otel*` placeholders are stamped by the `LoggingInstrumentor` (enabled by aidial-sdk when
-`OTEL_PYTHON_LOG_CORRELATION=true`) and only resolve while a span is in scope; otherwise they render as `0` / empty.
-Prefer `%(otel_context)s`, which collapses to nothing when no trace is present, unless you need a specific field.
-
-<details>
-<summary><strong>Example — JSON-shaped output</strong></summary>
-
-Because the value is a plain `%`-style string, you can lay the fields out as a JSON object to get one JSON line per
-log record:
-
-```bash
-LOG_FORMAT='{"level": "%(levelname)s", "time": "%(asctime)s", "pid": %(process)d, "logger": "%(name)s", "trace_id": "%(otelTraceID)s", "span_id": "%(otelSpanID)s", "message": "%(message)s"}'
-```
-
-Use `%(levelname)s` here, not `%(levelprefix)s` — the latter embeds ANSI color codes and padding. Note that field
-values are **not** JSON-escaped, so a message containing a `"`, a backslash, or a newline will produce a line that is
-not strictly valid JSON. For guaranteed-valid structured logs, plug in a dedicated JSON log formatter instead.
-
-</details>
+Moved to [docs/logging.md](docs/logging.md), which covers the text and JSON output modes, format
+customization, OTEL trace correlation, and OTLP log export.
 
 ## Local Development
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,7 @@ This folder contains technical documentation for the Quick Apps backend.
 | [ChatHub](./chathub.md)                       | Configuration guide for ChatHub variants — variant structure, authoring, and customization recipes.                                  |
 | [Error Handling](error_handling.md)           | How runtime failures become user-facing errors: resolution precedence, error-reference correlation, DIAL protocol delivery.          |
 | [File Transfer](file_transfer.md)             | How Quick Apps handles file parameters in tool calls (`file:{prefix}::` convention, preprocessing pipeline).                         |
+| [Logging](logging.md)                         | Console log configuration: levels, text and JSON output modes, OTEL trace correlation, OTLP log export.                              |
 | [Agent Skills](skills.md)                     | How to create and manage reusable agent skills (directory layout, metadata).                                                         |
 | [Time Awareness](time_awareness.md)           | How the agent knows the current time and reasons about data freshness.                                                               |
 | [Custom CA Certificates](custom_ca_certificates.md) | How to trust a private/corporate Root CA when running behind a TLS-intercepting proxy (`USE_SYSTEM_CA_CERTS`).               |

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,102 @@
+# Logging
+
+Quick Apps logs to the console (stderr) through the standard `logging` module, wired by
+`LoggingConfig` on top of [aidial-sdk's logging support](https://github.com/epam/ai-dial-sdk/blob/development/docs/logging.md):
+a single console handler lives on the root logger, and every managed logger (`quickapp`, `uvicorn*`,
+`httpx`, `httpcore`, `openai`, `aidial_sdk`) propagates to it. Everything is configured through
+environment variables.
+
+## Levels
+
+| Variable             | Default | Scope                                                                                     |
+|----------------------|---------|-------------------------------------------------------------------------------------------|
+| `LOG_LEVEL`          | `INFO`  | Root logger and managed third-party loggers (`uvicorn*`, `httpx`, `httpcore`, `openai`, `aidial_sdk`). |
+| `QUICKAPP_LOG_LEVEL` | `INFO`  | The application's own `quickapp.*` loggers.                                                |
+
+## Output format
+
+`DIAL_SDK_LOG_FORMAT` selects the console format: `text` (default, human-readable) or `json`
+(machine-readable, one record per line). The variable is shared with aidial-sdk, so the SDK's own
+early records — emitted before `LoggingConfig` runs — use the same format.
+
+### Text (default)
+
+The built-in format is rendered by `OtelAwareFormatter` (a uvicorn `DefaultFormatter` subclass):
+
+```
+%(levelprefix)s | %(asctime)s | %(process)d | %(name)s | %(otel_context)s%(message)s
+```
+
+`%(otel_context)s` is synthesized: when a trace is active it renders a
+`[trace_id=… span_id=… resource.service.name=… trace_sampled=…] | ` block, otherwise it collapses
+to nothing (see [Trace correlation](#trace-correlation)).
+
+To customize, set `DIAL_SDK_TEXT_LOG_FORMAT` to a Python `logging`
+[`%`-style](https://docs.python.org/3/library/logging.html#logrecord-attributes) format string:
+
+```sh
+DIAL_SDK_TEXT_LOG_FORMAT='%(levelprefix)s | %(asctime)s | %(name)s | %(message)s'
+```
+
+Custom formats are rendered by the SDK's text formatter, which does not synthesize
+`%(otel_context)s`. Reference the raw `otel*` fields instead — and only when tracing is guaranteed
+to be on: the text formatter has no missing-field fallback, so a format referencing an absent field
+drops the record.
+
+### JSON
+
+```sh
+DIAL_SDK_LOG_FORMAT=json
+```
+
+Each record renders as one line of valid JSON — values (including messages with quotes or newlines,
+and tracebacks) are escaped via `json.dumps`. The default template ships these fields:
+
+```json
+{"level": "INFO", "time": "2026-07-20 15:12:43", "logger": "quickapp.core.agent", "process": "42", "message": "hello", "exception": ""}
+```
+
+`exception` carries the formatted traceback for `logger.exception(...)` records and is empty
+otherwise. Any `otel*` trace fields present on the record are appended automatically.
+
+To customize, set `DIAL_SDK_JSON_LOG_FORMAT` to a JSON document whose string leaves are `%`-style
+format strings (nesting works, values are escaped):
+
+```sh
+DIAL_SDK_JSON_LOG_FORMAT='{"lvl": "%(levelname)s", "msg": "%(message)s", "err": "%(exc_text)s"}'
+```
+
+An overriding template fully replaces the default — keep a `%(exc_text)s` leaf, or tracebacks will
+be dropped from the output.
+
+### Deprecated: `LOG_FORMAT` and `LOG_DATE_FORMAT`
+
+These predate the SDK-aligned variables. They are still honored — and, when set, win over
+`DIAL_SDK_TEXT_LOG_FORMAT` so existing deployments keep their output — but a warning is emitted at
+startup and support will be removed in a future release. Setting either variable selects the legacy
+formatter path as a whole: e.g. `LOG_DATE_FORMAT` alone combines with the built-in default format,
+not with `DIAL_SDK_TEXT_LOG_FORMAT`. Don't mix old and new variables.
+
+- `LOG_FORMAT` → use `DIAL_SDK_TEXT_LOG_FORMAT` (or switch to `DIAL_SDK_LOG_FORMAT=json`).
+- `LOG_DATE_FORMAT` → no successor; the timestamp format is fixed to `%Y-%m-%d %H:%M:%S` (the
+  previous default) going forward.
+
+## Trace correlation
+
+When tracing is enabled (`OTEL_TRACES_EXPORTER=otlp` with a reachable
+`OTEL_EXPORTER_OTLP_ENDPOINT`), OpenTelemetry's logging instrumentor stamps `otelTraceID`,
+`otelSpanID`, `otelServiceName`, and `otelTraceSampled` onto every record. The default text format
+renders them through the conditional `%(otel_context)s` block; JSON output appends them
+automatically.
+
+> [!WARNING]
+> `OTEL_PYTHON_LOG_CORRELATION=true` is deprecated by aidial-sdk: it double-logs SDK records and
+> suppresses the console handler this service installs, so none of the formatting above applies.
+> Remove it from deployments — trace fields are injected whenever tracing is on.
+
+## OTLP log export
+
+With `OTEL_LOGS_EXPORTER=otlp`, aidial-sdk attaches an OTLP export handler to the root logger.
+Because every managed logger propagates to root, the exported records match the console output
+record-for-record. Console formatting does not apply to exported records — they travel as
+structured attributes.

--- a/src/quickapp/config/logging_config.py
+++ b/src/quickapp/config/logging_config.py
@@ -1,17 +1,18 @@
 import logging
-import logging.config
 
-# aidial_sdk configures its own loggers at import time (configure_sdk_logger()
-# in aidial_sdk/application.py), giving aidial_sdk and uvicorn private handlers
-# and setting uvicorn to propagate=False. Importing it here guarantees that
-# side effect lands before our dictConfig below, so LoggingConfig always has
-# the last word regardless of the caller's import order.
-import aidial_sdk  # noqa: F401
+# Importing from aidial_sdk triggers configure_sdk_logger() (application.py),
+# which gives aidial_sdk and uvicorn private handlers and sets uvicorn to
+# propagate=False. LoggingConfig undoes both below, so it always has the last
+# word regardless of the caller's import order.
+from aidial_sdk import LogConfig, configure_root_logger
 
+from quickapp.config._otel_aware_formatter import OtelAwareFormatter
 from quickapp.config.logging_settings import LoggingSettings
 
+logger = logging.getLogger(__name__)
+
 # Loggers whose levels LoggingConfig pins explicitly. They carry no handlers of
-# their own and propagate to the root logger, which owns the single "console"
+# their own and propagate to the root logger, which owns the single console
 # handler — and, when OTEL_LOGS_EXPORTER is set, the OTLP export handler that
 # aidial-sdk attaches to root. Exposed so tests can snapshot/restore identical
 # state.
@@ -27,57 +28,102 @@ MANAGED_LOGGER_NAMES: tuple[str, ...] = (
 )
 
 
+class _ExcTextBlankingFormatter(logging.Formatter):
+    """Blank exc_text on records without an exception before JSON rendering.
+
+    LogRecord initializes exc_text to None and the SDK JSON formatter
+    interpolates %(exc_text)s with str() semantics, so plain records would
+    render '"exception": "None"'. Exception records are unaffected: the inner
+    formatter fills exc_text from exc_info whenever it is falsy.
+    """
+
+    def __init__(self, inner: logging.Formatter) -> None:
+        super().__init__()
+        self._inner = inner
+
+    def format(self, record: logging.LogRecord) -> str:
+        if record.exc_text is None:
+            record.exc_text = ""
+        return self._inner.format(record)
+
+
 class LoggingConfig:
+    """Route all logging through one console handler on the root logger.
+
+    The handler and format selection belong to aidial-sdk's
+    configure_root_logger(): DIAL_SDK_LOG_FORMAT=json selects the SDK's
+    escape-safe JSON formatter (template via DIAL_SDK_JSON_LOG_FORMAT, otel*
+    trace fields auto-added), text selects a %-style format via
+    DIAL_SDK_TEXT_LOG_FORMAT. When no text format is requested through the
+    SDK vars, the SDK formatter is replaced with OtelAwareFormatter and this
+    service's default format — the SDK text formatter cannot render the
+    conditional %(otel_context)s trace block. The deprecated LOG_FORMAT /
+    LOG_DATE_FORMAT vars still feed that formatter when set, and win, so
+    existing deployments keep their output while the startup warning nudges
+    them to migrate.
+
+    Level pinning stays local: configure_root_logger() deliberately leaves
+    per-logger levels to the application.
+    """
+
     def __init__(self, settings: LoggingSettings) -> None:
         self._settings = settings
-        logging.config.dictConfig(self._get_logging_config())
+        # configure_root_logger drops competing stderr console handlers and
+        # installs its own, but leaves non-console handlers alone — the OTLP
+        # LoggingHandler that aidial-sdk attaches to root during DIALApp
+        # construction survives whether it is added before or after this call.
+        # Caveat: with the deprecated OTEL_PYTHON_LOG_CORRELATION=true set, the
+        # SDK defers the console to OTEL's own handler and none of the
+        # formatting below applies — drop that variable from deployments.
+        configure_root_logger(self._build_log_config())
+        self._pin_logger_levels()
+        self._warn_deprecated_vars()
 
-    def _formatter_kwargs(self) -> dict:
-        return {
-            "fmt": self._settings.log_format,
-            "datefmt": self._settings.log_date_format,
-            "use_colors": True,
-        }
+    def _build_log_config(self) -> LogConfig:
+        settings = self._settings
+        # The format values are passed through from settings so the SDK's own
+        # env fallbacks never fire — LoggingSettings is the single reader.
+        # (LogConfig.level still resolves from DIAL_SDK_LOG, but the result is
+        # overridden by _pin_logger_levels.)
+        config = LogConfig(
+            log_format=settings.log_output_format,
+            text_format=settings.text_log_format,
+            json_format=settings.json_log_format,
+        )
+        if settings.log_output_format == "json":
+            config.formatter = _ExcTextBlankingFormatter(config.formatter)
+        elif settings.text_log_format is None or settings.deprecated_format_vars_set:
+            config.formatter = OtelAwareFormatter(
+                fmt=settings.log_format,
+                datefmt=settings.log_date_format,
+                use_colors=True,
+            )
+        return config
 
-    def _get_logging_config(self) -> dict:
-        per_logger_config = {
-            name: {
-                "handlers": [],
-                "level": (
-                    self._settings.quickapp_log_level
-                    if name == "quickapp"
-                    else self._settings.log_level
-                ),
-                # Must stay explicit: dictConfig leaves `propagate` untouched
-                # when the key is absent, and the uvicorn CLI's default config
-                # (applied before ours in production) sets it to False —
-                # which would cut these loggers off from root and OTLP export.
-                "propagate": True,
-            }
-            for name in MANAGED_LOGGER_NAMES
-        }
-        return {
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {
-                "default": {
-                    "()": "quickapp.config._otel_aware_formatter.OtelAwareFormatter",
-                    **self._formatter_kwargs(),
-                },
-            },
-            "handlers": {
-                "console": {
-                    "class": "logging.StreamHandler",
-                    "formatter": "default",
-                },
-            },
-            # dictConfig strips any existing root handlers, and aidial-sdk
-            # appends its OTLP LoggingHandler to root during DIALApp
-            # construction — LoggingConfig must therefore run before the app
-            # is built.
-            "root": {
-                "handlers": ["console"],
-                "level": self._settings.log_level,
-            },
-            "loggers": per_logger_config,
-        }
+    def _pin_logger_levels(self) -> None:
+        logging.getLogger().setLevel(self._settings.log_level)
+        for name in MANAGED_LOGGER_NAMES:
+            managed = logging.getLogger(name)
+            # configure_root_logger already resets its own four names
+            # (aidial_sdk, uvicorn*); the explicit reset here covers the rest
+            # against the uvicorn CLI's default config (applied before ours in
+            # production), which attaches handlers and sets propagate=False —
+            # cutting loggers off from root, its console handler, and OTLP
+            # export. Kept uniform across all managed names for simplicity.
+            managed.handlers = []
+            managed.propagate = True
+            managed.setLevel(
+                self._settings.quickapp_log_level
+                if name == "quickapp"
+                else self._settings.log_level
+            )
+
+    def _warn_deprecated_vars(self) -> None:
+        deprecated = self._settings.deprecated_format_vars_set
+        if deprecated:
+            logger.warning(
+                "%s deprecated and will be removed in a future release; "
+                "use DIAL_SDK_TEXT_LOG_FORMAT or DIAL_SDK_LOG_FORMAT=json "
+                "instead (see docs/logging.md).",
+                " and ".join(deprecated),
+            )

--- a/src/quickapp/config/logging_settings.py
+++ b/src/quickapp/config/logging_settings.py
@@ -1,12 +1,29 @@
-import logging
+from typing import Any, Literal
 
-from pydantic import Field
+from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
-
-logger = logging.getLogger(__name__)
 
 _DEFAULT_LOG_FORMAT = "%(levelprefix)s | %(asctime)s | %(process)d | %(name)s | %(otel_context)s%(message)s"  # noqa: E501
 _DEFAULT_LOG_DATE_FORMAT = "%Y-%m-%d %H:%M:%S"
+
+# The aidial-sdk 0.38 default template plus an "exception" leaf: the SDK
+# renders only the fields the template references, so without it
+# logger.exception() tracebacks would be silently dropped from JSON output.
+# Pinned deliberately (not derived from the SDK constant): this is the
+# service's documented output contract and must not drift with SDK defaults.
+_DEFAULT_JSON_LOG_FORMAT: dict[str, Any] = {
+    "level": "%(levelname)s",
+    "time": "%(asctime)s",
+    "logger": "%(name)s",
+    "process": "%(process)d",
+    "message": "%(message)s",
+    "exception": "%(exc_text)s",
+}
+
+# Fields whose env vars are deprecated. Still honored (and they win over the
+# DIAL_SDK_* successors) so existing deployments keep their output, but
+# LoggingConfig warns at startup; support will be removed in a future release.
+_DEPRECATED_FIELDS: tuple[str, ...] = ("log_format", "log_date_format")
 
 
 class LoggingSettings(BaseSettings):
@@ -14,7 +31,32 @@ class LoggingSettings(BaseSettings):
 
     model_config = SettingsConfigDict()
 
+    # Deprecated: use DIAL_SDK_TEXT_LOG_FORMAT / DIAL_SDK_LOG_FORMAT=json.
     log_format: str = Field(default=_DEFAULT_LOG_FORMAT, alias="LOG_FORMAT")
+    # Deprecated: the date format is fixed to the default going forward.
     log_date_format: str = Field(default=_DEFAULT_LOG_DATE_FORMAT, alias="LOG_DATE_FORMAT")
     log_level: str = Field(default="INFO", alias="LOG_LEVEL")
     quickapp_log_level: str = Field(default="INFO", alias="QUICKAPP_LOG_LEVEL")
+    # The DIAL_SDK_* vars are shared with aidial-sdk: the SDK reads them for
+    # its own loggers at import time, LoggingConfig reads them here to shape
+    # the root console handler — one switch flips both.
+    log_output_format: Literal["text", "json"] = Field(default="text", alias="DIAL_SDK_LOG_FORMAT")
+    text_log_format: str | None = Field(default=None, alias="DIAL_SDK_TEXT_LOG_FORMAT")
+    json_log_format: dict[str, Any] = Field(
+        default=_DEFAULT_JSON_LOG_FORMAT, alias="DIAL_SDK_JSON_LOG_FORMAT"
+    )
+
+    @field_validator("log_output_format", mode="before")
+    @classmethod
+    def _lowercase_output_format(cls, value: object) -> object:
+        return value.lower() if isinstance(value, str) else value
+
+    @property
+    def deprecated_format_vars_set(self) -> tuple[str, ...]:
+        """Names of deprecated logging env vars present in the environment."""
+        return tuple(
+            alias
+            for field in _DEPRECATED_FIELDS
+            if (alias := type(self).model_fields[field].alias) is not None
+            and field in self.model_fields_set
+        )

--- a/src/tests/unit_tests/config_tests/test_logging_config.py
+++ b/src/tests/unit_tests/config_tests/test_logging_config.py
@@ -1,9 +1,11 @@
 import io
+import json
 import logging
 import re
 
 import pytest
 import uvicorn.logging
+from pydantic import ValidationError
 
 from quickapp.config._otel_aware_formatter import OtelAwareFormatter
 from quickapp.config.logging_config import MANAGED_LOGGER_NAMES, LoggingConfig
@@ -31,6 +33,42 @@ def _build_formatter() -> OtelAwareFormatter:
     )
 
 
+def _root_console_handler() -> logging.StreamHandler:
+    # configure_root_logger appends its console handler last; handlers pytest
+    # installs on root (non-stderr capture streams) survive in front of it.
+    handler = logging.getLogger().handlers[-1]
+    assert isinstance(handler, logging.StreamHandler)
+    return handler
+
+
+_ANSI_ESCAPE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _emit_and_capture(message: str) -> str:
+    """Log through the console handler into a buffer; return it ANSI-stripped."""
+    handler = _root_console_handler()
+    buf = io.StringIO()
+    handler.stream = buf
+    logging.getLogger("quickapp.x").info(message)
+    return _ANSI_ESCAPE.sub("", buf.getvalue())
+
+
+def _stamp_otel_fields_on_records(**fields: object) -> None:
+    """Install a record factory stamping otel* fields on every record.
+
+    No manual restore needed — reset_logging_state restores the factory.
+    """
+    original_factory = logging.getLogRecordFactory()
+
+    def factory(*args, **kwargs):
+        record = original_factory(*args, **kwargs)
+        for key, value in fields.items():
+            setattr(record, key, value)
+        return record
+
+    logging.setLogRecordFactory(factory)
+
+
 class _RecordingHandler(logging.Handler):
     def __init__(self) -> None:
         super().__init__()
@@ -41,6 +79,14 @@ class _RecordingHandler(logging.Handler):
 
 
 _TOUCHED_LOGGERS = ("", *MANAGED_LOGGER_NAMES)
+
+
+@pytest.fixture
+def no_format_env(monkeypatch):
+    """Clear the whole LoggingSettings env surface so tests exercise defaults."""
+    for field_info in LoggingSettings.model_fields.values():
+        if field_info.alias:
+            monkeypatch.delenv(field_info.alias, raising=False)
 
 
 @pytest.fixture
@@ -73,6 +119,14 @@ def reset_logging_state():
         logger.setLevel(level)
         logger.propagate = propagate
         logger.filters = filters
+
+
+@pytest.fixture
+def json_env(monkeypatch, no_format_env, reset_logging_state):
+    """Clean env with DIAL_SDK_LOG_FORMAT=json. Tests construct LoggingConfig
+    themselves: the console handler binds sys.stderr by value, so it must run
+    while the test's capsys capture is active, not during fixture setup."""
+    monkeypatch.setenv("DIAL_SDK_LOG_FORMAT", "json")
 
 
 class TestOtelAwareFormatter:
@@ -129,21 +183,13 @@ class TestLoggingConfigFormat:
     def test_default_format_renders_with_simulated_otel_record(self, capsys, reset_logging_state):
         LoggingConfig(LoggingSettings())
 
-        original_factory = logging.getLogRecordFactory()
-
-        def factory(*args, **kwargs):
-            record = original_factory(*args, **kwargs)
-            record.otelTraceID = "3fdd3958e0a9ed92c563f5af15009c15"
-            record.otelSpanID = "4cc359214676ab9a"
-            record.otelServiceName = "quickapps2"
-            record.otelTraceSampled = True
-            return record
-
-        logging.setLogRecordFactory(factory)
-        try:
-            logging.getLogger("quickapp.x").info("with-trace")
-        finally:
-            logging.setLogRecordFactory(original_factory)
+        _stamp_otel_fields_on_records(
+            otelTraceID="3fdd3958e0a9ed92c563f5af15009c15",
+            otelSpanID="4cc359214676ab9a",
+            otelServiceName="quickapps2",
+            otelTraceSampled=True,
+        )
+        logging.getLogger("quickapp.x").info("with-trace")
 
         captured = capsys.readouterr().err
         assert "trace_id=3fdd3958e0a9ed92c563f5af15009c15" in captured
@@ -155,21 +201,14 @@ class TestLoggingConfigFormat:
     def test_levelprefix_is_rendered(self, reset_logging_state):
         LoggingConfig(LoggingSettings())
 
-        # The shared "console" handler lives on the root logger only; managed
+        # The shared console handler lives on the root logger only; managed
         # loggers propagate to it.
-        handler = logging.getLogger().handlers[0]
-        assert isinstance(handler, logging.StreamHandler)
+        handler = _root_console_handler()
         assert isinstance(handler.formatter, OtelAwareFormatter)
         assert isinstance(handler.formatter, uvicorn.logging.DefaultFormatter)
 
-        buf = io.StringIO()
-        handler.stream = buf
-        logging.getLogger("quickapp.x").info("level-test")
-        output = buf.getvalue()
-
         # `%(levelprefix)s` produces "INFO:    " (with optional ANSI colour wrap).
-        # Strip ANSI escape sequences before asserting.
-        plain = re.sub(r"\x1b\[[0-9;]*m", "", output)
+        plain = _emit_and_capture("level-test")
         assert plain.lstrip().startswith("INFO:")
 
     def test_log_date_format_override(self, monkeypatch, reset_logging_state):
@@ -180,13 +219,7 @@ class TestLoggingConfigFormat:
 
         LoggingConfig(settings)
 
-        handler = logging.getLogger().handlers[0]
-        assert isinstance(handler, logging.StreamHandler)
-        buf = io.StringIO()
-        handler.stream = buf
-        logging.getLogger("quickapp.x").info("date-test")
-
-        plain = re.sub(r"\x1b\[[0-9;]*m", "", buf.getvalue())
+        plain = _emit_and_capture("date-test")
         # The pipe-separated layout puts the timestamp in the second field.
         fields = [f.strip() for f in plain.split("|")]
         assert re.fullmatch(r"\d{2}:\d{2}", fields[1])
@@ -258,3 +291,131 @@ class TestRecordRouting:
         logging.getLogger("quickapp.x").debug("filtered-out")
 
         assert recorder.records == []
+
+
+class TestJsonOutputMode:
+    def test_emits_escape_safe_single_line(self, json_env, capsys):
+        LoggingConfig(LoggingSettings())
+
+        logging.getLogger("quickapp.x").info('has "quotes" and\na newline')
+
+        err = capsys.readouterr().err
+        assert err.count("\n") == 1
+        payload = json.loads(err)
+        assert payload["message"] == 'has "quotes" and\na newline'
+        assert payload["logger"] == "quickapp.x"
+        assert payload["level"] == "INFO"
+
+    def test_exception_records_carry_traceback(self, json_env, capsys):
+        LoggingConfig(LoggingSettings())
+
+        try:
+            raise ValueError("kaboom")
+        except ValueError:
+            logging.getLogger("quickapp.x").exception("op failed")
+
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["message"] == "op failed"
+        assert "Traceback" in payload["exception"]
+        assert "ValueError: kaboom" in payload["exception"]
+
+    def test_plain_records_render_empty_exception(self, json_env, capsys):
+        LoggingConfig(LoggingSettings())
+
+        logging.getLogger("quickapp.x").info("no-error")
+
+        payload = json.loads(capsys.readouterr().err)
+        # Not the literal "None" that %(exc_text)s would render by default.
+        assert payload["exception"] == ""
+
+    def test_otel_fields_are_auto_added(self, json_env, capsys):
+        LoggingConfig(LoggingSettings())
+
+        _stamp_otel_fields_on_records(otelTraceID="3fdd3958e0a9ed92c563f5af15009c15")
+        logging.getLogger("quickapp.x").info("with-trace")
+
+        payload = json.loads(capsys.readouterr().err)
+        assert payload["otelTraceID"] == "3fdd3958e0a9ed92c563f5af15009c15"
+
+    def test_template_override_via_env(self, json_env, monkeypatch, capsys):
+        monkeypatch.setenv(
+            "DIAL_SDK_JSON_LOG_FORMAT", '{"lvl": "%(levelname)s", "msg": "%(message)s"}'
+        )
+        LoggingConfig(LoggingSettings())
+
+        logging.getLogger("quickapp.x").info("templated")
+
+        payload = json.loads(capsys.readouterr().err)
+        assert payload == {"lvl": "INFO", "msg": "templated"}
+
+
+class TestTextFormatSelection:
+    def test_sdk_text_format_is_honored(self, monkeypatch, no_format_env, reset_logging_state):
+        monkeypatch.setenv("DIAL_SDK_TEXT_LOG_FORMAT", "%(levelname)s :: %(message)s")
+        LoggingConfig(LoggingSettings())
+
+        # The SDK-built formatter, not the OtelAwareFormatter override.
+        handler = _root_console_handler()
+        assert isinstance(handler.formatter, uvicorn.logging.DefaultFormatter)
+        assert not isinstance(handler.formatter, OtelAwareFormatter)
+
+        assert _emit_and_capture("sdk-text").strip() == "INFO :: sdk-text"
+
+    def test_deprecated_log_format_wins_over_sdk_text_format(
+        self, monkeypatch, no_format_env, reset_logging_state
+    ):
+        monkeypatch.setenv("LOG_FORMAT", "%(message)s !!")
+        monkeypatch.setenv("DIAL_SDK_TEXT_LOG_FORMAT", "%(levelname)s :: %(message)s")
+        LoggingConfig(LoggingSettings())
+
+        assert isinstance(_root_console_handler().formatter, OtelAwareFormatter)
+        assert _emit_and_capture("legacy-wins").strip() == "legacy-wins !!"
+
+    def test_deprecated_vars_warn_at_startup(
+        self, monkeypatch, capsys, no_format_env, reset_logging_state
+    ):
+        monkeypatch.setenv("LOG_DATE_FORMAT", "%H:%M")
+
+        LoggingConfig(LoggingSettings())
+
+        err = capsys.readouterr().err
+        assert "LOG_DATE_FORMAT deprecated" in err
+        assert "DIAL_SDK_TEXT_LOG_FORMAT" in err
+
+    def test_no_deprecation_warning_by_default(self, capsys, no_format_env, reset_logging_state):
+        LoggingConfig(LoggingSettings())
+
+        assert "deprecated" not in capsys.readouterr().err
+
+
+class TestLoggingSettings:
+    def test_output_format_is_case_insensitive(self, monkeypatch, no_format_env):
+        monkeypatch.setenv("DIAL_SDK_LOG_FORMAT", "JSON")
+
+        assert LoggingSettings().log_output_format == "json"
+
+    def test_invalid_output_format_is_rejected(self, monkeypatch, no_format_env):
+        monkeypatch.setenv("DIAL_SDK_LOG_FORMAT", "yaml")
+
+        with pytest.raises(ValidationError):
+            LoggingSettings()
+
+    def test_json_template_is_parsed_from_env(self, monkeypatch, no_format_env):
+        monkeypatch.setenv("DIAL_SDK_JSON_LOG_FORMAT", '{"m": "%(message)s"}')
+
+        assert LoggingSettings().json_log_format == {"m": "%(message)s"}
+
+    def test_default_json_template_keeps_tracebacks(self, no_format_env):
+        assert LoggingSettings().json_log_format["exception"] == "%(exc_text)s"
+
+    def test_deprecated_vars_are_detected(self, monkeypatch, no_format_env):
+        monkeypatch.setenv("LOG_FORMAT", "%(message)s")
+        monkeypatch.setenv("LOG_DATE_FORMAT", "%H:%M")
+
+        assert LoggingSettings().deprecated_format_vars_set == (
+            "LOG_FORMAT",
+            "LOG_DATE_FORMAT",
+        )
+
+    def test_no_deprecated_vars_by_default(self, no_format_env):
+        assert LoggingSettings().deprecated_format_vars_set == ()


### PR DESCRIPTION
### Applicable issues

- fixes #438 (part of #441)

### Description of changes

The only JSON option so far was a JSON-shaped `LOG_FORMAT` string that broke on quotes, newlines, and tracebacks — exactly the records that matter during an incident. aidial-sdk 0.38 ships structured logging upstream (epam/ai-dial-sdk#416), so this PR adopts it instead of building a local formatter:

- **JSON mode**: `DIAL_SDK_LOG_FORMAT=json` selects the SDK's escape-safe, one-record-per-line output; `DIAL_SDK_JSON_LOG_FORMAT` overrides the template; `otel*` trace fields are auto-added. The shipped default template extends the SDK's with an `exception` leaf (the SDK default silently drops `logger.exception()` tracebacks), and a small wrapper formatter keeps plain records from rendering the literal `"None"` there.
- **Handler ownership moves to the SDK**: `LoggingConfig` calls `configure_root_logger()` and keeps only per-logger level pinning. The OTLP export path (#433) is unaffected — covered by the existing routing tests.
- **Text mode unchanged by default**: the built-in format still renders through `OtelAwareFormatter` (conditional trace block); `DIAL_SDK_TEXT_LOG_FORMAT` is the supported customization knob.
- **Deprecations**: `LOG_FORMAT` / `LOG_DATE_FORMAT` are still honored (and win) but warn at startup; removal in a future release. Field naming of the JSON template becomes the contract for the request-context fields (#439).
- **Docs**: consolidated into `docs/logging.md`; README's Log Format section now points there.

Deployment note: `OTEL_PYTHON_LOG_CORRELATION=true` (set in some helm values) is deprecated by the SDK — it double-logs and bypasses the console formatting; it should be removed from deployments when this rolls out. Trace correlation now follows tracing itself.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (adoption of upstream SDK feature; #438 carries the re-scoped design)
- [x] Documentation is updated/created (if applicable)
- ~~[ ] Changes are tested on review environment~~
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no schema changes)
- ~~[ ] Integration tests pass~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
