### PR TITLE
ci: re-use venv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,9 @@ FILES ?= $(SRC_DIRS)
 POETRY ?= poetry
 PYTHON ?= python3
 
+# Any non-empty CI value (even 'false' or '0') means that CI is enabled
+CI ?=
+
 -include .env
 export
 
@@ -17,7 +20,7 @@ export PYDANTIC_V2=True
 	black black_check isort isort_check autoflake autoflake_check flake8
 
 init_venv:
-	$(POETRY) env use $(PYTHON)
+	$(if $(CI),,$(POETRY) env use $(PYTHON))
 
 install: init_venv
 	$(POETRY) install


### PR DESCRIPTION
CI speed-up:
- skip `poetry env use` when running in CI environment - no need to recreate the venv we already prepared in workflow script (`python_prepare` action)

For local execution everything stays the same