### PR TITLE
chore: make schema id configurable

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -13,6 +13,11 @@ Schema reference:
 - Generated locally via: make dump_app_schema
 - Hosted reference: https://mydial.epam.com/custom_application_schemas/quickapps2
 
+The `$id` written into the generated schema defaults to that hosted URL. Override it with
+`APP_SCHEMA_ID` when your DIAL installation uses a different hostname or schema name
+(see [README.md](./README.md#environment-variables)). When unset, the current default is kept
+for backward compatibility.
+
 ## Agent Configuration:
 
 <details>

--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ Controls which tool-execution stages are surfaced in the DIAL UI for each app. S
 | **DIAL Core**                              |                            |          |                                                                                                              |
 | `DIAL_URL`                                 | —                          | Yes      | URL of the DIAL Core API                                                                                     |
 | `DIAL_API_VERSION`                         | `2025-01-01-preview`       | No       | API version for DIAL Core API                                                                                |
+| `APP_SCHEMA_ID`                            | `https://mydial.epam.com/custom_application_schemas/quickapps2` | No | Full application type schema `$id` emitted in the generated app schema. When unset, the built-in default is used. |
 | **Logging**                                |                            |          |                                                                                                              |
 | `DIAL_SDK_LOG_FORMAT`                      | `text`                     | No       | Console log output format: `text` (human-readable) or `json` (escape-safe, one record per line). See [docs/logging.md](docs/logging.md). |
 | `DIAL_SDK_TEXT_LOG_FORMAT`                 | [see docs/logging.md](docs/logging.md) | No | Custom `%`-style format string for `text` output. Unset (default) keeps the built-in format with the conditional OTEL trace block. |

--- a/src/quickapp/common/base_config.py
+++ b/src/quickapp/common/base_config.py
@@ -9,9 +9,9 @@ from pydantic.fields import FieldInfo
 
 from quickapp.common.dial_schema import DialJSONSchemaExtensions
 from quickapp.common.feature_settings import FeatureSettings
+from quickapp.common.schema_settings import SchemaSettings
 
 _DIAL_SCHEMA_URL = "https://dial.epam.com/application_type_schemas/schema#"
-_DIAL_ID_PREFIX = "https://mydial.epam.com/custom_application_schemas/"
 
 _PREVIEW_MARKER = "x-preview"
 
@@ -535,7 +535,7 @@ class BaseApplicationTypeConfig(BaseModel):
 
         # Add DIAL-specific root properties
         if include_dial_fields:
-            schema["$id"] = f"{_DIAL_ID_PREFIX}{cls._dial_schema_id}"
+            schema["$id"] = SchemaSettings().resolve_schema_id(cls._dial_schema_id)
             schema["$schema"] = _DIAL_SCHEMA_URL
             schema[DialJSONSchemaExtensions.DISPLAY_NAME] = cls._dial_application_type_display_name
             schema[DialJSONSchemaExtensions.APPEND_APP_PROPERTIES_HEADER] = (

--- a/src/quickapp/common/schema_settings.py
+++ b/src/quickapp/common/schema_settings.py
@@ -1,0 +1,34 @@
+"""Application schema settings. Lives in common to avoid circular imports."""
+
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_DEFAULT_DIAL_ID_PREFIX = "https://mydial.epam.com/custom_application_schemas/"
+
+
+class SchemaSettings(BaseSettings):
+    """Controls the application type schema ``$id`` emitted in generated schemas."""
+
+    model_config = SettingsConfigDict()
+
+    app_schema_id: str | None = Field(
+        default=None,
+        alias="APP_SCHEMA_ID",
+        description=(
+            "Full application type schema $id override. When unset, uses the "
+            "built-in default (prefix + per-class _dial_schema_id)."
+        ),
+    )
+
+    @field_validator("app_schema_id", mode="after")
+    @classmethod
+    def _blank_to_none(cls, value: str | None) -> str | None:
+        # BaseSettings returns "" (not None) for an empty/whitespace env value.
+        if value is None:
+            return None
+        stripped = value.strip()
+        return stripped or None
+
+    def resolve_schema_id(self, dial_schema_id: str) -> str:
+        """Return ``APP_SCHEMA_ID`` when set, else ``prefix + dial_schema_id``."""
+        return self.app_schema_id or f"{_DEFAULT_DIAL_ID_PREFIX}{dial_schema_id}"

--- a/src/tests/unit_tests/common/test_base_config.py
+++ b/src/tests/unit_tests/common/test_base_config.py
@@ -99,6 +99,32 @@ class TestModelJsonSchema:
             DialJSONSchemaExtensions.PROPERTY_ORDER: 3,
         }
 
+    def test_app_schema_id_env_overrides_full_id(self, monkeypatch: pytest.MonkeyPatch):
+        """APP_SCHEMA_ID replaces the entire $id (no suffix appended)."""
+        override = "https://example.com/schemas/my-quickapps"
+        monkeypatch.setenv("APP_SCHEMA_ID", override)
+
+        class TestConfig(BaseApplicationTypeConfig):
+            _dial_schema_id = "quickapps2"
+            _dial_application_type_display_name = "Quick App 2.0"
+            name: str
+
+        assert TestConfig.model_json_schema()["$id"] == override
+
+    def test_blank_app_schema_id_env_keeps_default(self, monkeypatch: pytest.MonkeyPatch):
+        """Empty APP_SCHEMA_ID is treated as unset and keeps the composed default."""
+        monkeypatch.setenv("APP_SCHEMA_ID", "   ")
+
+        class TestConfig(BaseApplicationTypeConfig):
+            _dial_schema_id = "quickapps2"
+            _dial_application_type_display_name = "Quick App 2.0"
+            name: str
+
+        assert (
+            TestConfig.model_json_schema()["$id"]
+            == "https://mydial.epam.com/custom_application_schemas/quickapps2"
+        )
+
     def test_schema_with_override_append_header(self):
         """Test schema generation with overridden _dial_append_application_properties_header."""
 


### PR DESCRIPTION
### Applicable issues

<!-- Please link the GitHub issues related to this PR (You can reference an issue using # then number, e.g. #123) -->
- fixes #471 

### Description of changes

Add new ENV variable APP_SCHEMA_ID to use instead of default hard-coded schema id

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Documentation is updated/created (if applicable)
- [ ] Changes are tested on review environment
- [x] App schema changes are backward compatible, or breaking changes are documented with a migration guide

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
