### PR TITLE
feat: report token usage in the chat-completion response

### DIFF
--- a/src/quickapp/core/agent/_chat_completion_config_builder.py
+++ b/src/quickapp/core/agent/_chat_completion_config_builder.py
@@ -9,7 +9,6 @@ from injector import inject
 from quickapp.common import RESPONSE_FORMAT, ForwardedHeaders
 from quickapp.common.abstract.base_transformer import PreInvocationTransformer
 from quickapp.common.payload_logging import log_payload, payloads_enabled, summarize_roles
-from quickapp.common.presentation_settings import PresentationSettings
 from quickapp.config.application import ApplicationConfig
 from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
 from quickapp.core.agent.models import STATE_KEY_ORCHESTRATOR, OpenAiToolConfigDict
@@ -26,7 +25,6 @@ class _ChatCompletionConfigBuilder:
         response_format: RESPONSE_FORMAT,
         tool_choice_holder: _ToolChoiceHolder,
         pre_invocation_transformers: list[PreInvocationTransformer],
-        presentation_settings: PresentationSettings,
         forwarded_headers: ForwardedHeaders,
     ) -> None:
         self.__config: ApplicationConfig = config
@@ -34,7 +32,6 @@ class _ChatCompletionConfigBuilder:
         self.__response_format = response_format
         self.__tool_choice_holder = tool_choice_holder
         self.__pre_invocation_transformers = pre_invocation_transformers
-        self.__presentation_settings = presentation_settings
         self.__forwarded_headers = forwarded_headers
 
     def build(self, messages: list[Message]) -> dict[str, Any]:
@@ -66,8 +63,10 @@ class _ChatCompletionConfigBuilder:
 
         self._apply_tool_choice(payload)
 
-        if self.__presentation_settings.show_usage_statistics:
-            payload["stream_options"] = {"include_usage": True}
+        # Always request usage from the orchestrator model so the app can report an
+        # accurate top-level ``usage`` regardless of whether the Usage Statistics
+        # stage (a separate presentation opt-in) is shown.
+        payload["stream_options"] = {"include_usage": True}
 
         if self.__forwarded_headers:
             payload["extra_headers"] = self.__forwarded_headers

--- a/src/quickapp/core/agent/orchestrator.py
+++ b/src/quickapp/core/agent/orchestrator.py
@@ -118,6 +118,35 @@ class Orchestrator:
         """``completed`` or ``external_tool_calls`` — how the loop terminated."""
         return self.__completion_kind
 
+    @property
+    def total_usage(self) -> DeploymentUsage | None:
+        """Aggregated token usage for the whole turn — orchestrator LLM calls plus
+        every tool sub-call. ``None`` when no upstream usage was reported."""
+        if not self.__usage_statistics_list:
+            return None
+        return DeploymentUsage(
+            prompt_tokens=sum(u.prompt_tokens for u in self.__usage_statistics_list),
+            completion_tokens=sum(u.completion_tokens for u in self.__usage_statistics_list),
+        )
+
+    @property
+    def usage_per_model(self) -> list[DeploymentUsage]:
+        """Per-model token usage aggregated across the turn (orchestrator plus tool
+        sub-calls), one entry per distinct model. Empty when no usage was reported."""
+        aggregated: dict[str, DeploymentUsage] = {}
+        for usage in self.__usage_statistics_list:
+            existing = aggregated.get(usage.model_name)
+            if existing is None:
+                aggregated[usage.model_name] = DeploymentUsage(
+                    model_name=usage.model_name,
+                    prompt_tokens=usage.prompt_tokens,
+                    completion_tokens=usage.completion_tokens,
+                )
+            else:
+                existing.prompt_tokens += usage.prompt_tokens
+                existing.completion_tokens += usage.completion_tokens
+        return list(aggregated.values())
+
     @asynccontextmanager
     async def _persisting_state(self) -> AsyncIterator[None]:
         exc_to_reraise: BaseException | None = None
@@ -209,7 +238,7 @@ class Orchestrator:
             )
         )
 
-        if stream_result.usage and self.__SHOW_USAGE_STATISTICS:
+        if stream_result.usage:
             self.__usage_statistics_list.append(
                 DeploymentUsage(
                     model_name=self.__orchestrator_deployment_name,
@@ -266,7 +295,7 @@ class Orchestrator:
                         continue
                     self.__propagated_attachment_urls.add(url)
                 self.__choice.add_attachment(**attachment.model_dump(exclude={"index"}))
-            if tool_call_result.usage and self.__SHOW_USAGE_STATISTICS:
+            if tool_call_result.usage:
                 self.__usage_statistics_list.extend(tool_call_result.usage)
 
     def _surface_external_tool_calls(

--- a/src/quickapp/core/application/_quick_app_completion.py
+++ b/src/quickapp/core/application/_quick_app_completion.py
@@ -112,6 +112,20 @@ class _QuickAppCompletion(ChatCompletion):
                         error_reference=error_reference,
                     )
                 )
+
+                # Report the turn's aggregated token usage (orchestrator LLM calls plus
+                # every tool sub-call) as the standard top-level ``usage`` field. Only on
+                # the success path — an error response carries no meaningful usage.
+                if not failed and agent_invoker is not None:
+                    total_usage = agent_invoker.total_usage
+                    if total_usage is not None:
+                        response.set_usage(total_usage.prompt_tokens, total_usage.completion_tokens)
+                    for model_usage in agent_invoker.usage_per_model:
+                        response.add_usage_per_model(
+                            model_usage.model_name,
+                            model_usage.prompt_tokens,
+                            model_usage.completion_tokens,
+                        )
                 # Skip the execution-time stage when an error is propagating, so no
                 # spurious stage trails the delivered error.
                 if not failed and self.__presentation_settings.show_execution_time_stage:

--- a/src/tests/unit_tests/agent_tests/test_assistant_invoker.py
+++ b/src/tests/unit_tests/agent_tests/test_assistant_invoker.py
@@ -12,10 +12,6 @@ from quickapp.core.agent._chat_completion_config_builder import _ChatCompletionC
 from quickapp.core.agent._tool_choice_holder import _ToolChoiceHolder
 
 
-def _presentation_settings(show_usage: bool):
-    return SimpleNamespace(show_usage_statistics=show_usage)
-
-
 class FakeMessage:
     def __init__(self, content: str):
         self.content = content
@@ -56,7 +52,6 @@ def _make_config_builder(
     *,
     config: DummyConfig | None = None,
     tools: list | None = None,
-    show_usage: bool = False,
     forwarded_headers=None,
     response_format=None,
     tool_choice=None,
@@ -67,7 +62,6 @@ def _make_config_builder(
         response_format=response_format,
         tool_choice_holder=_ToolChoiceHolder(tool_choice=tool_choice),
         pre_invocation_transformers=[mock_filter],
-        presentation_settings=_presentation_settings(show_usage),
         forwarded_headers=forwarded_headers,
     )
 
@@ -92,7 +86,6 @@ def _make_invoker(
     messages,
     azure_client,
     tools: list | None = None,
-    show_usage: bool = False,
     chat_completion_recovery_policies=None,
     deferred_stage_close_registry=None,
     chat_completion_recovery: ChatCompletionRecoveryService | None = None,
@@ -101,8 +94,7 @@ def _make_invoker(
     return AssistantInvoker(
         messages=messages,
         azure_client=azure_client,
-        chat_completion_config_builder=config_builder
-        or _make_config_builder(tools=tools, show_usage=show_usage),
+        chat_completion_config_builder=config_builder or _make_config_builder(tools=tools),
         chat_completion_recovery=chat_completion_recovery
         or _make_recovery_service(
             messages,
@@ -113,7 +105,9 @@ def _make_invoker(
 
 
 @pytest.mark.asyncio
-async def test_invoke_without_show_usage():
+async def test_invoke_always_requests_usage():
+    # Usage is now requested unconditionally so the app can report an accurate
+    # top-level ``usage`` regardless of the Usage Statistics presentation stage.
     create_mock = AsyncMock(return_value="stream-result")
     azure_client = SimpleNamespace(
         chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
@@ -135,32 +129,7 @@ async def test_invoke_without_show_usage():
     assert called_kwargs["stream"] is True
     assert called_kwargs["messages"] == [{"role": "user", "content": "hello"}]
     assert called_kwargs["tools"] == tools
-    assert "stream_options" not in called_kwargs
-
-
-@pytest.mark.asyncio
-async def test_invoke_with_show_usage_true():
-    create_mock = AsyncMock(return_value="stream-result")
-    azure_client = SimpleNamespace(
-        chat=SimpleNamespace(completions=SimpleNamespace(create=create_mock))
-    )
-
-    tools = [{"name": "t2"}]
-    invoker = _make_invoker(
-        messages=[FakeMessage("hello2")],
-        azure_client=azure_client,
-        tools=tools,
-        show_usage=True,
-    )
-
-    result = await invoker.invoke()
-    assert result == "stream-result"
-    assert create_mock.await_count == 1
-    called_kwargs = create_mock.await_args.kwargs
     assert called_kwargs["stream_options"] == {"include_usage": True}
-    assert called_kwargs["tools"] == tools
-    assert called_kwargs["messages"] == [{"role": "user", "content": "hello2"}]
-    assert called_kwargs["stream"] is True
 
 
 @pytest.mark.asyncio

--- a/src/tests/unit_tests/agent_tests/test_orchestrator.py
+++ b/src/tests/unit_tests/agent_tests/test_orchestrator.py
@@ -1087,3 +1087,50 @@ async def test_propagation_keeps_urlless_attachments():
 
     # Attachments without a URL have no stable dedup key, so both are streamed.
     assert len(choice.add_attachment_kwargs) == 2
+
+
+class TestUsageAccessors:
+    """total_usage / usage_per_model aggregate the collected per-deployment usage."""
+
+    @staticmethod
+    def _set_usage(orchestrator: Orchestrator, usage: list[DeploymentUsage]) -> None:
+        orchestrator._Orchestrator__usage_statistics_list = usage  # type: ignore[attr-defined]
+
+    def test_total_usage_none_when_empty(self):
+        orchestrator = _make_orchestrator([])
+        assert orchestrator.total_usage is None
+        assert orchestrator.usage_per_model == []
+
+    def test_total_usage_sums_orchestrator_and_tools(self):
+        orchestrator = _make_orchestrator([])
+        self._set_usage(
+            orchestrator,
+            [
+                DeploymentUsage(model_name="orch-model", prompt_tokens=100, completion_tokens=10),
+                DeploymentUsage(model_name="orch-model", prompt_tokens=200, completion_tokens=20),
+                DeploymentUsage(model_name="rag-tool", prompt_tokens=50, completion_tokens=5),
+            ],
+        )
+
+        total = orchestrator.total_usage
+        assert total is not None
+        assert total.prompt_tokens == 350
+        assert total.completion_tokens == 35
+
+    def test_usage_per_model_aggregates_by_model(self):
+        orchestrator = _make_orchestrator([])
+        self._set_usage(
+            orchestrator,
+            [
+                DeploymentUsage(model_name="orch-model", prompt_tokens=100, completion_tokens=10),
+                DeploymentUsage(model_name="orch-model", prompt_tokens=200, completion_tokens=20),
+                DeploymentUsage(model_name="rag-tool", prompt_tokens=50, completion_tokens=5),
+            ],
+        )
+
+        per_model = {u.model_name: u for u in orchestrator.usage_per_model}
+        assert set(per_model) == {"orch-model", "rag-tool"}
+        assert per_model["orch-model"].prompt_tokens == 300
+        assert per_model["orch-model"].completion_tokens == 30
+        assert per_model["rag-tool"].prompt_tokens == 50
+        assert per_model["rag-tool"].completion_tokens == 5

--- a/src/tests/unit_tests/agent_tests/test_tool_choice_config_builder.py
+++ b/src/tests/unit_tests/agent_tests/test_tool_choice_config_builder.py
@@ -22,7 +22,6 @@ def _make_builder(
         response_format=None,
         tool_choice_holder=holder,
         pre_invocation_transformers=[],
-        presentation_settings=MagicMock(show_usage_statistics=False),
         forwarded_headers=None,
     )
 
@@ -68,7 +67,6 @@ class TestToolChoiceInPayload:
             response_format=None,
             tool_choice_holder=holder,
             pre_invocation_transformers=[],
-            presentation_settings=MagicMock(show_usage_statistics=False),
             forwarded_headers=None,
         )
         first = builder.build([])

--- a/src/tests/unit_tests/application_tests/test_completion.py
+++ b/src/tests/unit_tests/application_tests/test_completion.py
@@ -9,6 +9,7 @@ from aidial_sdk.exceptions import InvalidRequestError
 from httpx import HTTPError
 
 import quickapp.core.application._quick_app_completion as quick_app_completion
+from quickapp.common import DeploymentUsage
 from quickapp.common.exceptions import (
     ConfigResolutionException,
     OrchestratorExceedMaxIterationsException,
@@ -42,6 +43,14 @@ class FakeChoice:
 class FakeResponse:
     def __init__(self, choice: FakeChoice):
         self._choice = choice
+        self.usage: tuple[int, int] | None = None
+        self.usage_per_model: list[tuple[str, int, int]] = []
+
+    def set_usage(self, prompt_tokens: int, completion_tokens: int):
+        self.usage = (prompt_tokens, completion_tokens)
+
+    def add_usage_per_model(self, model: str, prompt_tokens: int, completion_tokens: int):
+        self.usage_per_model.append((model, prompt_tokens, completion_tokens))
 
     def create_single_choice(self):
         # synchronous context manager used inside async method
@@ -188,6 +197,11 @@ async def test_chat_completion_success(make_request_completion):
         iteration_count = 1
         total_tool_calls = 0
         completion_kind = "completed"
+        total_usage = DeploymentUsage(prompt_tokens=300, completion_tokens=35)
+        usage_per_model = [
+            DeploymentUsage(model_name="orch-model", prompt_tokens=250, completion_tokens=30),
+            DeploymentUsage(model_name="rag-tool", prompt_tokens=50, completion_tokens=5),
+        ]
 
         async def invoke(self):
             orchestrator_called["count"] += 1
@@ -200,6 +214,12 @@ async def test_chat_completion_success(make_request_completion):
     # Assert
     assert orchestrator_called["count"] == 1
     assert choice.contents == []
+    # Aggregated usage is reported on the success path.
+    assert response.usage == (300, 35)
+    assert response.usage_per_model == [
+        ("orch-model", 250, 30),
+        ("rag-tool", 50, 5),
+    ]
 
 
 @pytest.mark.asyncio
@@ -226,6 +246,9 @@ async def test_chat_completion_orchestrator_exceed_raises_dial_error(make_reques
     assert display is not None
     assert "Agent stopped due to max iterations." in display
     assert choice.contents == []
+    # No usage is reported on the error path.
+    assert response.usage is None
+    assert response.usage_per_model == []
 
 
 @pytest.mark.asyncio
@@ -377,6 +400,8 @@ async def test_chat_completion_sets_context_messages_when_request_is_request(
         iteration_count = 1
         total_tool_calls = 0
         completion_kind = "completed"
+        total_usage = None
+        usage_per_model: list = []
 
         async def invoke(self):
             return None


### PR DESCRIPTION
### Applicable issues

- fixes #463

### Description of changes

**Why.** QuickApp never populated the standard OpenAI `usage` object of its own chat-completion response — it returned `"usage": null`, calling neither `response.set_usage(...)` nor `response.add_usage_per_model(...)`. The orchestrator *does* consume real tokens (its LLM calls plus any DIAL-deployment tool sub-calls) and already tracked them in `Orchestrator.__usage_statistics_list`, but that data only ever fed the optional "Usage Statistics" markdown stage — it was never surfaced through the SDK's usage API. As a result, downstream consumers (billing, quota, per-app analytics, client SDKs) saw `null` for QuickApp turns, and token collection was coupled to the `show_usage_statistics` presentation flag.

**What changed.**

- **`_chat_completion_config_builder.py`** — always request `stream_options.include_usage` from the orchestrator model (previously gated behind `show_usage_statistics`), so usage is available regardless of the presentation stage. The now-unused `presentation_settings` dependency was dropped from the builder.
- **`orchestrator.py`** — remove the `show_usage_statistics` gate on usage accumulation (both the orchestrator-call and tool-sub-call sites), so tokens are always collected. Add two accessors over the collected list: `total_usage` (whole-turn total) and `usage_per_model` (aggregated per distinct model/deployment). The "Usage Statistics" *stage* stays gated on `show_usage_statistics` — only collection changed.
- **`_quick_app_completion.py`** — at the end of a successful turn, report `response.set_usage(...)` with the turn total (orchestrator + tools) and one `response.add_usage_per_model(...)` per model. Skipped on the error path.

**Result.** The response now carries a populated top-level `usage` plus `statistics.usage_per_model`. Verified end-to-end against `root_quick_app` (orchestrator `gpt-4.1-2025-04-14`) invoking the nested `nested_quick_app` DIAL-deployment tool — the top-level total is the sum of the per-model entries (orchestrator + tool):

```json
"usage": {
  "prompt_tokens": 12553,
  "completion_tokens": 1240,
  "total_tokens": 13793
},
"statistics": {
  "usage_per_model": [
    { "index": 0, "model": "gpt-4.1-2025-04-14", "prompt_tokens": 5116, "completion_tokens": 336,  "total_tokens": 5452 },
    { "index": 1, "model": "nested_quick_app",   "prompt_tokens": 7437, "completion_tokens": 904,  "total_tokens": 8341 }
  ]
}
```

(5116 + 7437 = 12553 prompt; 336 + 904 = 1240 completion.) Note the "Usage Statistics" presentation stage still renders tool token columns as `-`, but `usage_per_model` reports the tool's real tokens — the "Total" scope this PR implements.

**Tests.** Added orchestrator accessor tests (`total_usage`/`usage_per_model` aggregation) and completion-path coverage (usage reported on success, not on the error path). Updated existing config-builder / assistant-invoker tests for the dropped `presentation_settings` param and the now-unconditional `stream_options`.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for this change)
- ~~[ ] Documentation is updated/created (if applicable)~~ (`usage`/`usage_per_model` are standard response fields; no doc surface changed)
- [ ] Changes are tested on review environment
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no config/schema models touched)
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
