### PR TITLE
docs: add required column to release-notes env-var table

### DIFF
--- a/.claude/skills/quickapps-release-notes/SKILL.md
+++ b/.claude/skills/quickapps-release-notes/SKILL.md
@@ -161,7 +161,7 @@ Add this section **only** when the range introduces at least one env-var, behavi
 ## Deployment Changes
 
 ### New environment variables
-<table: Variable | Default | Description>
+<table: Variable | Default | Description | Required>
 
 ### Deprecated environment variables
 > [!CAUTION]
@@ -205,7 +205,7 @@ If a change requires the operator to touch a config file outside this repo (DIAL
 
 **Crucial — what does *not* belong here**: app-config-only fields (per-app `features.*` overrides, new manifest fields). Those changes belong in the **Features** bullet body where they're introduced. `Deployment Changes` is for operator-facing concerns: env vars, behavioral shifts, external-config migrations, schema-level deprecations. The user explicitly dropped an "App config additions" subsection during the `0.7.0-rc.0` pass with the message *"app config - not deployment changes. drop it"* — respect that boundary.
 
-For the env-var tables, the description column comes from `CONFIGURATION.md` when it exists there; otherwise from the settings class docstring. Cite bounds (`> 0`, `0 < x ≤ 3600`) verbatim from the validator.
+For the env-var tables, the description column comes from `CONFIGURATION.md` when it exists there; otherwise from the settings class docstring. Cite bounds (`> 0`, `0 < x ≤ 3600`) verbatim from the validator. The `Required` column is determined from **source, not the PR body**: a variable is `Yes` when its settings-class field has no default (the app fails to start without it), and `No` when the field declares a default — in which case put the default in the `Default` column and leave `Required` as `No`. Verify by reading the field via LSP (`goToDefinition`) rather than inferring from `CONFIGURATION.md`.
 
 ### 7. Pre-release / delta handling
 


### PR DESCRIPTION
### Applicable issues

- fixes #

### Description of changes

The `quickapps-release-notes` skill builds the `Deployment Changes` section's **New environment variables** table, but the table spec only listed `Variable | Default | Description`. There was no way for the notes author to communicate whether a newly added variable is mandatory — an operator-facing detail that matters when upgrading a deployment.

This PR:
- Adds a **Required** column to the `New environment variables` table spec (§6).
- Documents how to fill it: derive it from **source, not the PR body** — a variable is `Yes` when its settings-class field has no default (the app fails to start without it) and `No` when the field declares a default (in which case the default goes in the `Default` column). Verify via LSP (`goToDefinition`) rather than inferring from `CONFIGURATION.md`, consistent with the skill's existing "code wins" rule.

Documentation-only change to a skill instruction file — no Python, DI, or app-schema surface is touched.

### Checklist

- [x] Title of the pull request follows [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/)
- ~~[ ] Design documented is updated/created and approved by the team (if applicable)~~ (no design doc for a skill-doc edit)
- [x] Documentation is updated/created (if applicable)
- ~~[ ] Changes are tested on review environment~~ (not applicable — skill instruction doc, no runtime surface)
- ~~[ ] App schema changes are backward compatible, or breaking changes are documented with a migration guide~~ (no schema change)
- ~~[ ] Integration tests pass~~ (not applicable — no code change; CI responsibility)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
