### PR TITLE
fix: extract forwarded X-* headers from any Mapping, not only dict

### DIFF
--- a/src/quickapp/common/forwarded_headers.py
+++ b/src/quickapp/common/forwarded_headers.py
@@ -1,5 +1,7 @@
 """Forwarded request headers (e.g. X-*) to be passed to MCP and ChatCompletion requests."""
 
+from collections.abc import Mapping
+
 from aidial_sdk.chat_completion import Request
 
 from quickapp.common import ForwardedHeaders
@@ -8,11 +10,12 @@ from quickapp.common import ForwardedHeaders
 def extract_x_headers_from_request(request: Request) -> ForwardedHeaders:
     """
     Extract all headers whose names start with "X-" (case-insensitive) from the given
-    SDK Request. Uses original_request.headers when available, otherwise request.headers.
+    SDK Request. ``request.headers`` is a ``Mapping[str, str]`` (since aidial-sdk 0.38 a
+    Starlette ``MutableHeaders`` at runtime, not a ``dict``), so accept any mapping here.
     """
     headers: ForwardedHeaders = None
     raw_headers = request.headers
-    if isinstance(raw_headers, dict):
+    if isinstance(raw_headers, Mapping):
         for name, value in raw_headers.items():
             if name.lower().startswith("x-"):
                 if headers is None:

--- a/src/tests/unit_tests/common/test_forwarded_headers.py
+++ b/src/tests/unit_tests/common/test_forwarded_headers.py
@@ -3,6 +3,8 @@
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from starlette.datastructures import MutableHeaders
+
 from quickapp.common.forwarded_headers import extract_x_headers_from_request
 
 
@@ -55,8 +57,22 @@ class TestExtractXHeadersFromRequest:
         result = extract_x_headers_from_request(request)
         assert result is None
 
-    def test_extract_when_headers_not_dict_returns_empty(self):
-        """When request.headers is not a dict, returns empty (no crash)."""
+    def test_extract_from_mutable_headers(self):
+        """Regression (#466): since aidial-sdk 0.38, request.headers is a Starlette
+        MutableHeaders (a Mapping, not a dict); X- headers must still be extracted."""
+        request = SimpleNamespace(
+            headers=MutableHeaders(
+                raw=[
+                    (b"x-dial-client-channel-id", b"channel-abc"),
+                    (b"content-type", b"application/json"),
+                ]
+            )
+        )
+        result = extract_x_headers_from_request(request)
+        assert result == {"x-dial-client-channel-id": "channel-abc"}
+
+    def test_extract_when_headers_not_mapping_returns_empty(self):
+        """When request.headers is not a mapping, returns empty (no crash)."""
         request = SimpleNamespace(headers=MagicMock())
         result = extract_x_headers_from_request(request)
         assert result is None


### PR DESCRIPTION
### Applicable issues

- fixes #466

### Description of changes

**Why:** Since the aidial-sdk 0.38 bump (#461), forwarded `X-*` headers were being silently dropped on every request. The SDK now annotates its `headers` field with `SkipValidation` to preserve the case-insensitive object, so `request.headers` arrives as a Starlette `MutableHeaders` — a `Mapping`, but **not** a `dict`. Previously Pydantic validated the plain `Mapping[str, str]` field and coerced it to a real `dict`, so the `isinstance(raw_headers, dict)` guard in `extract_x_headers_from_request` passed. After 0.38 that guard is always `False`, and `extract_x_headers_from_request` returns `None`.

The most visible symptom is broken interactive login: `client_channel_id` is derived solely from the `X-DIAL-CLIENT-CHANNEL-ID` header, so toolsets requiring sign-in (e.g. a Notion MCP toolset) failed with `no_channel` — *"requires sign-in, but no client channel is available"*. The same silent drop also starved MCP tool requests and chat-completion forwarding of their `X-*` headers.

**What:** Loosen the guard from `isinstance(raw_headers, dict)` to `isinstance(raw_headers, collections.abc.Mapping)`, so any mapping (including `MutableHeaders`) is iterated. The result is still assembled as a plain `dict`, preserving the `ForwardedHeaders` (`dict | None`) contract. Adds a regression test that feeds a real `MutableHeaders` and asserts the `X-*` header is extracted, and renames the negative test to `test_extract_when_headers_not_mapping_returns_empty`.

Verified against a locally reproduced setup: interactive login now proceeds and `forwarded_headers` is populated instead of empty.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for this bug fix)
- ~~[ ] Documentation is updated/created (if applicable)~~ (no user-facing docs affected)
- [ ] Changes are tested on review environment
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no schema/config model change)
- [ ] Integration tests pass

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
