### PR TITLE
fix: show tool error text in MCP chat stage instead of content length #469

### DIFF
--- a/src/quickapp/common/exceptions/tool_error.py
+++ b/src/quickapp/common/exceptions/tool_error.py
@@ -5,7 +5,8 @@ class ToolErrorException(Exception):
     structure — the content rule (issue #436) keeps the tool response body out of the log
     pipeline. The body stays available on the :attr:`error_message` attribute, which the
     fallback machinery may forward to the LLM (``forward_tool_error_message``, #408) and
-    the error resolver may surface to the user; neither is a log channel.
+    the user channels (stage UI, error resolver) render via
+    :attr:`user_facing_message`; none of these is a log channel.
 
     The structural string form is owned here so no subclass can accidentally embed the
     body: subclasses set :attr:`tool_kind` (the human label) and the base builds the
@@ -22,3 +23,8 @@ class ToolErrorException(Exception):
         )
         self.tool_name = tool_name
         self.error_message = error_message
+
+    @property
+    def user_facing_message(self) -> str:
+        """User-facing rendering, body included; see the class docstring."""
+        return f"{self.tool_kind} '{self.tool_name}' returned an error: {self.error_message}"

--- a/src/quickapp/core/application/_exception_message_resolver.py
+++ b/src/quickapp/core/application/_exception_message_resolver.py
@@ -282,17 +282,17 @@ def _resolve_tool_error(e: ToolErrorException) -> ResolvedError | None:
 
     - If it wraps an httpx cause, delegate to the cause's resolution so the caller gets
       the appropriate HTTP-specific message (e.g. permission-denied, timeout).
-    - If there is no cause, expose the tool error text directly. Built from
-      ``error_message`` rather than ``str(e)``: the exception's string form is structural
-      by the content rule (issue #436), while this user-facing message keeps the real text.
+    - If there is no cause, expose the tool error text directly via
+      ``user_facing_message`` rather than ``str(e)``: the exception's string form is
+      structural by the content rule (issue #436), while the user channel keeps the real
+      text.
     - If the cause is something other than an httpx error, return None to fall through
       to the generic fallback.
     """
     if isinstance(e.__cause__, httpx.HTTPError):
         return resolve_exception(e.__cause__)
     if e.__cause__ is None:
-        message = f"{e.tool_kind} '{e.tool_name}' returned an error: {e.error_message}"
-        return _compose(message, False, ErrorDetails())
+        return _compose(e.user_facing_message, False, ErrorDetails())
     return None
 
 

--- a/src/quickapp/mcp_tooling/_mcp_stage_wrapper.py
+++ b/src/quickapp/mcp_tooling/_mcp_stage_wrapper.py
@@ -6,6 +6,7 @@ from injector import inject
 from pydantic import BaseModel
 
 from quickapp.common import TimedStageWrapper, ToolCallResult
+from quickapp.common.exceptions.tool_error import ToolErrorException
 from quickapp.common.response_formatter import ResponseFormatter
 from quickapp.common.utils import fenced_code_block
 
@@ -37,6 +38,10 @@ class _MCPStageWrapper(TimedStageWrapper):
         return stage_result
 
     def _build_debug_info_from_exception(self, exception: Exception) -> str:
+        # The stage is a user channel: render the tool error body (user_facing_message),
+        # not the structural str(e) mandated for logs by the content rule (#436).
+        if isinstance(exception, ToolErrorException):
+            return f"> ##### Error:\n{exception.user_facing_message}\n"
         return f"> ##### Exception:\n{type(exception).__name__}: {exception}\n"
 
     @staticmethod

--- a/src/tests/unit_tests/common/test_tool_error.py
+++ b/src/tests/unit_tests/common/test_tool_error.py
@@ -45,3 +45,13 @@ class TestBodyPreservedForNonLogChannels:
         # REST's error_message is already a status string (no body); left as-is.
         e = RestApiToolErrorException("rest_tool", "HTTP error 500 while calling REST API tool.")
         assert e.error_message == "HTTP error 500 while calling REST API tool."
+
+
+class TestUserFacingMessage:
+    def test_base_carries_body_and_tool_name(self):
+        e = ToolErrorException("my_tool", _BODY)
+        assert e.user_facing_message == f"Tool 'my_tool' returned an error: {_BODY}"
+
+    def test_mcp_uses_tool_kind_label(self):
+        e = MCPToolErrorException("mcp_tool", _BODY)
+        assert e.user_facing_message == f"MCP tool 'mcp_tool' returned an error: {_BODY}"

--- a/src/tests/unit_tests/mcp_tool_tests/test_stage_wrapper.py
+++ b/src/tests/unit_tests/mcp_tool_tests/test_stage_wrapper.py
@@ -9,6 +9,7 @@ from quickapp.common import ToolCallResult
 
 # noinspection PyProtectedMember
 from quickapp.mcp_tooling._mcp_stage_wrapper import _MCPStageWrapper
+from quickapp.mcp_tooling._mcp_tool_error_exception import MCPToolErrorException
 
 
 @pytest.fixture
@@ -196,6 +197,18 @@ def test_build_debug_info_from_params_and_exception(mock_stage, wrapper, params)
     assert mock_stage.append_content.call_count == 2
     mock_stage.append_content.assert_any_call(expected_params)
     mock_stage.append_content.assert_any_call(expected_exception)
+
+
+def test_tool_error_stage_shows_body_not_structural_str(mock_stage, wrapper):
+    # The stage is a user channel: it must show the MCP error body, not the
+    # content_length-only str(e) mandated for logs by the content rule (#436).
+    body = "the real mcp error text"
+    exception = MCPToolErrorException("mcp_tool", body)
+
+    wrapper.add_exception(exception)
+
+    expected = f"> ##### Error:\nMCP tool 'mcp_tool' returned an error: {body}\n"
+    mock_stage.append_content.assert_called_once_with(expected)
 
 
 def test_plain_text_response_is_fenced_without_language(mock_stage, wrapper):


### PR DESCRIPTION
### Applicable issues

- fixes #469

### Description of changes

The content rule (#436, enforced in #459) made `ToolErrorException`'s string form structural — `content_length` only — so tool response bodies never reach logs. The MCP chat stage, however, rendered errors via `str(e)`, so users lost the actual tool error text in chat and saw only the content length. The stage is a user-facing channel, not a log channel, and should keep showing the real text.

Fix: the user-facing rendering is now owned by the exception itself (`ToolErrorException.user_facing_message`, body included) and used by both user channels — the MCP stage wrapper and the exception message resolver, which previously hand-built the same string. `str(e)` stays structural for logs. REST stages are unaffected: they already surface the HTTP response by unwrapping the cause.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (small regression fix, no design doc)
- ~~[ ] Documentation is updated/created (if applicable)~~ (no documented behavior changed; docstrings updated in code)
- [ ] Changes are tested on review environment
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no schema changes)
- ~~[ ] Integration tests pass~~

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
